### PR TITLE
Add NOTE block to every page pointing to the CrateDB Reference

### DIFF
--- a/docs/_include/note.rst
+++ b/docs/_include/note.rst
@@ -1,0 +1,10 @@
+.. NOTE::
+
+    You are reading a digital copy of *SQL-99 Complete, Really*, a book that
+    documents the `SQL-99 standard`_.
+
+    For more information specific to CrateDB, check out the `CrateDB
+    Reference`_.
+
+.. _CrateDB Reference: https://crate.io/docs/crate/reference/en/4.3/general/index.html
+.. _SQL-99 standard: https://en.wikipedia.org/wiki/SQL:1999

--- a/docs/appendices/a.rst
+++ b/docs/appendices/a.rst
@@ -4,6 +4,8 @@
 Appendix A -- Remote Database Access
 ====================================
 
+.. include:: ../_include/note.rst
+
 Remote Database Access (RDA) is a standard for interfacing to databases via
 some network. The standards for networks are usually bound up with a hierarchy
 called the Open Systems Interconnect (OSI) layers, which look like this:
@@ -65,27 +67,27 @@ you'll get an idea of:
 ISO/IEC 9759
 ------------
 
-The standard for RDA is ISO/IEC 9759 "Remote Database Access For SQL". This is 
-a completely different document from the standard SQL document (ISO/IEC 9075), 
-so it's not correct to say that RDA is part of the SQL standard. But it's a 
-related standard, and the respective committees work together closely. 
+The standard for RDA is ISO/IEC 9759 "Remote Database Access For SQL". This is
+a completely different document from the standard SQL document (ISO/IEC 9075),
+so it's not correct to say that RDA is part of the SQL standard. But it's a
+related standard, and the respective committees work together closely.
 
-Much of the impetus for RDA came from an industry consortium known as the SQL 
-Access Group (SAG). In 1991 members of the SAG consortium produced the first 
-prototypes for version 1 of RDA. The latest edition is Version 3, which is 
-still unofficial at the time we're writing this. Version 3 is quite different 
-from the earlier versions. It operates very much like the SQL/CLI 
-specification, using similar or even the same names and parameters for most of 
-its functions. For example, the SQL/CLI function ``SQLExecDirect`` has an RDA 
-equivalent: ``RDAExecDirect``. The parameters are similar (a handle and a 
-string with an SQL statement and a size word). The effect is similar (an SQL 
-statement is parsed and executed). The big difference, and the whole point of 
-RDA, is architecture: ``SQLExecDirect`` is a function which you call directly, 
-``RDAExecDirect`` is a message which you pass to a "remote" entity. 
+Much of the impetus for RDA came from an industry consortium known as the SQL
+Access Group (SAG). In 1991 members of the SAG consortium produced the first
+prototypes for version 1 of RDA. The latest edition is Version 3, which is
+still unofficial at the time we're writing this. Version 3 is quite different
+from the earlier versions. It operates very much like the SQL/CLI
+specification, using similar or even the same names and parameters for most of
+its functions. For example, the SQL/CLI function ``SQLExecDirect`` has an RDA
+equivalent: ``RDAExecDirect``. The parameters are similar (a handle and a
+string with an SQL statement and a size word). The effect is similar (an SQL
+statement is parsed and executed). The big difference, and the whole point of
+RDA, is architecture: ``SQLExecDirect`` is a function which you call directly,
+``RDAExecDirect`` is a message which you pass to a "remote" entity.
 
-The nearby functions are the "client", the messages they send out are called 
-"requests". The remote entity is the "server", the messages that it sends back 
-are called "responses". 
+The nearby functions are the "client", the messages they send out are called
+"requests". The remote entity is the "server", the messages that it sends back
+are called "responses".
 
 TCP/IP
 ------
@@ -202,21 +204,21 @@ RDAEndTran
 
 **What the server is supposed to:**
 
-The ``RDAEndTran`` marks a transaction boundary, and the flag will usually 
-indicate ``COMMIT`` or ``ROLLBACK``, so the usual job is simple: the server 
-should end a current transaction with ``COMMIT`` or with ``ROLLBACK``. 
+The ``RDAEndTran`` marks a transaction boundary, and the flag will usually
+indicate ``COMMIT`` or ``ROLLBACK``, so the usual job is simple: the server
+should end a current transaction with ``COMMIT`` or with ``ROLLBACK``.
 
-There is a reason that ``RDAEndTran`` is a distinct message -- that makes it 
-easier for the network to notice it, without having to know how to parse SQL 
-statements. The network might intercept ``RDAEndTran``, because the job of 
-"committing" might affect more than just one server job. 
+There is a reason that ``RDAEndTran`` is a distinct message -- that makes it
+easier for the network to notice it, without having to know how to parse SQL
+statements. The network might intercept ``RDAEndTran``, because the job of
+"committing" might affect more than just one server job.
 
-One other flag value that ``CompletionType`` may contain (besides ``COMMIT`` or 
-``ROLLBACK``) is: ``PREPARE TO COMMIT``. As part of what we call the "two-phase 
-commit" process, the first step is to co-ordinate: get all the servers on the 
-network to acknowledge that they are all ready to commit. The second step is 
-the ``COMMIT`` itself. Two-phase commit is advanced stuff; many DBMSs will 
-refuse to support the ``PREPARE TO COMMIT`` operation. 
+One other flag value that ``CompletionType`` may contain (besides ``COMMIT`` or
+``ROLLBACK``) is: ``PREPARE TO COMMIT``. As part of what we call the "two-phase
+commit" process, the first step is to co-ordinate: get all the servers on the
+network to acknowledge that they are all ready to commit. The second step is
+the ``COMMIT`` itself. Two-phase commit is advanced stuff; many DBMSs will
+refuse to support the ``PREPARE TO COMMIT`` operation.
 
 RDAClientAttribute
 ..................
@@ -229,16 +231,16 @@ RDAClientAttribute
 
 **What the server is supposed to do:**
 
-Take note of what attributes the client has. An "attribute" is an ``env`` or 
-``dbc`` or ``stmt`` attribute. That is, it's a number or string that was 
-earlier passed to the client, via a ``SQLSetEnvAttr`` or ``SQLSetConnectAttr`` 
-or ``SQLSetStmtAttr`` function call. 
+Take note of what attributes the client has. An "attribute" is an ``env`` or
+``dbc`` or ``stmt`` attribute. That is, it's a number or string that was
+earlier passed to the client, via a ``SQLSetEnvAttr`` or ``SQLSetConnectAttr``
+or ``SQLSetStmtAttr`` function call.
 
-The client won't send a new ``RDAClientAttribute`` message every time its own 
-attributes change. That would result in too much network traffic. One of the 
-features of client/server architecture is: the server doesn't do everything. 
-The client is capable of storing data locally for a particular connection and 
-only passing on what's necessary when it's necessary. 
+The client won't send a new ``RDAClientAttribute`` message every time its own
+attributes change. That would result in too much network traffic. One of the
+features of client/server architecture is: the server doesn't do everything.
+The client is capable of storing data locally for a particular connection and
+only passing on what's necessary when it's necessary.
 
 RDAStatementPrepare
 ...................
@@ -252,17 +254,17 @@ RDAStatementPrepare
 
 **What the server is supposed to do:**
 
-Prepare an SQL statement. The client might be able to do some primitive syntax 
-checking, but for the full job of binding and parsing, the client has to pass 
-the SQL statement to the server. Only the server has direct access to the 
-database and its metadata. 
+Prepare an SQL statement. The client might be able to do some primitive syntax
+checking, but for the full job of binding and parsing, the client has to pass
+the SQL statement to the server. Only the server has direct access to the
+database and its metadata.
 
-If we were calling ``SQLPrepare``, we'd pass a ``hstmt`` (handle of a 
-``stmt``). But a handle is a local identifier. There's no guarantee that a 
-handle value will be unique over the whole network. Therefore, instead of a 
-``hstmt``, the client must pass a ``StatementIdent``. This is a handle of a 
-handle. Given a ``StatementIdent``, the client and server can each look up what 
-their respective hstmt values are for the same ``stmt``. 
+If we were calling ``SQLPrepare``, we'd pass a ``hstmt`` (handle of a
+``stmt``). But a handle is a local identifier. There's no guarantee that a
+handle value will be unique over the whole network. Therefore, instead of a
+``hstmt``, the client must pass a ``StatementIdent``. This is a handle of a
+handle. Given a ``StatementIdent``, the client and server can each look up what
+their respective hstmt values are for the same ``stmt``.
 
 RDAStatementDeallocate
 ......................
@@ -275,7 +277,7 @@ RDAStatementDeallocate
 
 **What the server is supposed to do:**
 
-Free a ``stmt``. Compare the SQL/CLI function 
+Free a ``stmt``. Compare the SQL/CLI function
 ``SQLFreeHandle(SQL_HANDLE_STMT,...)``.
 
 With client-server, any statement resource (``stmt``) will be duplicated in two
@@ -296,21 +298,21 @@ RDAStatementExecute
 
 **What the server is supposed to do:**
 
-Execute an SQL statement. Presumably the statement was prepared earlier, due to 
-an ``RDAStatementPrepare`` message with the same ``StatementIdent``. 
+Execute an SQL statement. Presumably the statement was prepared earlier, due to
+an ``RDAStatementPrepare`` message with the same ``StatementIdent``.
 
-The ``ParameterDescriptor`` and ``ParameterData`` fields -- which weren't 
-necessary for ``SQLPrepare`` -- represent the solution to a rather tough 
-question: what should be done with input parameters? There are no direct RDA 
-equivalents for the SQL/CLI functions that handle "parameter descriptors". 
-They'd be useless anyway, because SQL/CLI parameter descriptors require 
-pointers and pointers have no meaning to a job on a different machine. So what 
-happens is: the client bundles up all the input parameter values, and sends 
-them as part of the message. 
+The ``ParameterDescriptor`` and ``ParameterData`` fields -- which weren't
+necessary for ``SQLPrepare`` -- represent the solution to a rather tough
+question: what should be done with input parameters? There are no direct RDA
+equivalents for the SQL/CLI functions that handle "parameter descriptors".
+They'd be useless anyway, because SQL/CLI parameter descriptors require
+pointers and pointers have no meaning to a job on a different machine. So what
+happens is: the client bundles up all the input parameter values, and sends
+them as part of the message.
 
-This might mean that requests get monstrous. But RDA's designers thought it 
-would be a bad idea to split ``RDAStatementExecute`` into multiple separate 
-messages. What if the messages didn't all arrive in the right order? 
+This might mean that requests get monstrous. But RDA's designers thought it
+would be a bad idea to split ``RDAStatementExecute`` into multiple separate
+messages. What if the messages didn't all arrive in the right order?
 
 RDAStatementExecDirect
 ......................
@@ -326,13 +328,13 @@ RDAStatementExecDirect
 
 **What the Server is supposed to do:**
 
-Prepare what's in ``StatementText``, then execute it (using the input 
-parameters if there are any). 
+Prepare what's in ``StatementText``, then execute it (using the input
+parameters if there are any).
 
-``RDAStatementExecDirect`` is logically redundant: we could accomplish the same 
-thing by sending ``RDAStatementPrepare`` followed by ``RDAStatementExecute``. 
-Such redundancy is occasionally justifiable because it's more efficient to send 
-one message instead of two. Network traffic is expensive. 
+``RDAStatementExecDirect`` is logically redundant: we could accomplish the same
+thing by sending ``RDAStatementPrepare`` followed by ``RDAStatementExecute``.
+Such redundancy is occasionally justifiable because it's more efficient to send
+one message instead of two. Network traffic is expensive.
 
 RDAStatementFetchRows
 .....................
@@ -348,21 +350,21 @@ RDAStatementFetchRows
 
 **What the server is supposed to do:**
 
-Get the values in each of the indicated rows, and ship them to the client. 
-Presumably there was an early ``RDAStatementExecute`` or 
-``RDAStatementExecDirect`` message for this ``StatementIdent``, which caused a 
-query to be executed. So the server has a result set that it can fetch the rows 
-from. 
+Get the values in each of the indicated rows, and ship them to the client.
+Presumably there was an early ``RDAStatementExecute`` or
+``RDAStatementExecDirect`` message for this ``StatementIdent``, which caused a
+query to be executed. So the server has a result set that it can fetch the rows
+from.
 
-The ``FetchOrientation`` and ``FetchOffset`` parameters contain values 
-equivalent to those which are used by the SQL/CLI function ``SQLFetchScroll``. 
-For example, ``FetchOrientation`` might equal ``SQL_FETCH_ABSOLUTE`` and 
-``FetchOffset`` might equal 55. 
+The ``FetchOrientation`` and ``FetchOffset`` parameters contain values
+equivalent to those which are used by the SQL/CLI function ``SQLFetchScroll``.
+For example, ``FetchOrientation`` might equal ``SQL_FETCH_ABSOLUTE`` and
+``FetchOffset`` might equal 55.
 
-In standard SQL, it's only possible to fetch one row at a time. With RDA -- and 
-once again this can be explained by "efficiency" -- it's possible to ask for 
-multiple rows to be fetched at once. That's what the ``FetchCount`` parameter 
-is for. 
+In standard SQL, it's only possible to fetch one row at a time. With RDA -- and
+once again this can be explained by "efficiency" -- it's possible to ask for
+multiple rows to be fetched at once. That's what the ``FetchCount`` parameter
+is for.
 
 RDAStatementCloseCursor
 .......................
@@ -375,16 +377,16 @@ RDAStatementCloseCursor
 
 **What the server is supposed to do:**
 
-Well, close the Cursor. This isn't an end-of-transaction signal, but it does 
-tell the server that it can forget about a result set that it created with a 
-recent ``SELECT`` statement. 
+Well, close the Cursor. This isn't an end-of-transaction signal, but it does
+tell the server that it can forget about a result set that it created with a
+recent ``SELECT`` statement.
 
-The client could pass messages in this sequence: *(a)* 
-``RDAStatementExecDirect`` with a ``SELECT`` statement so that the server 
-creates a result set and Cursor, *(b)* ``RDAStatementFetchRows`` so that the 
-server will fetch row values and send them to the client and *(c)* 
-``RDAStatementCloseCursor`` so that the server will free (and possibly unlock) 
-resources that were allocated for Cursor maintenance. 
+The client could pass messages in this sequence: *(a)*
+``RDAStatementExecDirect`` with a ``SELECT`` statement so that the server
+creates a result set and Cursor, *(b)* ``RDAStatementFetchRows`` so that the
+server will fetch row values and send them to the client and *(c)*
+``RDAStatementCloseCursor`` so that the server will free (and possibly unlock)
+resources that were allocated for Cursor maintenance.
 
 RDAStatementCancel
 ..................
@@ -407,19 +409,19 @@ perhaps because the execution is taking too long or because some new
 information has arrived (such as a Shutdown message from Windows). Or,
 consider this scenario:
 
-1. There are two servers. Each server is responsible for a copy of the same 
-   database. 
+1. There are two servers. Each server is responsible for a copy of the same
+   database.
 
-2. The client sends an ``RDAExecDirect`` message to both servers, with the 
-   same query. 
+2. The client sends an ``RDAExecDirect`` message to both servers, with the
+   same query.
 
-3. Inevitably, one of the servers will respond more quickly than the other. 
-   Perhaps it's less busy, or perhaps its message packets are just moving by a 
-   shorter route. 
+3. Inevitably, one of the servers will respond more quickly than the other.
+   Perhaps it's less busy, or perhaps its message packets are just moving by a
+   shorter route.
 
-4. Once the client receives the response from the fast server, it sends an 
-   ``RDAStatementCancel`` message to the slow one, meaning "oh forget it -- I 
-   already have the data". 
+4. Once the client receives the response from the fast server, it sends an
+   ``RDAStatementCancel`` message to the slow one, meaning "oh forget it -- I
+   already have the data".
 
 5. The Server's Response: ``RDAResponse``
 
@@ -526,7 +528,7 @@ potentially significant.
 
 5. There are optional Schemas which contain Tables which contain information
    about available servers, logs of requests and so on. The Tables can be
-   accessed in the same way that Views can be accessed in 
+   accessed in the same way that Views can be accessed in
    ``INFORMATION_SCHEMA``.
 
 What good is RDA?

--- a/docs/appendices/b.rst
+++ b/docs/appendices/b.rst
@@ -4,6 +4,8 @@
 Appendix B -- SQL Taxonomy
 ==========================
 
+.. include:: ../_include/note.rst
+
 For easy reference, this appendix gathers together all of our notes on what to
 avoid if you want to restrict your code to Core SQL. It also includes the SQL
 Taxonomy tables from the SQL Standard -- these list all of the features
@@ -41,40 +43,40 @@ Core SQL Notes
   operator, ``SUBSTRING`` or the ``[NOT LIKE]`` predicate with ``BLOB``\s.
 
 * If you want to restrict your code to Core SQL, don't add a Character set
-  specification to <character string literal>s, don't add a ``COLLATE`` clause 
-  to <character string literal>s and don't split long <character string 
+  specification to <character string literal>s, don't add a ``COLLATE`` clause
+  to <character string literal>s and don't split long <character string
   literal>s into smaller strings.
 
 * If you want to restrict your code to Core SQL, don't use <national
   character string literal>s.
 
 * If you want to restrict your code to Core SQL, don't use the ``CHARACTER SET``
-  clause or the ``COLLATE`` clause for ``CHAR`` or ``VARCHAR`` or ``CLOB`` 
+  clause or the ``COLLATE`` clause for ``CHAR`` or ``VARCHAR`` or ``CLOB``
   <data type> specifications.
 
-* If you want to restrict your code to Core SQL, don't use the ``NCHAR`` or 
+* If you want to restrict your code to Core SQL, don't use the ``NCHAR`` or
   ``NCHAR VARYING`` or ``NCLOB`` <data type>s.
 
-* If you want to restrict your code to Core SQL, don't use ``CLOB``\s or 
+* If you want to restrict your code to Core SQL, don't use ``CLOB``\s or
   ``NCLOB``\s in comparisons.
 
 * If you want to restrict your code to Core SQL, don't use the concatenation
-  operator with ``CLOB``\s or ``NCLOB``\s and don't use the ``COLLATE`` clause 
+  operator with ``CLOB``\s or ``NCLOB``\s and don't use the ``COLLATE`` clause
   to force an ``EXPLICIT`` Collation for any character string concatenation.
 
-* If you want to restrict your code to Core SQL, don't use ``SUBSTRING`` with 
-  ``NCLOB``\s and don't use the ``COLLATE`` clause to force an ``EXPLICIT`` 
+* If you want to restrict your code to Core SQL, don't use ``SUBSTRING`` with
+  ``NCLOB``\s and don't use the ``COLLATE`` clause to force an ``EXPLICIT``
   Collation for any ``SUBSTRING`` operation.
 
 * If you want to restrict your code to Core SQL, don't use ``OVERLAY`` with
   character strings.
 
-* If you want to restrict your code to Core SQL, don't use ``TRIM`` with 
-  ``NCLOB``\s and don't use the ``COLLATE`` clause to force an ``EXPLICIT`` 
+* If you want to restrict your code to Core SQL, don't use ``TRIM`` with
+  ``NCLOB``\s and don't use the ``COLLATE`` clause to force an ``EXPLICIT``
   Collation for any ``TRIM`` operation.
 
-* If you want to restrict your code to Core SQL, don't use the ``COLLATE`` 
-  clause to force an ``EXPLICIT`` Collation for any ``UPPER`` or ``LOWER`` 
+* If you want to restrict your code to Core SQL, don't use the ``COLLATE``
+  clause to force an ``EXPLICIT`` Collation for any ``UPPER`` or ``LOWER``
   operation.
 
 * If you want to restrict your code to Core SQL, don't use ``TRANSLATE``.
@@ -91,9 +93,9 @@ Core SQL Notes
   ``CHAR_LENGTH`` or ``OCTET_LENGTH`` with ``NCLOB``\s.
 
 * If you want to restrict your code to Core SQL, don't use the ``[NOT] LIKE``
-  predicate with ``CLOB``\s or ``NCLOB``\s and, when you do use ``[NOT LIKE]``, 
-  make sure your ``character_string_argument`` is a <Column reference> and that 
-  your ``pattern`` and your ``escape_character`` are both 
+  predicate with ``CLOB``\s or ``NCLOB``\s and, when you do use ``[NOT LIKE]``,
+  make sure your ``character_string_argument`` is a <Column reference> and that
+  your ``pattern`` and your ``escape_character`` are both
   <value specification>s.
 
 * If you want to restrict your code to Core SQL, don't use the ``[NOT] SIMILAR``
@@ -113,9 +115,9 @@ Core SQL Notes
   seconds precision greater than 6 digits or a <time zone interval> to your
   timestamp values.
 
-* If you want to restrict your code to Core SQL, don't define your ``TIME`` 
-  <data type>s with a fractional seconds precision and don't add the optional 
-  noise words ``WITHOUT TIME ZONE``: use only ``TIME``, never ``TIME(x) WITHOUT 
+* If you want to restrict your code to Core SQL, don't define your ``TIME``
+  <data type>s with a fractional seconds precision and don't add the optional
+  noise words ``WITHOUT TIME ZONE``: use only ``TIME``, never ``TIME(x) WITHOUT
   TIME ZONE``.
 
 * If you want to restrict your code to Core SQL, don't use ``TIME WITH TIME
@@ -136,12 +138,12 @@ Core SQL Notes
   type>.
 
 * If you want to restrict your code to Core SQL, don't add or subtract
-  datetime expressions, don't add the optional ``AT LOCAL/AT TIME ZONE`` clause 
+  datetime expressions, don't add the optional ``AT LOCAL/AT TIME ZONE`` clause
   to any time or timestamp value and don't use interval expressions at all.
 
 * If you want to restrict your code to Core SQL, don't use ``CURRENT_TIME`` or
-  ``CURRENT_TIMESTAMP``, don't specify a fractional seconds precision for 
-  ``LOCALTIME`` and don't specify a fractional seconds precision for 
+  ``CURRENT_TIMESTAMP``, don't specify a fractional seconds precision for
+  ``LOCALTIME`` and don't specify a fractional seconds precision for
   ``LOCALTIMESTAMP`` other than zero or 6.
 
 * If you want to restrict your code to Core SQL, don't use ``EXTRACT``.
@@ -159,12 +161,12 @@ Core SQL Notes
   <data type>s.
 
 * If you want to restrict your code to Core SQL, don't use the optional truth
-  value Boolean test (i.e.: don't use the constructs "boolean_argument" ``IS 
-  TRUE``, "boolean_argument" ``IS FALSE`` or "boolean_argument" ``IS UNKNOWN``) 
-  and don't use "boolean_argument" unless it's an SQL predicate or it's 
+  value Boolean test (i.e.: don't use the constructs "boolean_argument" ``IS
+  TRUE``, "boolean_argument" ``IS FALSE`` or "boolean_argument" ``IS UNKNOWN``)
+  and don't use "boolean_argument" unless it's an SQL predicate or it's
   enclosed in parentheses.
 
-* If you want to restrict your code to Core SQL, don't define any ``ARRAY`` 
+* If you want to restrict your code to Core SQL, don't define any ``ARRAY``
   <data type>s and don't use any of SQL's array syntax.
 
 * If you want to restrict your code to Core SQL, don't use ``CONCATENATE``.
@@ -173,9 +175,9 @@ Core SQL Notes
 
 * If you want to restrict your code to Core SQL, don't use the ``ROW`` <data
   type> or <row reference>s and <Field reference>s and, when using a <row value
-  constructor>, don't use ``ARRAY[]`` or ``ARRAY??(??)`` as an 
-  "element_expression", don't construct a row with more than one Field, don't 
-  use the ``ROW`` <keyword> in front of your element_expression and don't use a 
+  constructor>, don't use ``ARRAY[]`` or ``ARRAY??(??)`` as an
+  "element_expression", don't construct a row with more than one Field, don't
+  use the ``ROW`` <keyword> in front of your element_expression and don't use a
   subquery to construct your row.
 
 * If you want to restrict your code to Core SQL, don't use the ``REF`` <data
@@ -183,7 +185,7 @@ Core SQL Notes
 
 * If you want to restrict your code to Core SQL, don't use ``DEREF``.
 
-* If you want to restrict your code to Core SQL, don't use ``UDT``\s, methods 
+* If you want to restrict your code to Core SQL, don't use ``UDT``\s, methods
   or any of SQL's <reference type> or ``UDT`` syntax.
 
 * If you want to restrict your code to Core SQL, don't use <Domain name> as a
@@ -202,11 +204,11 @@ Core SQL Notes
   statement.
 
 * If you want to restrict your code to Core SQL, don't specify the ``UNDER``
-  Privilege, don't specify the ``SELECT`` Privilege as a Column Privilege (that 
-  is, with a <Column name> list) and don't specify the ``INSERT`` Privilege as 
+  Privilege, don't specify the ``SELECT`` Privilege as a Column Privilege (that
+  is, with a <Column name> list) and don't specify the ``INSERT`` Privilege as
   a Column Privilege.
 
-* If you want to restrict your code to Core SQL, don't use the ``FROM`` 
+* If you want to restrict your code to Core SQL, don't use the ``FROM``
   <grantor> clause with the ``GRANT`` statement.
 
 * If you want to restrict your code to Core SQL, don't use the <grant role
@@ -214,11 +216,11 @@ Core SQL Notes
   Privileges on your Objects to other users -- Core SQL only allows the owner of
   an Object to hold a grantable Privilege.
 
-* If you want to restrict your code to Core SQL, don't use the <revoke role 
-  statement> form of the ``REVOKE`` statement and don't use ``REVOKE ... 
-  CASCADE`` or the ``GRANT OPTION FOR`` clause. Also, when revoking, make sure 
-  that your current <AuthorizationID> is the owner of the Schema that owns the 
-  Object you're revoking Privileges for. 
+* If you want to restrict your code to Core SQL, don't use the <revoke role
+  statement> form of the ``REVOKE`` statement and don't use ``REVOKE ...
+  CASCADE`` or the ``GRANT OPTION FOR`` clause. Also, when revoking, make sure
+  that your current <AuthorizationID> is the owner of the Schema that owns the
+  Object you're revoking Privileges for.
 
 * If you want to restrict your code to Core SQL, don't use the ``DROP ROLE``
   statement.
@@ -230,62 +232,62 @@ Core SQL Notes
   name>s.
 
 * If you want to restrict your code to Core SQL, do not reference
-  
+
   ::
-  
+
    INFORMATION_SCHEMA.ADMINISTRABLE_ROLE_AUTHORIZATIONS,
-   INFORMATION_SCHEMA.APPLICABLE_ROLES, 
+   INFORMATION_SCHEMA.APPLICABLE_ROLES,
    INFORMATION_SCHEMA.ASSERTIONS,
-   INFORMATION_SCHEMA.COLLATIONS, 
+   INFORMATION_SCHEMA.COLLATIONS,
    INFORMATION_SCHEMA.COLUMN_DOMAIN_USAGE,
    INFORMATION_SCHEMA.COLUMN_PRIVILEGES,
    INFORMATION_SCHEMA.COLUMN_USER_DEFINED_TYPE_USAGE,
    INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE,
    INFORMATION_SCHEMA.CONSTRAINT_TABLE_USAGE,
-   INFORMATION_SCHEMA.DIRECT_SUPERTABLES, 
+   INFORMATION_SCHEMA.DIRECT_SUPERTABLES,
    INFORMATION_SCHEMA.DOMAINS,
    INFORMATION_SCHEMA.DOMAIN_CONSTRAINTS,
    INFORMATION_SCHEMA.DOMAIN_USER_DEFINED_TYPE_USAGE,
-   INFORMATION_SCHEMA.ENABLED_ROLES, 
+   INFORMATION_SCHEMA.ENABLED_ROLES,
    INFORMATION_SCHEMA.KEY_COLUMN_USAGE,
    INFORMATION_SCHEMA.METHOD_SIGNATURES,
    INFORMATION_SCHEMA.METHOD_SIGNATURE_PARAMETERS,
-   INFORMATION_SCHEMA.ROLE_COLUMN_GRANTS, 
+   INFORMATION_SCHEMA.ROLE_COLUMN_GRANTS,
    INFORMATION_SCHEMA.ROLE_ROUTINE_GRANTS,
-   INFORMATION_SCHEMA.ROLE_TABLE_GRANTS, 
+   INFORMATION_SCHEMA.ROLE_TABLE_GRANTS,
    INFORMATION_SCHEMA.ROLE_USAGE_GRANTS,
    INFORMATION_SCHEMA.ROLE_USER_DEFINED_TYPE_GRANTS,
    INFORMATION_SCHEMA.ROUTINE_COLUMN_USAGE,
-   INFORMATION_SCHEMA.ROUTINE_TABLE_USAGE, 
+   INFORMATION_SCHEMA.ROUTINE_TABLE_USAGE,
    INFORMATION_SCHEMA.SQL_FEATURES,
-   INFORMATION_SCHEMA.SQL_IMPLEMENTATION_INFO, 
+   INFORMATION_SCHEMA.SQL_IMPLEMENTATION_INFO,
    INFORMATION_SCHEMA.SQL_SIZING,
-   INFORMATION_SCHEMA.SQL_SIZING_PROFILES, 
+   INFORMATION_SCHEMA.SQL_SIZING_PROFILES,
    INFORMATION_SCHEMA.TABLE_PRIVILEGES,
-   INFORMATION_SCHEMA.TRANSFORMS, 
+   INFORMATION_SCHEMA.TRANSFORMS,
    INFORMATION_SCHEMA.TRANSLATIONS,
    INFORMATION_SCHEMA.TRIGGER_COLUMN_USAGE,
-   INFORMATION_SCHEMA.TRIGGER_TABLE_USAGE, 
+   INFORMATION_SCHEMA.TRIGGER_TABLE_USAGE,
    INFORMATION_SCHEMA.USAGE_PRIVILEGES,
    INFORMATION_SCHEMA.USER_DEFINED_TYPE_PRIVILEGES,
-   INFORMATION_SCHEMA.USER_DEFINED_TYPES, 
+   INFORMATION_SCHEMA.USER_DEFINED_TYPES,
    INFORMATION_SCHEMA.VIEW_COLUMN_USAGE or
    INFORMATION_SCHEMA.VIEW_TABLE_USAGE.
 
-* If you want to restrict your code to Core SQL, don't use a ``DEFAULT 
-  CHARACTER SET`` clause or a ``PATH`` clause in your ``CREATE SCHEMA`` 
-  statements and don't include any of the following in your <Schema element 
-  list>: ``CREATE ASSERTION`` statements, ``CREATE CHARACTER SET`` statements, 
-  ``CREATE COLLATION`` statements, ``CREATE DOMAIN`` statements, ``CREATE 
-  TRANSLATION`` statements, ``CREATE TYPE`` statements, ``CREATE ROLE`` 
-  statements or ``GRANT`` statements to Roles. 
+* If you want to restrict your code to Core SQL, don't use a ``DEFAULT
+  CHARACTER SET`` clause or a ``PATH`` clause in your ``CREATE SCHEMA``
+  statements and don't include any of the following in your <Schema element
+  list>: ``CREATE ASSERTION`` statements, ``CREATE CHARACTER SET`` statements,
+  ``CREATE COLLATION`` statements, ``CREATE DOMAIN`` statements, ``CREATE
+  TRANSLATION`` statements, ``CREATE TYPE`` statements, ``CREATE ROLE``
+  statements or ``GRANT`` statements to Roles.
 
 * If you want to restrict your code to Core SQL, don't use the ``DROP SCHEMA``
   statement.
 
 * If you want to restrict your code to Core SQL, don't create any temporary
-  Base tables, don't use a ``LIKE`` clause as a <table element>, don't use an 
-  ``OF`` clause as a <table element> and don't add a <column scope clause> to 
+  Base tables, don't use a ``LIKE`` clause as a <table element>, don't use an
+  ``OF`` clause as a <table element> and don't add a <column scope clause> to
   any ``CREATE TABLE`` statement.
 
 * If you want to restrict your code to Core SQL, don't add a ``COLLATE`` clause
@@ -304,16 +306,16 @@ Core SQL Notes
 * If you want to restrict your code to Core SQL, don't use the ``CASCADE`` drop
   behaviour for your ``DROP TABLE`` statements.
 
-* If you want to restrict your code to Core SQL, don't define any ``RECURSIVE`` 
-  Views, don't use the ``EXCEPT``, ``INTERSECT`` or ``CORRESPONDING`` operators 
-  in your View queries and don't use the optional ``CASCADED`` or ``LOCAL`` 
-  levels specification in your check clauses -- always define Views only with 
-  ``WITH CHECK OPTION`` alone. 
+* If you want to restrict your code to Core SQL, don't define any ``RECURSIVE``
+  Views, don't use the ``EXCEPT``, ``INTERSECT`` or ``CORRESPONDING`` operators
+  in your View queries and don't use the optional ``CASCADED`` or ``LOCAL``
+  levels specification in your check clauses -- always define Views only with
+  ``WITH CHECK OPTION`` alone.
 
 * If you want to restrict your code to Core SQL, don't use the ``CASCADE`` drop
   behaviour for your ``DROP VIEW`` statements.
 
-* If you want to restrict your code to Core SQL, don't use the ``DECLARE LOCAL 
+* If you want to restrict your code to Core SQL, don't use the ``DECLARE LOCAL
   TEMPORARY TABLE`` statement.
 
 * If you want to restrict your code to Core SQL, don't use the ``CREATE DOMAIN``
@@ -327,26 +329,26 @@ Core SQL Notes
 
 * If you want to restrict your code to Core SQL, don't name your Constraints
   and don't add a <constraint attributes> clause to your Constraint definitions.
-  (This means you'll be defining all Constraints as ``NOT DEFERRABLE 
+  (This means you'll be defining all Constraints as ``NOT DEFERRABLE
   INITIALLY IMMEDIATE``.)
 
 * If you want to restrict your code to Core SQL, don't use the
-  ``UNIQUE(VALUE)`` form to define a ``UNIQUE`` Constraint and don't add a 
-  ``NOT NULL`` Constraint to any Column that is part of a unique key for a 
+  ``UNIQUE(VALUE)`` form to define a ``UNIQUE`` Constraint and don't add a
+  ``NOT NULL`` Constraint to any Column that is part of a unique key for a
   ``UNIQUE`` Constraint.
 
 * If you want to restrict your code to Core SQL, don't define your ``FOREIGN
-  KEY`` Constraints with a ``MATCH`` clause, an ``ON UPDATE`` clause or an 
+  KEY`` Constraints with a ``MATCH`` clause, an ``ON UPDATE`` clause or an
   ``ON DELETE`` clause.
 
-* If you want to restrict your code to Core SQL, don't use a subquery in a 
-  ``CHECK`` Constraint's search condition. Also, for Core SQL, the 
-  ``REFERENCES`` Privilege isn't needed to create a ``CHECK`` Constraint. 
+* If you want to restrict your code to Core SQL, don't use a subquery in a
+  ``CHECK`` Constraint's search condition. Also, for Core SQL, the
+  ``REFERENCES`` Privilege isn't needed to create a ``CHECK`` Constraint.
 
 * If you want to restrict your code to Core SQL, don't use the ``CREATE
   ASSERTION`` statement.
 
-* If you want to restrict your code to Core SQL, don't use the ``DROP 
+* If you want to restrict your code to Core SQL, don't use the ``DROP
   ASSERTION`` statement.
 
 * If you want to restrict your code to Core SQL, don't use any <Character set
@@ -355,7 +357,7 @@ Core SQL Notes
 * If you want to restrict your code to Core SQL, don't use the ``CREATE
   CHARACTER SET`` statement.
 
-* If you want to restrict your code to Core SQL, don't use the ``DROP 
+* If you want to restrict your code to Core SQL, don't use the ``DROP
   CHARACTER SET`` statement.
 
 * If you want to restrict your code to Core SQL, don't use any <Collation
@@ -364,7 +366,7 @@ Core SQL Notes
 * If you want to restrict your code to Core SQL, don't use the ``CREATE
   COLLATION`` statement.
 
-* If you want to restrict your code to Core SQL, don't use the ``DROP 
+* If you want to restrict your code to Core SQL, don't use the ``DROP
   COLLATION`` statement.
 
 * If you want to restrict your code to Core SQL, don't use any <Translation
@@ -376,16 +378,16 @@ Core SQL Notes
 * If you want to restrict your code to Core SQL, don't use the ``DROP
   TRANSLATION`` statement.
 
-* If you want to restrict your code to Core SQL, don't use the ``CREATE 
+* If you want to restrict your code to Core SQL, don't use the ``CREATE
   TRIGGER`` statement.
 
-* If you want to restrict your code to Core SQL, don't use the ``DROP 
+* If you want to restrict your code to Core SQL, don't use the ``DROP
   TRIGGER`` statement.
 
-* If you want to restrict your code to Core SQL, don't use ``LOCATOR`` 
-  indicators, ``DYNAMIC RESULT SETS`` clauses, ``TRANSFORM GROUP`` clauses or 
-  duplicate <Routine name>s when defining an SQL-invoked routine and don't 
-  define any SQL-invoked methods. 
+* If you want to restrict your code to Core SQL, don't use ``LOCATOR``
+  indicators, ``DYNAMIC RESULT SETS`` clauses, ``TRANSFORM GROUP`` clauses or
+  duplicate <Routine name>s when defining an SQL-invoked routine and don't
+  define any SQL-invoked methods.
 
 * If you want to restrict your code to Core SQL, don't use the ``CASCADE`` drop
   behaviour for your ``DROP ROUTINE/FUNCTION/PROCEDURE`` statements.
@@ -394,8 +396,8 @@ Core SQL Notes
   reference> or ``CURRENT_PATH`` to specify a value.
 
 * If you want to restrict your code to Core SQL, don't use a <value
-  expression> that evaluates to a Boolean value, an array, an interval or a 
-  ``REF`` value, don't use a <subtype treatment> to specify a value and don't 
+  expression> that evaluates to a Boolean value, an array, an interval or a
+  ``REF`` value, don't use a <subtype treatment> to specify a value and don't
   use the ``COLLATE`` clause to force a collating sequence for any value.
 
 * If you want to restrict your code to Core SQL, don't use a <query name> to
@@ -405,11 +407,11 @@ Core SQL Notes
 * If you want to restrict your code to Core SQL, don't use the <distinct
   predicate>.
 
-* If you want to restrict your code to Core SQL, don't use ``BLOB``\s, 
+* If you want to restrict your code to Core SQL, don't use ``BLOB``\s,
   ``CLOB``\s or ``NCLOB``\s in a ``CASE`` expression.
 
 * If you want to restrict your code to Core SQL, don't use ``CROSS JOIN``, don't
-  use ``UNION JOIN``, don't use ``NATURAL`` for any type of join and don't use 
+  use ``UNION JOIN``, don't use ``NATURAL`` for any type of join and don't use
   ``FULL [OUTER] JOIN``.
 
 * If you want to restrict your code to Core SQL, make sure that all
@@ -435,50 +437,50 @@ Core SQL Notes
   contain exactly one row.
 
 * If you want to restrict your code to Core SQL, don't use ``WITH [RECURSIVE]``
-  in a <query expression>, the ``INTERSECT`` set operator, a ``CORRESPONDING`` 
-  clause with any set operator or any set operator with an explicit 
+  in a <query expression>, the ``INTERSECT`` set operator, a ``CORRESPONDING``
+  clause with any set operator or any set operator with an explicit
   ``DISTINCT``.
 
-* If you want to restrict your code to Core SQL, don't use ``ROLLUP`` or 
+* If you want to restrict your code to Core SQL, don't use ``ROLLUP`` or
   ``CUBE``, and don't add a ``COLLATE`` clause to any grouping Column reference.
 
-* If you want to restrict your code to Core SQL, don't use the set functions 
-  ``EVERY``, ``ANY``, ``SOME`` or ``GROUPING``, don't use a set function unless 
-  it operates only on a <Column reference> that refers to a Column belonging to 
-  a Table named in the ``FROM`` clause, and when counting, always use 
-  ``COUNT(*)``: don't use ``COUNT(Column)`` or ``COUNT(ALL Column)`` at all. 
+* If you want to restrict your code to Core SQL, don't use the set functions
+  ``EVERY``, ``ANY``, ``SOME`` or ``GROUPING``, don't use a set function unless
+  it operates only on a <Column reference> that refers to a Column belonging to
+  a Table named in the ``FROM`` clause, and when counting, always use
+  ``COUNT(*)``: don't use ``COUNT(Column)`` or ``COUNT(ALL Column)`` at all.
 
-* If you want to restrict your code to Core SQL, don't use a <query expression> 
-  with ``EXCEPT``, ``INTERSECT`` or ``CORRESPONDING`` in an ``INSERT`` 
-  statement, don't use a <query expression> that names an underlying Table of 
-  your target Table in an ``INSERT`` statement, don't use the <query 
-  expression> ``TABLE`` <Table name> in an ``INSERT`` statement, if you use the 
-  <query expression ``VALUES`` (value commalist) in an ``INSERT`` statement, 
-  make sure it constructs only one new row, don't use the ``DEFAULT VALUES`` 
-  form of the ``INSERT`` statement and make sure all your ``INSERT`` <Table 
-  reference>s are actually <Table name>s, with no <Correlation name>s or 
-  <derived Column list>s. 
+* If you want to restrict your code to Core SQL, don't use a <query expression>
+  with ``EXCEPT``, ``INTERSECT`` or ``CORRESPONDING`` in an ``INSERT``
+  statement, don't use a <query expression> that names an underlying Table of
+  your target Table in an ``INSERT`` statement, don't use the <query
+  expression> ``TABLE`` <Table name> in an ``INSERT`` statement, if you use the
+  <query expression ``VALUES`` (value commalist) in an ``INSERT`` statement,
+  make sure it constructs only one new row, don't use the ``DEFAULT VALUES``
+  form of the ``INSERT`` statement and make sure all your ``INSERT`` <Table
+  reference>s are actually <Table name>s, with no <Correlation name>s or
+  <derived Column list>s.
 
-* If you want to restrict your code to Core SQL, don't use a <search condition> 
-  that names an underlying Table of your target Table in an ``UPDATE`` 
-  statement and make sure all your ``UPDATE`` <Table reference>s are actually 
-  <Table name>s, with no <Correlation name>s or <derived Column list>s. 
+* If you want to restrict your code to Core SQL, don't use a <search condition>
+  that names an underlying Table of your target Table in an ``UPDATE``
+  statement and make sure all your ``UPDATE`` <Table reference>s are actually
+  <Table name>s, with no <Correlation name>s or <derived Column list>s.
 
-* If you want to restrict your code to Core SQL, don't use a <search condition> 
-  that names an underlying Table of your target Table in a ``DELETE`` statement 
-  and make sure all your ``DELETE`` <Table reference>s are actually <Table 
-  name>s, with no <Correlation name>s or <derived Column list>s. 
+* If you want to restrict your code to Core SQL, don't use a <search condition>
+  that names an underlying Table of your target Table in a ``DELETE`` statement
+  and make sure all your ``DELETE`` <Table reference>s are actually <Table
+  name>s, with no <Correlation name>s or <derived Column list>s.
 
-* If you want to restrict your code to Core SQL, don't use ``AND CHAIN`` or 
+* If you want to restrict your code to Core SQL, don't use ``AND CHAIN`` or
   ``AND NO CHAIN`` with ``COMMIT``.
 
-* If you want to restrict your code to Core SQL, don't use ``AND CHAIN``, ``AND 
+* If you want to restrict your code to Core SQL, don't use ``AND CHAIN``, ``AND
   NO CHAIN`` or ``TO SAVEPOINT`` with ``ROLLBACK``.
 
-* If you want to restrict your code to Core SQL, don't use the ``SAVEPOINT`` 
+* If you want to restrict your code to Core SQL, don't use the ``SAVEPOINT``
   statement.
 
-* If you want to restrict your code to Core SQL, don't use the ``RELEASE 
+* If you want to restrict your code to Core SQL, don't use the ``RELEASE
   SAVEPOINT`` statement.
 
 * If you want to restrict your code to Core SQL, don't use ``SET LOCAL
@@ -491,7 +493,7 @@ Core SQL Notes
 * If you want to restrict your code to Core SQL, don't use the ``CONNECT``
   statement.
 
-* If you want to restrict your code to Core SQL, don't use the ``SET 
+* If you want to restrict your code to Core SQL, don't use the ``SET
   CONNECTION`` statement.
 
 * If you want to restrict your code to Core SQL, don't use the ``DISCONNECT``
@@ -514,21 +516,21 @@ Taxonomy Tables
 
 In the following tables:
 
-* The first column, "Feature ID", gives the SQL Standard's identification 
-  for each feature and subfeature. The Feature ID value consists of either a 
-  letter and three digits or a letter, three digits, a hyphen and one or two 
-  additional digits. Feature ID values without a hyphen identify complete 
-  features. Feature ID values containing a hyphen and additional digits 
-  identify subfeatures that help to define a complete feature. 
+* The first column, "Feature ID", gives the SQL Standard's identification
+  for each feature and subfeature. The Feature ID value consists of either a
+  letter and three digits or a letter, three digits, a hyphen and one or two
+  additional digits. Feature ID values without a hyphen identify complete
+  features. Feature ID values containing a hyphen and additional digits
+  identify subfeatures that help to define a complete feature.
 
-* The second column, "Feature Description", gives a brief description of 
-  the feature or subfeature. 
+* The second column, "Feature Description", gives a brief description of
+  the feature or subfeature.
 
-* The third column, "Core SQL?", shows the SQL Standard's definition of 
-  the minimal conformance requirement, called "Core SQL". Features that are 
-  included in the definition of Core SQL contain a "YES" in this column (their 
-  subfeatures contain "(yes)" for consistency). Features and subfeatures that 
-  are not part of Core SQL contain a "No" in this column. 
+* The third column, "Core SQL?", shows the SQL Standard's definition of
+  the minimal conformance requirement, called "Core SQL". Features that are
+  included in the definition of Core SQL contain a "YES" in this column (their
+  subfeatures contain "(yes)" for consistency). Features and subfeatures that
+  are not part of Core SQL contain a "No" in this column.
 
 Table Tax_1: SQL/Foundation Feature Taxonomy
 ............................................

--- a/docs/appendices/c.rst
+++ b/docs/appendices/c.rst
@@ -4,12 +4,14 @@
 Appendix C -- Non-portable SQL Features
 =======================================
 
-Not all SQL DBMSs are created equal. This Appendix lists the areas for which 
-the SQL Standard provides no standardized solution for a DBMS, i.e.: the 
-following areas are all labeled either "implementor-defined" or "implementor- 
-dependent" in the Standard. Thus, valid syntax and/or the expected response 
-will vary from one DBMS to another -- keep this in mind when writing your 
-applications. 
+.. include:: ../_include/note.rst
+
+Not all SQL DBMSs are created equal. This Appendix lists the areas for which
+the SQL Standard provides no standardized solution for a DBMS, i.e.: the
+following areas are all labeled either "implementor-defined" or "implementor-
+dependent" in the Standard. Thus, valid syntax and/or the expected response
+will vary from one DBMS to another -- keep this in mind when writing your
+applications.
 
 .. rubric:: Table of Contents
 
@@ -40,13 +42,13 @@ non-standard for four reasons:
    the "implementor-defined" and "implementor-dependent" areas contained in the
    Standard.
 
-4. The SQL Standard allows implementors to provide options for processing 
-   database operations that the Standard does not address (e.g.: a ``CREATE 
-   INDEX`` statement), as well as allowing implementors to provide options for 
-   processing Standard-defined SQL in a non-conforming manner. To quote the 
-   Standard: "An [SQL-]implementation remains conforming even if it provides 
-   user options to process nonconforming SQL language or to process conforming 
-   SQL language in a nonconforming manner." 
+4. The SQL Standard allows implementors to provide options for processing
+   database operations that the Standard does not address (e.g.: a ``CREATE
+   INDEX`` statement), as well as allowing implementors to provide options for
+   processing Standard-defined SQL in a non-conforming manner. To quote the
+   Standard: "An [SQL-]implementation remains conforming even if it provides
+   user options to process nonconforming SQL language or to process conforming
+   SQL language in a nonconforming manner."
 
 *Connection and Session Results*
 --------------------------------
@@ -80,9 +82,9 @@ The effect of omitting the optional ``USER`` clause from a ``CONNECT`` statement
 is non-standard because the SQL Standard requires implementors to define their
 own initial default SQL-session <AuthorizationID>.
 
-Whether the <user name> in a ``CONNECT`` statement must be identical to the 
-Module <AuthorizationID> is non-standard because the SQL Standard requires 
-implementors to define whether the two must match. 
+Whether the <user name> in a ``CONNECT`` statement must be identical to the
+Module <AuthorizationID> is non-standard because the SQL Standard requires
+implementors to define whether the two must match.
 
 A DBMS's initial default Catalog is non-standard because the SQL Standard
 requires implementors to choose their own initial default <Catalog name>.
@@ -114,23 +116,23 @@ reasons:
    times, the SQL Standard allows implementors to define when exactly when the
    SQL-session default <AuthorizationID> may also be changed.
 
-SQL does not include any ``CREATE CLUSTER``, ``OPEN CLUSTER``, ``ADD TO 
-CLUSTER`` or ``DROP CLUSTER`` statements. The method you'll use to access a 
-Cluster with your DBMS is thus non-standard because the SQL Standard requires 
-implementors to define what the physical aspects of a Cluster are, whether any 
-Catalog can be part of more than one Cluster at a time, how a Cluster comes 
-into being, how it may be accessed and how it may be destroyed. 
+SQL does not include any ``CREATE CLUSTER``, ``OPEN CLUSTER``, ``ADD TO
+CLUSTER`` or ``DROP CLUSTER`` statements. The method you'll use to access a
+Cluster with your DBMS is thus non-standard because the SQL Standard requires
+implementors to define what the physical aspects of a Cluster are, whether any
+Catalog can be part of more than one Cluster at a time, how a Cluster comes
+into being, how it may be accessed and how it may be destroyed.
 
-SQL does not include any ``CREATE CATALOG``, ``OPEN CATALOG`` or ``DROP 
-CATALOG`` statements. The method you'll use to access a Catalog with your DBMS 
-is thus non-standard because the SQL Standard requires implementors to define 
-how a Catalog comes into being, how it may be accessed and how it may be 
-destroyed. 
+SQL does not include any ``CREATE CATALOG``, ``OPEN CATALOG`` or ``DROP
+CATALOG`` statements. The method you'll use to access a Catalog with your DBMS
+is thus non-standard because the SQL Standard requires implementors to define
+how a Catalog comes into being, how it may be accessed and how it may be
+destroyed.
 
-The total number of Views in ``INFORMATION_SCHEMA``, and their exact 
-definition, is non-standard because the SQL Standard allows implementors to add 
-additional Views, as well as to add additional Columns to the Standard-defined 
-Views, to describe additional, implementation-defined features. 
+The total number of Views in ``INFORMATION_SCHEMA``, and their exact
+definition, is non-standard because the SQL Standard allows implementors to add
+additional Views, as well as to add additional Columns to the Standard-defined
+Views, to describe additional, implementation-defined features.
 
 *Parsing/Display*
 -----------------
@@ -143,7 +145,7 @@ The logical representation of the null value is non-standard because the SQL
 Standard requires implementors to define the character used to display the
 null value.
 
-Either a ``NULL`` is greater than all non-null values or a ``NULL`` is less 
+Either a ``NULL`` is greater than all non-null values or a ``NULL`` is less
 than all non-null values -- it's non-standard because the SQL Standard requires
 implementors to define whether ``NULL``\s sort high or low.
 
@@ -168,11 +170,11 @@ An <AuthorizationID> is non-standard for four reasons:
    mapping <AuthorizationID>s to users.
 
 3. The SQL Standard requires implementors to define their own method for
-   creating an <AuthorizationID>. SQL does not include a ``CREATE 
+   creating an <AuthorizationID>. SQL does not include a ``CREATE
    AUTHORIZATIONID`` statement.
 
 4. The SQL Standard requires implementors to define their own method for
-   dropping an <AuthorizationID>. SQL does not include a ``DROP 
+   dropping an <AuthorizationID>. SQL does not include a ``DROP
    AUTHORIZATIONID`` statement.
 
 <Connection name>s are non-standard for two reasons:
@@ -192,7 +194,7 @@ standard because the SQL Standard requires implementors to define all valid
 ---------------------
 
 A national <character string literal> belongs to a Character set which is the
-same Character set used for ``NCHAR`` and ``NCHAR VARYING`` <data type>s but is 
+same Character set used for ``NCHAR`` and ``NCHAR VARYING`` <data type>s but is
 non-standard for two reasons:
 
 1. The SQL Standard requires implementors to define the Character set
@@ -210,7 +212,7 @@ is non-standard because the SQL Standard requires implementors to define the
 maximum size of a <time value>'s fractional seconds precision.
 
 The allowable range for a <time value> must include, at a minimum, all times
-from: ``TIME '00:00:00.0'`` to: ``TIME '23:59:61.999999'`` but the exact range 
+from: ``TIME '00:00:00.0'`` to: ``TIME '23:59:61.999999'`` but the exact range
 of valid values is non-standard because the SQL Standard requires implementors
 to define the maximum size of a <time value>'s fractional seconds precision.
 
@@ -218,18 +220,18 @@ The maximum length of a <timestamp literal> may not be less than 26 characters
 but is non-standard because the SQL Standard requires implementors to define
 the maximum size of a <time value>'s fractional seconds precision.
 
-The allowable range for a <timestamp value> must include, at a minimum, all 
-timestamps from: ``TIMESTAMP '0001-01-01 00:00:00.0'`` to: ``TIMESTAMP 
-'9999-12-31 23:59:61.999999'`` but the exact range of valid values is 
-non-standard because the SQL Standard requires implementors to define the 
-maximum size of a <time value>'s fractional seconds precision. 
+The allowable range for a <timestamp value> must include, at a minimum, all
+timestamps from: ``TIMESTAMP '0001-01-01 00:00:00.0'`` to: ``TIMESTAMP
+'9999-12-31 23:59:61.999999'`` but the exact range of valid values is
+non-standard because the SQL Standard requires implementors to define the
+maximum size of a <time value>'s fractional seconds precision.
 
 The maximum "start datetime" precision for an <interval qualifier> may not be
 less than 2 digits but is non-standard because the SQL Standard requires
 implementors to uefine the maximum leading precision.
 
 The maximum fractional seconds precision for an <interval qualifier>'s "start
-datetime" value or "end datetime" value of ``SECOND`` may not be less than 6 
+datetime" value or "end datetime" value of ``SECOND`` may not be less than 6
 digits but is non-standard because the SQL Standard requires implemented
 Privileges held on the Module by any other <AuthorizationID> are also revoked.
 
@@ -239,13 +241,13 @@ are dropped with a ``CASCADE`` drop behaviour.
 *BEGIN ... END: Compound Statement*
 -----------------------------------
 
-Advance warning: ``BEGIN ... END`` has several optional clauses. We are going 
-to start with the simplest form, and examine the options in following sections. 
+Advance warning: ``BEGIN ... END`` has several optional clauses. We are going
+to start with the simplest form, and examine the options in following sections.
 
-In its simplest form, ``BEGIN ... END`` in SQL serves the same purpose as 
-"begin...end" in Pascal or "{...}" in C. ``BEGIN ... END`` encloses a sequence 
-of statements which are part of the same syntactical unit: a compound 
-statement. The simplest required syntax is: 
+In its simplest form, ``BEGIN ... END`` in SQL serves the same purpose as
+"begin...end" in Pascal or "{...}" in C. ``BEGIN ... END`` encloses a sequence
+of statements which are part of the same syntactical unit: a compound
+statement. The simplest required syntax is:
 
 ::
 
@@ -274,9 +276,9 @@ clause: ``[NOT] ATOMIC``. The required syntax is:
       [ <SQL statement>; ... ]
     END
 
-If ``ATOMIC`` is specified, the compound statement may not contain ``COMMIT`` 
-or ``ROLLBACK``. If you omit the clause, it defaults to ``NOT ATOMIC``: the 
-compound statement may contain ``COMMIT`` or ``ROLLBACK``. Here's an example: 
+If ``ATOMIC`` is specified, the compound statement may not contain ``COMMIT``
+or ``ROLLBACK``. If you omit the clause, it defaults to ``NOT ATOMIC``: the
+compound statement may contain ``COMMIT`` or ``ROLLBACK``. Here's an example:
 
 ::
 
@@ -285,14 +287,14 @@ compound statement may contain ``COMMIT`` or ``ROLLBACK``. Here's an example:
       INSERT INTO Table_2 VALUES (6);
    END
 
-We've already discussed the idea that transactions are atomic, and individual 
-SQL statements are atomic. Compound SQL statements can be atomic too, provided 
-that they are explicitly designated by the <keyword> ``ATOMIC``. Thus, in the 
-above example, if the first ``INSERT`` statement succeeds but the second 
-``INSERT`` statement fails, then the effects of the first ``INSERT`` is 
-cancelled. It's as if there was a savepoint at the beginning of the compound 
-statement and a ``ROLLBACK TO SAVEPOINT`` was executed when the second 
-``INSERT`` failed. 
+We've already discussed the idea that transactions are atomic, and individual
+SQL statements are atomic. Compound SQL statements can be atomic too, provided
+that they are explicitly designated by the <keyword> ``ATOMIC``. Thus, in the
+above example, if the first ``INSERT`` statement succeeds but the second
+``INSERT`` statement fails, then the effects of the first ``INSERT`` is
+cancelled. It's as if there was a savepoint at the beginning of the compound
+statement and a ``ROLLBACK TO SAVEPOINT`` was executed when the second
+``INSERT`` failed.
 
 Variables
 _________
@@ -306,7 +308,7 @@ clause: a variable declaration list. The required syntax is:
       [ <variable declaration>; ... ]     /* variable-declaration list */
       [ <SQL statement>; ... ]
     END
-    
+
    <variable declaration> ::=
    DECLARE <SQL variable name> <data type> [ DEFAULT default value ]
 
@@ -324,33 +326,33 @@ Here's an example:
 
 .. CAUTION::
 
-   Don't get confused by the similarity to a <Column definition>. A variable 
-   definition can contain ``ONLY`` a <data type> and (optionally) a ``DEFAULT`` 
-   clause. It cannot contain a <Domain name>, a <Constraint> or a ``COLLATE`` 
-   clause. 
+   Don't get confused by the similarity to a <Column definition>. A variable
+   definition can contain ``ONLY`` a <data type> and (optionally) a ``DEFAULT``
+   clause. It cannot contain a <Domain name>, a <Constraint> or a ``COLLATE``
+   clause.
 
-In our example we defined five variables: ``v1``, ``v2``, ``v3``, ``v4``, 
-``v5``. ``BEGIN ... END`` defines a "local scope", which means that *(a)* these 
-variable names have no meaning outside the compound statement, *(b)* the values 
-in these variables are not saved when the compound statement ends and *(c)* the 
-values in these variables are not reset by execution of a ``ROLLBACK`` 
-statement, because variables are not part of the database. 
+In our example we defined five variables: ``v1``, ``v2``, ``v3``, ``v4``,
+``v5``. ``BEGIN ... END`` defines a "local scope", which means that *(a)* these
+variable names have no meaning outside the compound statement, *(b)* the values
+in these variables are not saved when the compound statement ends and *(c)* the
+values in these variables are not reset by execution of a ``ROLLBACK``
+statement, because variables are not part of the database.
 
-The example uses the first four variables as targets in a singleton ``SELECT`` 
-statement. It also uses all five variables as sources in an ``INSERT`` 
-statement. Variables can be used in all sorts of <value expression>s. Variables 
-are extremely useful for temporary storage, and it's a wonder that most SQL 
-implementations get along without them. The designers of SQL don't give us the 
-option of using variables for persistent storage: we're supposed to use Base 
-tables for that. 
+The example uses the first four variables as targets in a singleton ``SELECT``
+statement. It also uses all five variables as sources in an ``INSERT``
+statement. Variables can be used in all sorts of <value expression>s. Variables
+are extremely useful for temporary storage, and it's a wonder that most SQL
+implementations get along without them. The designers of SQL don't give us the
+option of using variables for persistent storage: we're supposed to use Base
+tables for that.
 
 Assignment Statements
 _____________________
 
-Assignment statements begin with the <keyword> ``SET`` -- but don't call them 
-"``SET`` statements", to avoid confusion with non-PSM statements that also 
-begin with ``SET``. Assignment statements are syntactically similar to the 
-``SET`` clauses used in ``UPDATE`` statements. Here is the required syntax: 
+Assignment statements begin with the <keyword> ``SET`` -- but don't call them
+"``SET`` statements", to avoid confusion with non-PSM statements that also
+begin with ``SET``. Assignment statements are syntactically similar to the
+``SET`` clauses used in ``UPDATE`` statements. Here is the required syntax:
 
 ::
 
@@ -401,7 +403,7 @@ for SQL/CLI. Here's an example:
 
 Objects that you declare in a compound statement have "local scope", so the
 <Cursor name> in this example -- cc -- can only be  used by SQL statements
-within the ``BEGIN ... END``. The example could be replaced with this SQL 
+within the ``BEGIN ... END``. The example could be replaced with this SQL
 statement:
 
 ::
@@ -429,12 +431,12 @@ declare conditions as well as variables. The required syntax is:
    <condition declaration> ::=
       DECLARE <condition name> CONDITION [ FOR <sqlstate value> ]
 
-**Quick review:** An ``SQLSTATE`` value is a 5-character status code string. 
-Upon completion of any SQL statement, there will be a status code in 
-``SQLSTATE``, which is the main diagnostic field. Typical values are ``'01006' 
-(warning-privilege not revoked)``, ``'22012' (data exception-division by 
-zero)``, ``'42000' (syntax error or access violation)``. You'll find a complete 
-list of ``SQLSTATE`` values in our chapter on SQL/CLI diagnostics. 
+**Quick review:** An ``SQLSTATE`` value is a 5-character status code string.
+Upon completion of any SQL statement, there will be a status code in
+``SQLSTATE``, which is the main diagnostic field. Typical values are ``'01006'
+(warning-privilege not revoked)``, ``'22012' (data exception-division by
+zero)``, ``'42000' (syntax error or access violation)``. You'll find a complete
+list of ``SQLSTATE`` values in our chapter on SQL/CLI diagnostics.
 
 Here's an example of the latest form of ``BEGIN ... END``:
 
@@ -472,16 +474,16 @@ clause: a handler declaration list. The required syntax is:
       [ <handler declaration>; ...]               /* handler-declaration list */
       [ <SQL statement>; ... ]
     END
-    
+
     <handler declaration> ::=
     DECLARE <handler type> HANDLER FOR <condition value list> <handler action>
-    
+
     <handler type> ::= {CONTINUE | EXIT | UNDO }
-    
+
     <handler action> ::= <SQL statement>
-    
+
     <condition value list> ::= <condition value> [ {,<condition value>}... ]
-    
+
     <condition value> ::=
     <sqlstate value>| <condition name>| SQLEXCEPTION | SQLWARNING | NOT FOUND
 
@@ -511,19 +513,19 @@ statement:
 
    INSERT INTO Table_1 VALUES (99999);
 
-If this SQL statement fails due to overflow, then variable ``v1`` gets 
-``'Ovflw'``; if it fails due to an integrity Constraint violation, then 
-variable ``v1`` gets ``'c-err'``; if it succeeds but there is some warning, 
-then variable ``v1`` gets ``'?????'``. But, regardless, play continues because 
-all the handlers are ``CONTINUE`` handlers. So the second ``INSERT`` statement 
-will put in one of the values ``'Ovflw'``, ``'c-err'``, ``'?????'`` or 
-``'Okay!'`` (``'Okay!'`` is the default value for ``v1`` so this is what goes 
-in if the result of the first ``INSERT`` is success with no warnings). 
+If this SQL statement fails due to overflow, then variable ``v1`` gets
+``'Ovflw'``; if it fails due to an integrity Constraint violation, then
+variable ``v1`` gets ``'c-err'``; if it succeeds but there is some warning,
+then variable ``v1`` gets ``'?????'``. But, regardless, play continues because
+all the handlers are ``CONTINUE`` handlers. So the second ``INSERT`` statement
+will put in one of the values ``'Ovflw'``, ``'c-err'``, ``'?????'`` or
+``'Okay!'`` (``'Okay!'`` is the default value for ``v1`` so this is what goes
+in if the result of the first ``INSERT`` is success with no warnings).
 
-What if exception ``'42000'`` happens? That would be an "unhandled exception" 
-since we did not define a handler for exception ``'42000'``. The result would 
-be that the second ``INSERT`` is not attempted -- the whole compound statement 
-fails. 
+What if exception ``'42000'`` happens? That would be an "unhandled exception"
+since we did not define a handler for exception ``'42000'``. The result would
+be that the second ``INSERT`` is not attempted -- the whole compound statement
+fails.
 
 The following chart compares the exception-handling features of embedded SQL,
 the CLI and the PSM.
@@ -539,7 +541,7 @@ the CLI and the PSM.
     handles specific status codes?  no                 N/A   yes
 
 Among the SQL statements that a handler can execute are two new special ones:
-the ``SIGNAL`` statement and the ``RESIGNAL`` statement. These SQL statements 
+the ``SIGNAL`` statement and the ``RESIGNAL`` statement. These SQL statements
 affect the diagnostics area.
 
 Labels
@@ -558,9 +560,9 @@ end label. The required syntax for a compound statement is:
       [ <handler declaration>; ...]
       [ <SQL statement>; ... ]
     END [ <end_label> ]
-    
+
     <beginning_label> ::= <identifier>
-    
+
     <end_label> ::= <identifier>
 
 If you add labels to your compound statement, they should be equivalent (if
@@ -587,17 +589,17 @@ definition is trivial.
 *SIGNAL Statement*
 ------------------
 
-The ``SIGNAL`` statement is used to clear the diagnostics area. The required 
+The ``SIGNAL`` statement is used to clear the diagnostics area. The required
 syntax for the ``SIGNAL`` statement is:
 
 ::
 
     SIGNAL <condition name or sqlstate value>
        SET <signal information item list>
-       
+
        <signal information item list> ::=
        <signal information item> [ {,<signal information item>}... ]
-       
+
           <signal information item> ::=
           <condition information item name> = <simple value specification>
 
@@ -609,7 +611,7 @@ you include the optional ``SET`` clause, your DBMS effectively executes:
 
    RESIGNAL <signal information item list>;
 
-**Note:** You'll find the list of <condition information item name>s in our 
+**Note:** You'll find the list of <condition information item name>s in our
 chapter on embedded SQL -- see the ``GET DIAGNOSTICS`` statement.
 
 *RESIGNAL Statement*
@@ -636,7 +638,7 @@ Program Control
 _______________
 
 Essential SQL has almost nothing that can control the program flow (except for
-the ``CALL`` and ``RETURN`` statements which are associated with SQL routines). 
+the ``CALL`` and ``RETURN`` statements which are associated with SQL routines).
 By contrast, a DBMS with PSM support will allow eight control statements. Of
 these, seven are similar to statements which appear in other languages. The
 eighth, ``FOR``, depends on Objects which are unique to the SQL environment.
@@ -668,7 +670,7 @@ value expressions. The required syntax for the ``CASE`` statement is:
       [ WHEN <search condition> THEN <statement>(s) ... ]
       [ ELSE <statement>(s) ]
     END CASE
-    
+
     simple CASE statement ::=
     CASE <case value>
        WHEN <when value> THEN <statement>(s)
@@ -676,11 +678,11 @@ value expressions. The required syntax for the ``CASE`` statement is:
        [ ELSE <statement>(s) ]
     END CASE
 
-A "simple ``CASE`` statement" is merely a shorthand, and may be replaced by a 
-"searched ``CASE`` statement" which has the form: "``CASE WHEN`` <when value> = 
-<case value> ...". Thus, the following examples, showing a searched ``CASE`` 
-statement on the left and a simple ``CASE`` statement on the right, are exactly 
-equivalent: 
+A "simple ``CASE`` statement" is merely a shorthand, and may be replaced by a
+"searched ``CASE`` statement" which has the form: "``CASE WHEN`` <when value> =
+<case value> ...". Thus, the following examples, showing a searched ``CASE``
+statement on the left and a simple ``CASE`` statement on the right, are exactly
+equivalent:
 
 ::
 
@@ -692,30 +694,30 @@ equivalent:
      ELSE INSERT INTO t VALUES (0);      ELSE INSERT INTO t VALUES (0);
    END CASE                            END CASE
 
-When executing a ``CASE`` statement, the DBMS goes through the ``WHEN`` clauses 
-from top to bottom, looking for a ``TRUE`` condition. If it finds one, it 
-executes the statement(s) after ``THEN``, and the ``CASE`` terminates. If it 
-finds none, it executes the statements(s) after ``ELSE`` -- or, if there is no 
-``ELSE``, returns this ``SQLSTATE error: 20000 "case not found for case 
-statement"``. For the above example, then, if the value of ``parameter_value`` 
-is ``5``, then the DBMS will execute this SQL statement: 
+When executing a ``CASE`` statement, the DBMS goes through the ``WHEN`` clauses
+from top to bottom, looking for a ``TRUE`` condition. If it finds one, it
+executes the statement(s) after ``THEN``, and the ``CASE`` terminates. If it
+finds none, it executes the statements(s) after ``ELSE`` -- or, if there is no
+``ELSE``, returns this ``SQLSTATE error: 20000 "case not found for case
+statement"``. For the above example, then, if the value of ``parameter_value``
+is ``5``, then the DBMS will execute this SQL statement:
 
 ::
 
    INSERT INTO t VALUES (0);
 
-.. CAUTION:: 
+.. CAUTION::
 
-   The syntax for the ``CASE`` statement is somewhat different from the syntax 
-   for the SQL ``CASE`` expression (see our chapter on Simple Search 
-   Conditions). In particular, the ``CASE`` statement has no equivalent for the 
-   ``ELSE NULL`` clause, and the terminator is ``END CASE`` rather than 
-   ``END``. 
+   The syntax for the ``CASE`` statement is somewhat different from the syntax
+   for the SQL ``CASE`` expression (see our chapter on Simple Search
+   Conditions). In particular, the ``CASE`` statement has no equivalent for the
+   ``ELSE NULL`` clause, and the terminator is ``END CASE`` rather than
+   ``END``.
 
 *IF Statement*
 --------------
 
-The ``IF`` statement is useful for simple "if (x) then (do this)" situations. 
+The ``IF`` statement is useful for simple "if (x) then (do this)" situations.
 The required syntax for the ``IF`` statement is:
 
 ::
@@ -733,9 +735,9 @@ Here's an example:
    5=5 THEN UPDATE Table_1 SET column_1 = column_1 + 1;
   END IF
 
-In this example, the search condition is ``TRUE``, so the ``UPDATE`` statement 
-will be executed. If the search condition had been ``FALSE`` or ``UNKNOWN``, 
-then the ``UPDATE`` statement would not have been executed. 
+In this example, the search condition is ``TRUE``, so the ``UPDATE`` statement
+will be executed. If the search condition had been ``FALSE`` or ``UNKNOWN``,
+then the ``UPDATE`` statement would not have been executed.
 
 *LOOP Statement*
 ----------------
@@ -789,7 +791,7 @@ In this example, the loop will be exited once the value of ``x`` passes 1000.
 -----------------
 
 The ``WHILE`` statement is useful for repeated execution of SQL statements, with
-a built-in equivalent to the ``LEAVE`` statement. The required syntax for the 
+a built-in equivalent to the ``LEAVE`` statement. The required syntax for the
 ``WHILE`` statement is:
 
 ::
@@ -799,9 +801,9 @@ a built-in equivalent to the ``LEAVE`` statement. The required syntax for the
        <SQL statement>(s)
     END WHILE [ <end_label> ]
 
-As long as the <search condition> is ``TRUE``, the SQL statements between 
-``WHILE`` and ``END WHILE`` are repeatedly executed. The <beginning_label> and 
-the <end_label> must be equivalent, if you use them both. Here's an example: 
+As long as the <search condition> is ``TRUE``, the SQL statements between
+``WHILE`` and ``END WHILE`` are repeatedly executed. The <beginning_label> and
+the <end_label> must be equivalent, if you use them both. Here's an example:
 
 ::
 
@@ -809,9 +811,9 @@ the <end_label> must be equivalent, if you use them both. Here's an example:
       SET x = x + 1;
    END WHILE
 
-This example will loop, incrementing ``x``, until "``x <= 1000``" is either 
-``FALSE`` or ``UNKNOWN``. If the <search condition> is ``FALSE`` or ``UNKNOWN`` 
-when the loop begins, then nothing happens. 
+This example will loop, incrementing ``x``, until "``x <= 1000``" is either
+``FALSE`` or ``UNKNOWN``. If the <search condition> is ``FALSE`` or ``UNKNOWN``
+when the loop begins, then nothing happens.
 
 *REPEAT Statement*
 ------------------
@@ -827,10 +829,10 @@ syntax for the ``REPEAT`` statement is:
        <SQL statement>(s) UNTIL <search condition>
     END REPEAT [ <end_label> ]
 
-As long as the <search condition> is ``FALSE`` or ``UNKNOWN``, the SQL 
-statements between ``REPEAT`` and ``END REPEAT`` are repeatedly executed. The 
-<beginning_label> and the <end_label> must be equivalent, if you use them both. 
-Here's an example: 
+As long as the <search condition> is ``FALSE`` or ``UNKNOWN``, the SQL
+statements between ``REPEAT`` and ``END REPEAT`` are repeatedly executed. The
+<beginning_label> and the <end_label> must be equivalent, if you use them both.
+Here's an example:
 
 ::
 
@@ -840,177 +842,177 @@ Here's an example:
       UNTIL x > 5
    END REPEAT
 
-In this example, the ``UPDATE`` statement will be repeated until ``x`` is 
-greater than 5 -- that is, the loop will repeat until after theIf a sensitive 
-or asensitive holdable-Cursor is held open for a subsequent transaction, then 
-whether any significant changes made to SQL-data (by this or any subsequent 
-transaction in which the Cursor is held open) will be visible through that 
-Cursor in the subsequent transaction is non-standard because the SQL Standard 
-requires implementors to define how they will handle this situation. 
+In this example, the ``UPDATE`` statement will be repeated until ``x`` is
+greater than 5 -- that is, the loop will repeat until after theIf a sensitive
+or asensitive holdable-Cursor is held open for a subsequent transaction, then
+whether any significant changes made to SQL-data (by this or any subsequent
+transaction in which the Cursor is held open) will be visible through that
+Cursor in the subsequent transaction is non-standard because the SQL Standard
+requires implementors to define how they will handle this situation.
 
-Whether a DBMS is able to disallow significant changes that would not be 
-visible through a currently open Cursor is non-standard because the SQL 
-Standard requires implementors to define their actions in such situations. 
+Whether a DBMS is able to disallow significant changes that would not be
+visible through a currently open Cursor is non-standard because the SQL
+Standard requires implementors to define their actions in such situations.
 
-The extent to which a DBMS may disallow independent changes that are not 
-significant is non-standard because the SQL Standard requires implementors to 
-define their actions in such situations. 
+The extent to which a DBMS may disallow independent changes that are not
+significant is non-standard because the SQL Standard requires implementors to
+define their actions in such situations.
 
-The status of any open Cursors in any SQL-client Module associated with the 
-current transaction that were opened by that transaction before the 
-establishment of a savepoint to which a ``ROLLBACK`` is executed is 
-non-standard because the SQL Standard requires implementors to define their 
+The status of any open Cursors in any SQL-client Module associated with the
+current transaction that were opened by that transaction before the
+establishment of a savepoint to which a ``ROLLBACK`` is executed is
+non-standard because the SQL Standard requires implementors to define their
 actions in such situations.
 
 *Diagnostics*
 -------------
 
-The actual length of variable-length character items in the diagnostics area 
-has to be at least 128 octets but is otherwise non-standard because the SQL 
-Standard requires implementors to define the actual length. 
+The actual length of variable-length character items in the diagnostics area
+has to be at least 128 octets but is otherwise non-standard because the SQL
+Standard requires implementors to define the actual length.
 
-The character string value set for the diagnostic area's ``CLASS_ORIGIN`` and 
-``SUBCLASS_ORIGIN`` fields may not be ``'ISO 9075'`` but is otherwise 
-non-standard because the SQL Standard requires implementors to define their own 
-values for any non-standard errors. 
+The character string value set for the diagnostic area's ``CLASS_ORIGIN`` and
+``SUBCLASS_ORIGIN`` fields may not be ``'ISO 9075'`` but is otherwise
+non-standard because the SQL Standard requires implementors to define their own
+values for any non-standard errors.
 
-The character string value set for the diagnostic area's ``MESSAGE_TEXT`` field 
-is non-standard because the SQL Standard requires implementors to define their 
-own values for this field. 
+The character string value set for the diagnostic area's ``MESSAGE_TEXT`` field
+is non-standard because the SQL Standard requires implementors to define their
+own values for this field.
 
-Any negative values set for the diagnostic area's ``COMMAND_FUNCTION_CODE`` 
-field indicate implementation-defined SQL-statements and are thus non-standard 
-because the SQL Standard requires implementors to define their own values for 
-this field if they support any non-standard SQL statements. 
+Any negative values set for the diagnostic area's ``COMMAND_FUNCTION_CODE``
+field indicate implementation-defined SQL-statements and are thus non-standard
+because the SQL Standard requires implementors to define their own values for
+this field if they support any non-standard SQL statements.
 
-The method of flagging nonconforming SQL language or processing of conforming 
-SQL language is implementation-defined, as is the list of additional <keyword>s 
-that may be required by the DBMS. 
+The method of flagging nonconforming SQL language or processing of conforming
+SQL language is implementation-defined, as is the list of additional <keyword>s
+that may be required by the DBMS.
 
-The full set of known functional dependencies is non-standard because the SQL 
-Standard allows implementors to define additional functional dependencies if 
-they choose. 
+The full set of known functional dependencies is non-standard because the SQL
+Standard allows implementors to define additional functional dependencies if
+they choose.
 
 Implementation-Dependent Features
 =================================
 
-The SQL Standard requires a SQL DBMS to define how it will handle each of these 
-features. The decision does not have to be documented. 
+The SQL Standard requires a SQL DBMS to define how it will handle each of these
+features. The decision does not have to be documented.
 
-If more than one condition could have occurred when executing an SQL statement, 
-it is implementation-dependent whether the DBMS will make diagnostic 
-information pertaining to more than one condition available. 
+If more than one condition could have occurred when executing an SQL statement,
+it is implementation-dependent whether the DBMS will make diagnostic
+information pertaining to more than one condition available.
 
-The treatment of language that does not conform to the SQL Standard is 
-implementation-dependent. 
+The treatment of language that does not conform to the SQL Standard is
+implementation-dependent.
 
-If evaluation of the inessential parts of an expression or search condition 
-would cause an exception condition to be raised, it is implementation-dependent 
-whether or not that condition is raised. 
+If evaluation of the inessential parts of an expression or search condition
+would cause an exception condition to be raised, it is implementation-dependent
+whether or not that condition is raised.
 
-The actual size of the diagnostics area is implementation-dependent if you 
-don't specify the size yourself. 
+The actual size of the diagnostics area is implementation-dependent if you
+don't specify the size yourself.
 
-If ``DECLARE CURSOR`` does not include an ``ORDER BY`` clause, or includes an 
-``ORDER BY`` clause that doesn't specify the order of the rows completely, then 
-the rows of the result Table have an order that is defined only to the extent 
-that the ``ORDER BY`` clause specifies and is otherwise 
-implementation-dependent. 
+If ``DECLARE CURSOR`` does not include an ``ORDER BY`` clause, or includes an
+``ORDER BY`` clause that doesn't specify the order of the rows completely, then
+the rows of the result Table have an order that is defined only to the extent
+that the ``ORDER BY`` clause specifies and is otherwise
+implementation-dependent.
 
-The effect on the position and state of an open Cursor when an error occurs 
-during the execution of an SQL statement that identifies the Cursor is 
-implementation-dependent. 
+The effect on the position and state of an open Cursor when an error occurs
+during the execution of an SQL statement that identifies the Cursor is
+implementation-dependent.
 
-If an asensitive Cursor is open and a change is made to SQL-data from within 
-the same transaction other than through that Cursor, then whether that change 
-will be visible through that Cursor before it is closed is 
-implementation-dependent. 
+If an asensitive Cursor is open and a change is made to SQL-data from within
+the same transaction other than through that Cursor, then whether that change
+will be visible through that Cursor before it is closed is
+implementation-dependent.
 
-The mapping of <AuthorizationID>s to operating system users is 
-implementation-dependent. 
+The mapping of <AuthorizationID>s to operating system users is
+implementation-dependent.
 
-When an SQL-session is initiated, the current <authorization identifier> for 
-the SQL-session is determined in an implementation-dependent manner, unless the 
-session is initiated using a <connect statement>. 
+When an SQL-session is initiated, the current <authorization identifier> for
+the SQL-session is determined in an implementation-dependent manner, unless the
+session is initiated using a <connect statement>.
 
-A unique implementation-dependent SQL-session identifier is associated with 
-each SQL-session. 
+A unique implementation-dependent SQL-session identifier is associated with
+each SQL-session.
 
-The SQL-client <Module name> of the SQL-client Module that is effectively 
-materialized on an SQL-server is implementation-dependent. 
+The SQL-client <Module name> of the SQL-client Module that is effectively
+materialized on an SQL-server is implementation-dependent.
 
-Diagnostic information is passed to the diagnostics area in an application in 
-an implementation-dependent manner. 
+Diagnostic information is passed to the diagnostics area in an application in
+an implementation-dependent manner.
 
-The effect on diagnostic information of incompatibilities between the character 
-repertoires supported by the SQL-client and SQL-server environments is 
-implementation-dependent. 
+The effect on diagnostic information of incompatibilities between the character
+repertoires supported by the SQL-client and SQL-server environments is
+implementation-dependent.
 
-The time of evaluation of the ``CURRENT_DATE``, ``CURRENT_TIME`` and 
-``CURRENT_TIMESTAMP`` functions during the execution of an SQL statement is 
-implementation-dependent. 
+The time of evaluation of the ``CURRENT_DATE``, ``CURRENT_TIME`` and
+``CURRENT_TIMESTAMP`` functions during the execution of an SQL statement is
+implementation-dependent.
 
-The start datetime used for converting intervals to scalars for subtraction 
-purposes is implementation-dependent. 
+The start datetime used for converting intervals to scalars for subtraction
+purposes is implementation-dependent.
 
-The names of the Columns of a <row value constructor> that specifies a <row 
-value constructor list> are implementation-dependent. 
+The names of the Columns of a <row value constructor> that specifies a <row
+value constructor list> are implementation-dependent.
 
-When a Column is not named by an ``AS`` clause and is not derived from a single 
-Column reference, then the name of the Column is implementation-dependent. 
+When a Column is not named by an ``AS`` clause and is not derived from a single
+Column reference, then the name of the Column is implementation-dependent.
 
-If a <simple Table> is neither a <query specification> nor an <explicit Table>, 
-then the name of each Column of the <simple Table> is implementation-dependent. 
+If a <simple Table> is neither a <query specification> nor an <explicit Table>,
+then the name of each Column of the <simple Table> is implementation-dependent.
 
-If a <non-join query term> is not a <non-join query primary> and the <Column 
-name> of the corresponding Columns of both Tables participating in the 
-<non-join query term> are not the same, then the result Column has an 
-implementation-dependent <Column name>. 
+If a <non-join query term> is not a <non-join query primary> and the <Column
+name> of the corresponding Columns of both Tables participating in the
+<non-join query term> are not the same, then the result Column has an
+implementation-dependent <Column name>.
 
-If a <non-join query expression> is not a <non-join query term> and the <Column 
-name> of the corresponding Columns of both Tables participating in the 
-<non-join query expression> are not the same, then the result Column has an 
-implementation-dependent <Column name>. 
+If a <non-join query expression> is not a <non-join query term> and the <Column
+name> of the corresponding Columns of both Tables participating in the
+<non-join query expression> are not the same, then the result Column has an
+implementation-dependent <Column name>.
 
-When the operations ``MAX``, ``MIN``, ``DISTINCT``, and references to a 
-grouping Column refer to a variable-length character string or a 
-variable-length bit string, the specific value selected from the set of equal 
-values is implementation-dependent. 
+When the operations ``MAX``, ``MIN``, ``DISTINCT``, and references to a
+grouping Column refer to a variable-length character string or a
+variable-length bit string, the specific value selected from the set of equal
+values is implementation-dependent.
 
-The specific Character set chosen for the result of an aggregation is 
-implementation-dependent, but must be the Character set of one of the <data 
-type>s being aggregated. 
+The specific Character set chosen for the result of an aggregation is
+implementation-dependent, but must be the Character set of one of the <data
+type>s being aggregated.
 
-The <Constraint name> of a Constraint that does not specify a <Constraint name> 
-is implementation-dependent. 
+The <Constraint name> of a Constraint that does not specify a <Constraint name>
+is implementation-dependent.
 
-The specific value to use for cascading foreign keys among various values that 
-are not distinct is implementation-dependent. 
+The specific value to use for cascading foreign keys among various values that
+are not distinct is implementation-dependent.
 
-The Collation of characters for which a Collation is not otherwise specified is 
-implementation-dependent. 
+The Collation of characters for which a Collation is not otherwise specified is
+implementation-dependent.
 
-If an error occurs during assignment of a value to a target during the 
-execution of a singleton ``SELECT``, the values of targets other than status 
-parameters are implementation-dependent. 
+If an error occurs during assignment of a value to a target during the
+execution of a singleton ``SELECT``, the values of targets other than status
+parameters are implementation-dependent.
 
-If the cardinality of a singleton ``SELECT`` is greater than one, it is 
-implementation-dependent whether or not values are assigned to the 
-``SELECT``\'s targets. 
+If the cardinality of a singleton ``SELECT`` is greater than one, it is
+implementation-dependent whether or not values are assigned to the
+``SELECT``\'s targets.
 
-For Cursor operations, if an exception condition occurs during the assignment 
-of a value to a target, the values of all targets are implementation-dependent 
-and the Cursor remains positioned on the current row. 
+For Cursor operations, if an exception condition occurs during the assignment
+of a value to a target, the values of all targets are implementation-dependent
+and the Cursor remains positioned on the current row.
 
-It is implementation-dependent whether a Cursor remains positioned on the 
-current row when an exception condition is raised during the derivation of any 
-derived Column. 
+It is implementation-dependent whether a Cursor remains positioned on the
+current row when an exception condition is raised during the derivation of any
+derived Column.
 
-If <number of conditions> for the diagnostics area is not specified in a ``SET 
-TRANSACTION`` statement, then an implementation-dependent value, not less than 
-one, is the default. 
+If <number of conditions> for the diagnostics area is not specified in a ``SET
+TRANSACTION`` statement, then an implementation-dependent value, not less than
+one, is the default.
 
-The value of the diagnostic area's ``ROW_COUNT`` following the execution of an 
-SQL-statement that does not directly result in the execution of a <delete 
-statement: searched>, an <insert statement> or an <update statement: searched> 
-is implementation-dependent. 
+The value of the diagnostic area's ``ROW_COUNT`` following the execution of an
+SQL-statement that does not directly result in the execution of a <delete
+statement: searched>, an <insert statement> or an <update statement: searched>
+is implementation-dependent.

--- a/docs/appendices/d.rst
+++ b/docs/appendices/d.rst
@@ -4,6 +4,8 @@
 Appendix D -- Incompatibilities with SQL-92
 ===========================================
 
+.. include:: ../_include/note.rst
+
 SQL3 is compatible with the former version of the Standard (SQL-92) except in
 the following cases.
 
@@ -21,7 +23,7 @@ the following cases.
   warning-cursor operation conflict.
 
 * In SQL-92, there were two <status parameter>s provided: the deprecated
-  ``SQLCODE`` and ``SQLSTATE``. SQL3 does not support the ``SQLCODE`` <status 
+  ``SQLCODE`` and ``SQLSTATE``. SQL3 does not support the ``SQLCODE`` <status
   parameter> and ``SQLCODE`` is no longer a reserved <keyword>.
 
 * SQL-92 allowed you to omit the semicolon at the end of <module contents>;
@@ -35,7 +37,7 @@ the following cases.
   their names and other minor details.
 
 * In SQL-92, it was possible for applications to specify the Character set
-  associated with an <identifier> using: ``_<Character set specification>``. 
+  associated with an <identifier> using: ``_<Character set specification>``.
   SQL3 no longer supports that capability.
 
 * In SQL-92, it was possible to sort a Cursor by a Column's ordinal position

--- a/docs/appendices/e.rst
+++ b/docs/appendices/e.rst
@@ -4,6 +4,8 @@
 Appendix E -- SQL Web Sites
 ===========================
 
+.. include:: ../_include/note.rst
+
 You will get millions of hits if you submit the keyword SQL to any Internet
 search engine. You will get only 12 hits from this list. But they all have one
 interesting common feature: FREE STUFF. Our list of SQL web sites includes:

--- a/docs/appendices/f.rst
+++ b/docs/appendices/f.rst
@@ -4,6 +4,8 @@
 Appendix F -- Glossary
 ======================
 
+.. include:: ../_include/note.rst
+
 The entries in this glossary include the computer-related words, names,
 acronyms, abbreviations, SQL keywords and official terms used in this book, as
 well as those that are common in the SQL/database industry. Each entry is

--- a/docs/appendices/g.rst
+++ b/docs/appendices/g.rst
@@ -4,12 +4,14 @@
 Appendix G -- Errata
 ====================
 
-This concise errata list concerns apparent errors in some of our source 
-literature, such as the SQL standard documents or the ODBC manual. We do not 
-intend this as a comment. Like any errata list, its sole use is to help you 
-avoid confusion if you happen to read one of those texts. And, like any errata 
-list, it's ephemeral. At some time, the original documents will cease to 
-contain these errors. 
+.. include:: ../_include/note.rst
+
+This concise errata list concerns apparent errors in some of our source
+literature, such as the SQL standard documents or the ODBC manual. We do not
+intend this as a comment. Like any errata list, its sole use is to help you
+avoid confusion if you happen to read one of those texts. And, like any errata
+list, it's ephemeral. At some time, the original documents will cease to
+contain these errors.
 
 .. rubric:: Table of Contents
 
@@ -19,273 +21,273 @@ contain these errors.
 SQL Foundation
 ==============
 
-* The data type and size of ``CURRENT_ROLE`` is not defined, but we have 
-  assumed that it's supposed to match the data type and size defined for 
-  ``CURRENT_USER``. 
+* The data type and size of ``CURRENT_ROLE`` is not defined, but we have
+  assumed that it's supposed to match the data type and size defined for
+  ``CURRENT_USER``.
 
-* The Standard declares that precision is the number of "significant digits". 
-  We have to assume they don't use the usual definition of significant. 
+* The Standard declares that precision is the number of "significant digits".
+  We have to assume they don't use the usual definition of significant.
 
-* The Standard speaks of valid datetime or interval results "according to the 
-  Gregorian calendar". But the Gregorian calendar only validates dates. We 
-  assume they mean "based on a 24 hour clock" for times, with adjustments 
-  according to the Gregorian calendar in the case of timestamps and (where 
-  applicable) intervals. 
+* The Standard speaks of valid datetime or interval results "according to the
+  Gregorian calendar". But the Gregorian calendar only validates dates. We
+  assume they mean "based on a 24 hour clock" for times, with adjustments
+  according to the Gregorian calendar in the case of timestamps and (where
+  applicable) intervals.
 
-* The word "satisfies" means "is ``TRUE``" when the context is the ``HAVING`` 
-  clause, or "is not ``FALSE``" when the context is a constraint. But it is not 
-  clear what "satisfies" means when the context is a ``WHEN`` clause or a 
-  view's ``WITH CHECK OPTION`` clause. Therefore it is not possible to be sure 
-  whether these clauses are "satisfied" if the search conditions that they 
-  refer to are ``UNKNOWN``. 
+* The word "satisfies" means "is ``TRUE``" when the context is the ``HAVING``
+  clause, or "is not ``FALSE``" when the context is a constraint. But it is not
+  clear what "satisfies" means when the context is a ``WHEN`` clause or a
+  view's ``WITH CHECK OPTION`` clause. Therefore it is not possible to be sure
+  whether these clauses are "satisfied" if the search conditions that they
+  refer to are ``UNKNOWN``.
 
-* SQL3's ``BOOLEAN`` data type should have four values: ``TRUE``, ``FALSE``, 
-  ``UNKNOWN`` and ``NULL``. 
+* SQL3's ``BOOLEAN`` data type should have four values: ``TRUE``, ``FALSE``,
+  ``UNKNOWN`` and ``NULL``.
 
-* For "effect of replacing rows in base tables", the trigger event is defined 
-  as ``DELETE``. We assume that ``UPDATE`` is meant. 
+* For "effect of replacing rows in base tables", the trigger event is defined
+  as ``DELETE``. We assume that ``UPDATE`` is meant.
 
-* The ``DROP TABLE ... CASCADE`` definition fails to specify that all dependent 
-  triggers will also be dropped. The ``DROP TABLE ... RESTRICT`` definition 
-  fails to specify that, if there are dependent triggers, the drop will fail. 
-  Since analogous statements are true for ``DROP VIEW``, we assume that they 
-  should also be true for ``DROP TABLE``. 
+* The ``DROP TABLE ... CASCADE`` definition fails to specify that all dependent
+  triggers will also be dropped. The ``DROP TABLE ... RESTRICT`` definition
+  fails to specify that, if there are dependent triggers, the drop will fail.
+  Since analogous statements are true for ``DROP VIEW``, we assume that they
+  should also be true for ``DROP TABLE``.
 
-* The Standard states six times that the following statement, or a slight 
+* The Standard states six times that the following statement, or a slight
   variation thereof, is "implicit" (in column definitions etc.):
-  
+
   ::
-  
+
       "CREATE TRIGGER BTN BEFORE DELETE ON TND
         FOR EACH STATEMENT
         SET CONSTRAINT CCN DEFERRED"
-  
+
   But ``SET CONSTRAINT`` statements are illegal within triggers.
 
-* According to the Standard, ``DROP TRIGGER`` is legal in Core SQL; but 
-  ``CREATE TRIGGER`` is illegal. We assume that the intent is not to include 
-  ``DROP TRIGGER`` in Core SQL either. 
+* According to the Standard, ``DROP TRIGGER`` is legal in Core SQL; but
+  ``CREATE TRIGGER`` is illegal. We assume that the intent is not to include
+  ``DROP TRIGGER`` in Core SQL either.
 
-* In the description of <cast specification> there is a reference to an 
-  ``SQLSTATE error 'Data exception - invalid interval format'``; this error 
-  does not appear in the list of ``SQLSTATE`` exception conditions so we 
-  haven't been able to provide an ``SQLSTATE`` code for it. 
+* In the description of <cast specification> there is a reference to an
+  ``SQLSTATE error 'Data exception - invalid interval format'``; this error
+  does not appear in the list of ``SQLSTATE`` exception conditions so we
+  haven't been able to provide an ``SQLSTATE`` code for it.
 
-* The ``ASCII_FULL`` character set does not include the ``\0`` character. This 
-  contradicts FIPS, and makes casts from bit strings difficult. 
+* The ``ASCII_FULL`` character set does not include the ``\0`` character. This
+  contradicts FIPS, and makes casts from bit strings difficult.
 
-* The Standard's Section 9.7 <type name determination> has no mention of 
-  ``BOOLEAN``. Neither does Section 10.14. ``BOOLEAN`` appears to have been 
-  forgotten in many places. 
+* The Standard's Section 9.7 <type name determination> has no mention of
+  ``BOOLEAN``. Neither does Section 10.14. ``BOOLEAN`` appears to have been
+  forgotten in many places.
 
-* There is an initial definition of "subtype". The Standard's description of 
-  UDTs is comprehensible only if this definition is ignored. 
+* There is an initial definition of "subtype". The Standard's description of
+  UDTs is comprehensible only if this definition is ignored.
 
-* The Standard's definition of "direct subtype" is confusing: 
-  
-  "A type ``T(a)`` 
-  is a direct subtype of a type ``T(b)`` if ``T(a)`` is a proper subtype of 
-  ``T(b)`` and there does not exist a type ``T(c)`` such that ``T(c)`` is a 
-  proper subtype of ``T(b)`` and a proper subtype of ``T(a)``." 
-  
-  Perhaps it should read: 
-  
-  "A type ``T(a)`` is a direct subtype of a type ``T(b)`` if ``T(a)`` is a 
-  proper subtype of ``T(b)`` and there does not exist a type ``T(c)`` such that 
-  ``T(c)`` is a proper subtype of ``T(b)`` and a proper supertype of ``T(a)``." 
-  
-  If this emendation is correct, then the terms "every direct supertype" and 
-  "every direct supertable" are misleading; more English are the terms "the 
-  direct supertype" and "the direct supertable", passim. 
+* The Standard's definition of "direct subtype" is confusing:
+
+  "A type ``T(a)``
+  is a direct subtype of a type ``T(b)`` if ``T(a)`` is a proper subtype of
+  ``T(b)`` and there does not exist a type ``T(c)`` such that ``T(c)`` is a
+  proper subtype of ``T(b)`` and a proper subtype of ``T(a)``."
+
+  Perhaps it should read:
+
+  "A type ``T(a)`` is a direct subtype of a type ``T(b)`` if ``T(a)`` is a
+  proper subtype of ``T(b)`` and there does not exist a type ``T(c)`` such that
+  ``T(c)`` is a proper subtype of ``T(b)`` and a proper supertype of ``T(a)``."
+
+  If this emendation is correct, then the terms "every direct supertype" and
+  "every direct supertable" are misleading; more English are the terms "the
+  direct supertype" and "the direct supertable", passim.
 
 * The ``CREATE TYPE`` definition contains a contradiction:
-  
+
   ::
-  
+
     "4) If <subtype clause> is not specified, then <representation> shall be specified.
      5) If <subtype clause> is not specified, then NOT FINAL shall be specified.
      6) If <representation> specifies <predefined type>, then:
          a) ...
          b) FINAL shall be specified.
          c) <subtype clause> shall not be specified."
-  
+
   We have made no assumption as to the Standard's intent here.
 
-* The ``BNF`` nonterminal <method specification> is defined differently in two 
-  separate sections. We have made no assumption as to which definition is the 
+* The ``BNF`` nonterminal <method specification> is defined differently in two
+  separate sections. We have made no assumption as to which definition is the
   correct one.
 
-* For the ``NEW`` statement, the Standard contains this suspicious looking 
+* For the ``NEW`` statement, the Standard contains this suspicious looking
   grammer:
-  
+
   ::
-  
+
     "<new specification> ::= NEW <routine invocation>
-    
+
        <new invocation> ::= <method invocation>"
-  
-  <new invocation> is not used elsewhere. We assume that the definition is 
+
+  <new invocation> is not used elsewhere. We assume that the definition is
   actually "``NEW`` <method invocation>".
-  
-  If this assumption is incorrect, the first syntax rule for the ``NEW`` 
+
+  If this assumption is incorrect, the first syntax rule for the ``NEW``
   statement seems like it would work only for the main option:
-  
-  "1) Let ``RN`` be the <routine name> immediately contained in the <routine 
-  invocation>. Let ``MN`` be the <qualified identifier> immediately contained in 
+
+  "1) Let ``RN`` be the <routine name> immediately contained in the <routine
+  invocation>. Let ``MN`` be the <qualified identifier> immediately contained in
   ``RN``."
-  
+
   Possibly what is meant is:
-  
-  "1) Let ``RN`` be the <routine name> immediately contained in the <routine 
-  invocation> or <method invocation>. Let ``MN`` be the <qualified identifier> 
+
+  "1) Let ``RN`` be the <routine name> immediately contained in the <routine
+  invocation> or <method invocation>. Let ``MN`` be the <qualified identifier>
   immediately contained in ``RN``."
 
 * This note looks out of place, and in any case is superseded by Note 243:
 
-  "NOTE 242 - The comparison categories of two user-defined types in the same 
+  "NOTE 242 - The comparison categories of two user-defined types in the same
   type family must be the same."
-  
+
   Possibly what is meant is:
-  
-  "NOTE 242 - The comparison forms of two user-defined types in the same 
+
+  "NOTE 242 - The comparison forms of two user-defined types in the same
   type family must be the same."
 
-* The ``INFORMATION_SCHEMA.ATTRIBUTES`` view definition contains references to 
-  ``TABLE_CATALOG`` and ``COLUMN_DEFAULT`` columns -- neither of which are 
-  applicable here. We assume they should be ``UDT_CATALOG`` and 
-  ``ATTRIBUTE_DEFAULT``. 
+* The ``INFORMATION_SCHEMA.ATTRIBUTES`` view definition contains references to
+  ``TABLE_CATALOG`` and ``COLUMN_DEFAULT`` columns -- neither of which are
+  applicable here. We assume they should be ``UDT_CATALOG`` and
+  ``ATTRIBUTE_DEFAULT``.
 
-* The ``DEFINITION_SCHEMA.ATTRIBUTES`` base table is also defined as having two 
-  columns -- ``TABLE_CATALOG`` and ``TABLE_SCHEMA`` -- which are not applicable 
-  here. We assume they should be ``UDT_CATALOG`` and ``UDT_SCHEMA``. 
-  
-  Also, this table's columns ``USER_DEFINED_TYPE_CATALOG``, 
-  ``USER_DEFINED_TYPE_SCHEMA`` and ``USER_DEFINED_TYPE_NAME`` are defined on 
-  domain ``INFORMATION_SCHEMA.CHARACTER_DATA``. 
-  
-  But everywhere else, such columns are defined on domain 
-  ``INFORMATION_SCHEMA.SQL_IDENTIFIER``. We assume the intent is to be 
-  consistent here as well. 
+* The ``DEFINITION_SCHEMA.ATTRIBUTES`` base table is also defined as having two
+  columns -- ``TABLE_CATALOG`` and ``TABLE_SCHEMA`` -- which are not applicable
+  here. We assume they should be ``UDT_CATALOG`` and ``UDT_SCHEMA``.
 
-* The ``NUMERIC_PRECISION_RADIX`` value for datetime / interval data types is 
-  unclear. The ``GetTypeInfo`` description of the ODBC 3.0 manual says: "If the 
-  data type is an approximate numeric type, this column contains the value 
-  ``2`` to indicate that ``COLUMN_SIZE`` specifies a number of bits. For exact 
-  numeric types, this column contains the value ``10`` to indicate that 
-  ``COLUMN_SIZE`` specifies a number of decimal digits. Otherwise, this column 
-  is ``NULL``." 
-  
+  Also, this table's columns ``USER_DEFINED_TYPE_CATALOG``,
+  ``USER_DEFINED_TYPE_SCHEMA`` and ``USER_DEFINED_TYPE_NAME`` are defined on
+  domain ``INFORMATION_SCHEMA.CHARACTER_DATA``.
+
+  But everywhere else, such columns are defined on domain
+  ``INFORMATION_SCHEMA.SQL_IDENTIFIER``. We assume the intent is to be
+  consistent here as well.
+
+* The ``NUMERIC_PRECISION_RADIX`` value for datetime / interval data types is
+  unclear. The ``GetTypeInfo`` description of the ODBC 3.0 manual says: "If the
+  data type is an approximate numeric type, this column contains the value
+  ``2`` to indicate that ``COLUMN_SIZE`` specifies a number of bits. For exact
+  numeric types, this column contains the value ``10`` to indicate that
+  ``COLUMN_SIZE`` specifies a number of decimal digits. Otherwise, this column
+  is ``NULL``."
+
   The same section in the SQL/CLI document says:
-  
+
   ::
-  
+
     "r) The value of NUM_PREC_RADIX is
          Case:
          i) If the value of PRECISION is the value of a precision, then the radix of that precision.
          ii) Otherwise, the null value."
-  
-  While the definition of the ``DEFINITION_SCHEMA.DATA_TYPE_DESCRIPTOR`` base 
+
+  While the definition of the ``DEFINITION_SCHEMA.DATA_TYPE_DESCRIPTOR`` base
   table, where this information is stored has this constraint:
-  
+
   ::
-  
+
     "    CHECK (
          ...
          DATA_TYPE IN ( 'DATE', 'TIME', 'TIMESTAMP',
                         'TIME WITH TIME ZONE', 'TIMESTAMP WITH TIME ZONE' )
          ...
          AND ( NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX ) IS NOT NULL"
-  
+
   From the above quotes, some disagreements are visible:
-  
+
    (a) The writers of ODBC thought datetime/interval radices are nullable.
-   
-   (b) The SQL/CLI writers had no idea ``PRECISION`` is a nonexistent column 
+
+   (b) The SQL/CLI writers had no idea ``PRECISION`` is a nonexistent column
        but agree that radices can be nullable if a data type has no precision.
-   
+
    (c) The foundation writers thought datetime/interval radices couldn't be ``NULL``.
-  
-  For ``GET_TYPE_INFO``, we assume the first two quotes reflect the true 
-  intent: that ``NUMERIC_PRECISION_RADIX`` value for datetimes and intervals is 
+
+  For ``GET_TYPE_INFO``, we assume the first two quotes reflect the true
+  intent: that ``NUMERIC_PRECISION_RADIX`` value for datetimes and intervals is
   ``NULL``.
 
-* The definition of the ``INFORMATION_SCHEMA.ROLE_ROUTINE_GRANTS`` view 
+* The definition of the ``INFORMATION_SCHEMA.ROLE_ROUTINE_GRANTS`` view
   contains:
-  
+
   ::
-  
+
        "SELECT
        ...
        ROUTINE_CATALOG, ROUTINE_SCHEMA, ROUTINE_NAME
        ...
        FROM ROUTINE_PRIVILEGES"
-  
-  But these three columns do not exist in the ``ROUTINE_PRIVILEGES`` table. We 
+
+  But these three columns do not exist in the ``ROUTINE_PRIVILEGES`` table. We
   assume these columns should be omitted from the view.
 
-* The definition of the ``INFORMATION_SCHEMA.ROLE_USER_DEFINED_TYPE_GRANTS`` 
+* The definition of the ``INFORMATION_SCHEMA.ROLE_USER_DEFINED_TYPE_GRANTS``
   view contains:
-  
+
   ::
-  
+
        "SELECT
        ...
        OBJECT_TYPE
        ...
        FROM DEFINITION_SCHEMA.USER_DEFINED_TYPE_PRIVILEGES"
-  
-  But this column does not exist the in ``USER_DEFINED_TYPE_PRIVILEGES`` table. 
+
+  But this column does not exist the in ``USER_DEFINED_TYPE_PRIVILEGES`` table.
   We assume this column should be omitted from the view.
 
 SQL/CLI
 =======
 
-* The "Description of CLI item descriptors" says that ``DEFERRED`` is true if 
+* The "Description of CLI item descriptors" says that ``DEFERRED`` is true if
   the octet length pointer points to ``SQL NULL DATA``.
 
-* For ``SQLGetTypeInfo``, ``NULL`` values are returned for ``sql_prefix`` and 
-  ``sql_suffix`` -- i.e.: ``NULL`` is used to mean "blank string". In other 
+* For ``SQLGetTypeInfo``, ``NULL`` values are returned for ``sql_prefix`` and
+  ``sql_suffix`` -- i.e.: ``NULL`` is used to mean "blank string". In other
   fields it means N/A.
 
-* For ``SQLExecute`` and ``SQLExecute``, the general rules are ordered in such 
-  a way that input parameters will be checked for consistency ``AFTER`` 
-  execution. We assume that checking should take place before execution. The 
-  embedded SQL document has parameter-checking in the logical place. 
+* For ``SQLExecute`` and ``SQLExecute``, the general rules are ordered in such
+  a way that input parameters will be checked for consistency ``AFTER``
+  execution. We assume that checking should take place before execution. The
+  embedded SQL document has parameter-checking in the logical place.
 
-* The ``SQLDisconnect`` function description contains a reference to an 
-  exception "active SQL-statement"; we assume this should read "active 
-  SQL-transaction". 
+* The ``SQLDisconnect`` function description contains a reference to an
+  exception "active SQL-statement"; we assume this should read "active
+  SQL-transaction".
 
-* The ``SQLGetData`` function description contains a reference to ``IP`` and 
-  ``DP``, which do not exist. 
+* The ``SQLGetData`` function description contains a reference to ``IP`` and
+  ``DP``, which do not exist.
 
-* The ``SQLSetDescField`` function description suggests that it is illegal to 
-  set the ``SQL_DESC_TYPE`` field to ``SQL_SMALLINT``, ``SQL_INTEGER``, 
-  ``SQL_REAL`` or ``SQL_DOUBLE_PRECISION`` (or several other legal data types). 
-  This is clearly an oversight. 
+* The ``SQLSetDescField`` function description suggests that it is illegal to
+  set the ``SQL_DESC_TYPE`` field to ``SQL_SMALLINT``, ``SQL_INTEGER``,
+  ``SQL_REAL`` or ``SQL_DOUBLE_PRECISION`` (or several other legal data types).
+  This is clearly an oversight.
 
-* The ``SQLSetDescField`` function description fails to state that the 
-  ``RecordNumber`` parameter should be ignored if ``FieldIdentifier`` is 
-  ``SQL_DESC_COUNT``. We assume this is the case. 
+* The ``SQLSetDescField`` function description fails to state that the
+  ``RecordNumber`` parameter should be ignored if ``FieldIdentifier`` is
+  ``SQL_DESC_COUNT``. We assume this is the case.
 
-* The ``SQLGetDescRec`` function description is ambiguous about the field to be 
-  used as the source for Length. 
+* The ``SQLGetDescRec`` function description is ambiguous about the field to be
+  used as the source for Length.
 
-* For ``SQLGetDiagField``, the Standard says ``SQL_DIAG_MORE`` is associated 
-  with a return of ``'Y'`` or ``'N'``. But ``SQL_DIAG_MORE`` is not defined as 
-  a string. 
+* For ``SQLGetDiagField``, the Standard says ``SQL_DIAG_MORE`` is associated
+  with a return of ``'Y'`` or ``'N'``. But ``SQL_DIAG_MORE`` is not defined as
+  a string.
 
-* For ``SQLGetLength``: exception "Invalid argument value" is undefined. 
+* For ``SQLGetLength``: exception "Invalid argument value" is undefined.
 
-* For ``SQLColumns``: for a <fractional seconds precision>, the value is taken 
-  from ``INFORMATION_SCHEMA.COLUMNS.NUMERIC_PRECISION``. The value is actually 
-  in ``INFORMATION_SCHEMA.COLUMNS.DATETIME_PRECISION`` and we assume this is 
-  the intent. Also: the ``SQL_DATA_TYPE`` column has been forgotten; we assume 
-  it is included. Also: for calculating ``SQL_DATETIME_SUB``, the Standard says 
-  one is supposed to use ``INFORMATION_SCHEMA.COLUMNS.DATA_TYPE`` to look up a 
-  ``'Code'`` -- however, the information is actually in found in 
-  ``INFORMATION_SCHEMA.COLUMNS.INTERVAL_TYPE``; we assume this is the intent. 
+* For ``SQLColumns``: for a <fractional seconds precision>, the value is taken
+  from ``INFORMATION_SCHEMA.COLUMNS.NUMERIC_PRECISION``. The value is actually
+  in ``INFORMATION_SCHEMA.COLUMNS.DATETIME_PRECISION`` and we assume this is
+  the intent. Also: the ``SQL_DATA_TYPE`` column has been forgotten; we assume
+  it is included. Also: for calculating ``SQL_DATETIME_SUB``, the Standard says
+  one is supposed to use ``INFORMATION_SCHEMA.COLUMNS.DATA_TYPE`` to look up a
+  ``'Code'`` -- however, the information is actually in found in
+  ``INFORMATION_SCHEMA.COLUMNS.INTERVAL_TYPE``; we assume this is the intent.
 
-* There is an implicit assumption that ``CAST`` is possible between two 
-  character sets (otherwise, why bother having character set in the 
+* There is an implicit assumption that ``CAST`` is possible between two
+  character sets (otherwise, why bother having character set in the
   descriptor IDA?). But ``CAST`` is illegal if repertoires differ.

--- a/docs/appendices/index.rst
+++ b/docs/appendices/index.rst
@@ -4,6 +4,8 @@
 Appendices
 ==========
 
+.. include:: ../_include/note.rst
+
 .. rubric:: Table of Contents
 
 .. toctree::

--- a/docs/chapters/01.rst
+++ b/docs/chapters/01.rst
@@ -4,6 +4,8 @@
 Chapter 1 -- Introduction
 =========================
 
+.. include:: ../_include/note.rst
+
 SQL-99 (more commonly still called, "SQL3", the term we'll use throughout this
 book) will soon be the current internationally accepted standard for the
 database programming language called SQL. The SQL Standard -- a complicated

--- a/docs/chapters/02.rst
+++ b/docs/chapters/02.rst
@@ -4,6 +4,8 @@
 Chapter 2 -- General Concepts
 =============================
 
+.. include:: ../_include/note.rst
+
 A *database system* can be described as essentially nothing more than a
 computerized record-keeping system. A *database*, then, is simply a collection
 of structured data files and any associated indexes. The user of such a system

--- a/docs/chapters/03.rst
+++ b/docs/chapters/03.rst
@@ -4,6 +4,8 @@
 Chapter 3 -- Numbers
 ====================
 
+.. include:: ../_include/note.rst
+
 In SQL, a number -- i.e.: any signed, or unsigned, combination of the digits 0
 to 9 -- is either an exact numeric value or an approximate numeric value. A
 numeric value may be a <literal>, the value of a parameter or a host language

--- a/docs/chapters/04.rst
+++ b/docs/chapters/04.rst
@@ -4,6 +4,8 @@
 Chapter 4 -- Bit strings
 ========================
 
+.. include:: ../_include/note.rst
+
 In SQL, a bit string is either a binary bit string or a hexadecimal bit string.
 Binary bit strings are arbitrary sequences of zero or more binary digits
 (bits), each having a value of 0 or 1 and a length of 1 bit. Hexadecimal bit

--- a/docs/chapters/05.rst
+++ b/docs/chapters/05.rst
@@ -4,6 +4,8 @@
 Chapter 5 -- Binary strings
 ===========================
 
+.. include:: ../_include/note.rst
+
 In SQL, a binary string, (or ``BLOB``), is any arbitrary sequence of zero or
 more octets that isn't associated with either a Character set or a Collation. A
 ``BLOB`` value may be a <literal>, the value of a parameter or a host language

--- a/docs/chapters/06.rst
+++ b/docs/chapters/06.rst
@@ -4,6 +4,8 @@
 Chapter 6 -- Characters
 =======================
 
+.. include:: ../_include/note.rst
+
 *"Now we know our Alphabet all the way from A to Z[ed]"*
 
 *(Grade 1 Tune)*

--- a/docs/chapters/07.rst
+++ b/docs/chapters/07.rst
@@ -4,6 +4,8 @@
 Chapter 7 -- Character strings
 ==============================
 
+.. include:: ../_include/note.rst
+
 In SQL, a character string is any sequence of zero or more alphanumeric
 characters that belong to a given Character set. A *Character* set is a named
 characters that belong to a given *Character set*. A Character set is a named

--- a/docs/chapters/08.rst
+++ b/docs/chapters/08.rst
@@ -4,6 +4,8 @@
 Chapter 8 -- Temporal values
 ============================
 
+.. include:: ../_include/note.rst
+
 In SQL, a *temporal value* is either a datetime (i.e.: a date, a clock time or
 a timestamp) or an interval (i.e.: a span of time). They consist of a
 contiguous subset of one or more of the datetime fields (in their order of

--- a/docs/chapters/09.rst
+++ b/docs/chapters/09.rst
@@ -4,6 +4,8 @@
 Chapter 9 -- Boolean values
 ===========================
 
+.. include:: ../_include/note.rst
+
 In SQL, a Boolean value -- either ``TRUE``, ``FALSE`` or ``UNKNOWN`` -- is a
 truth value. A Boolean value may be a <literal>, the value of a parameter or a
 host language variable or the result of any expression or argument (including a

--- a/docs/chapters/10.rst
+++ b/docs/chapters/10.rst
@@ -4,6 +4,8 @@
 Chapter 10 -- Collection types
 ==============================
 
+.. include:: ../_include/note.rst
+
 [Obscure Rule] applies for this entire chapter.
 
 In SQL, a <collection type> is an array: a composite constructed SQL <data

--- a/docs/chapters/11.rst
+++ b/docs/chapters/11.rst
@@ -4,6 +4,8 @@
 Chapter 11 -- Row types
 =======================
 
+.. include:: ../_include/note.rst
+
 [Obscure Rule] applies for this entire chapter.
 
 In SQL, a <row type> is a row of data: a composite constructed SQL <data type>.

--- a/docs/chapters/12.rst
+++ b/docs/chapters/12.rst
@@ -4,6 +4,8 @@
 Chapter 12 -- Reference types
 =============================
 
+.. include:: ../_include/note.rst
+
 [Obscure Rule] applies for this entire chapter.
 
 In SQL, a <reference type> is a pointer; a scalar constructed SQL <data type>.

--- a/docs/chapters/13.rst
+++ b/docs/chapters/13.rst
@@ -4,6 +4,8 @@
 Chapter 13 -- NULLs
 ===================
 
+.. include:: ../_include/note.rst
+
 *"The problem isn't what they don't know. It's what they do know that ain't
 *so."*
 

--- a/docs/chapters/14.rst
+++ b/docs/chapters/14.rst
@@ -4,6 +4,8 @@
 Chapter 14 -- SQL Cluster
 =========================
 
+.. include:: ../_include/note.rst
+
 The SQL Standard describes the concepts on which SQL is based in terms of
 Objects, such as Tables. Each SQL Object is defined in terms of the
 characteristics (e.g.: its name) that describe it; the Standard calls this the

--- a/docs/chapters/15.rst
+++ b/docs/chapters/15.rst
@@ -4,6 +4,8 @@
 Chapter 15 -- SQL Authorizationid
 =================================
 
+.. include:: ../_include/note.rst
+
 In this chapter, we'll describe SQL <AuthorizationID>s in detail, and show you
 the syntax to use to create, alter and destroy them.
 

--- a/docs/chapters/16.rst
+++ b/docs/chapters/16.rst
@@ -4,6 +4,8 @@
 Chapter 16 -- SQL Catalogs
 ==========================
 
+.. include:: ../_include/note.rst
+
 In this chapter, we'll describe SQL Catalogs in detail, and show you the syntax
 to use to create, alter and destroy them.
 

--- a/docs/chapters/17.rst
+++ b/docs/chapters/17.rst
@@ -4,6 +4,8 @@
 Chapter 17 -- SQL Schema
 ========================
 
+.. include:: ../_include/note.rst
+
 The SQL Standard describes the concepts on which SQL is based in terms of
 Objects, such as Tables. Most of these Objects are Schema Objects; that is,
 they depend on some Schema. In this chapter, we'll describe SQL Schemas in

--- a/docs/chapters/18.rst
+++ b/docs/chapters/18.rst
@@ -4,6 +4,8 @@
 Chapter 18 -- SQL Table and View
 ================================
 
+.. include:: ../_include/note.rst
+
 In this chapter, we'll describe SQL Tables in detail, and show you the syntax
 to use to create, alter and destroy them.
 
@@ -23,13 +25,13 @@ Tables contain data (as atomic values at the intersection of each row and
 single occurrence of that entity. Rows are the smallest unit of Table
 insertion and deletion. Table rows are unordered, but an order can be imposed
 on them during retrieval. Table Columns are ordered, from left to right --
-their ordinal position matches the ordinal position of the <Column 
+their ordinal position matches the ordinal position of the <Column
 definition> in the Table's definition.
 
-SQL supports two types of Tables: the physically existent, named *Base 
-table* and the derived, named *View*. We use the word "Table" to mean both 
-Base tables and Views throughout this book. (SQL also supports the concept 
-of unnamed derived tables -- these are tables which are derived from a 
+SQL supports two types of Tables: the physically existent, named *Base
+table* and the derived, named *View*. We use the word "Table" to mean both
+Base tables and Views throughout this book. (SQL also supports the concept
+of unnamed derived tables -- these are tables which are derived from a
 <query expression>, so we won't discuss them here.)
 
 .. rubric:: Table of Contents
@@ -66,16 +68,16 @@ the SQL-session (depending on the Table's definition). You create global
 temporary Base tables with ``CREATE GLOBAL TEMPORARY TABLE`` and created local
 temporary Base tables with ``CREATE LOCAL TEMPORARY TABLE``.
 
-There is one kind of Module Base table: the declared local temporary Base 
+There is one kind of Module Base table: the declared local temporary Base
 table.
 
 * The declared local temporary Base table is a named Table defined
-  (with the ``DECLARE TABLE`` statement) in an SQL-client Module. It is 
-  effectively materialized the first time it is referenced in an SQL-session 
-  and it persists until that SQL-session ends. A declared local temporary 
-  Base table can only be accessed by <externally-invoked procedure>s within 
-  the SQL-client Module that contains the Table's declaration. Temporary 
-  Base tables are always empty when an SQL-session begins and are always 
+  (with the ``DECLARE TABLE`` statement) in an SQL-client Module. It is
+  effectively materialized the first time it is referenced in an SQL-session
+  and it persists until that SQL-session ends. A declared local temporary
+  Base table can only be accessed by <externally-invoked procedure>s within
+  the SQL-client Module that contains the Table's declaration. Temporary
+  Base tables are always empty when an SQL-session begins and are always
   emptied when the SQL-session ends.
 
 Subtables and Supertables
@@ -94,9 +96,9 @@ Any Table which has a subtable or a supertable also has a row identifier (this
 is implicitly defined). The row identifier type for a Table with supertables
 is a subtype of the row identifier type defined for each supertable. A value
 of a row identifier type can be substituted for a value of another row
-identifier type if *(a)* both types are the same or *(b)* the first is a 
-subtype of the second. The rules for the ``INSERT``, ``DELETE`` and 
-``UPDATE`` statements ensure that the rows in the Tables of a subtable 
+identifier type if *(a)* both types are the same or *(b)* the first is a
+subtype of the second. The rules for the ``INSERT``, ``DELETE`` and
+``UPDATE`` statements ensure that the rows in the Tables of a subtable
 family are consistent with one another. Specifically:
 
 **If you** ``INSERT`` **a row into a subtable**, your DBMS will ``INSERT`` a
@@ -107,10 +109,10 @@ subtable's supertables, cascading upward in the Table hierarchy. Thus, if you
 
 **If you** ``UPDATE`` **a row of a supertable**, all inherited Columns in any
 corresponding rows of that supertable's subtables are also updated. If you
-``UPDATE`` a row of a subtable, your DBMS will ``UPDATE`` every 
+``UPDATE`` a row of a subtable, your DBMS will ``UPDATE`` every
 corresponding row so that their Columns also contain the new values.
 
-**If you** ``DELETE`` **a row from a Table**, your DBMS will also ``DELETE`` 
+**If you** ``DELETE`` **a row from a Table**, your DBMS will also ``DELETE``
 every corresponding row in the subtable family.
 
 For example, consider these SQL statements:
@@ -133,17 +135,17 @@ For example, consider these SQL statements:
       number SMALLINT,
       total DECIMAL(8,2));
 
-A row in a subtable is "contained" in its supertables. This means that, for 
-example, a row could exist for a person in the ``PEOPLE`` Table without there 
-being a corresponding row in the ``AUTHOR`` Table (if the person described 
-isn't also an author). It also means that you could ``INSERT`` a row for a new 
-author (one that doesn't correspond to any existing person) into the 
-``AUTHOR`` Table, and your DBMS would automatically create a corresponding 
-row in the ``PEOPLE`` Table for that author. 
+A row in a subtable is "contained" in its supertables. This means that, for
+example, a row could exist for a person in the ``PEOPLE`` Table without there
+being a corresponding row in the ``AUTHOR`` Table (if the person described
+isn't also an author). It also means that you could ``INSERT`` a row for a new
+author (one that doesn't correspond to any existing person) into the
+``AUTHOR`` Table, and your DBMS would automatically create a corresponding
+row in the ``PEOPLE`` Table for that author.
 
 A Base table is defined by a descriptor that contains 13 pieces of information:
 
-1. The <Table name>, qualified by the <Schema name> of the Schema it belongs 
+1. The <Table name>, qualified by the <Schema name> of the Schema it belongs
    to.
 
 2. The Base table's type: either persistent Base table, global temporary
@@ -156,16 +158,16 @@ A Base table is defined by a descriptor that contains 13 pieces of information:
 
 5. A descriptor for every Constraint that belongs to the Table.
 
-6. [Obscure Rule] The name of the structured type (if any) associated with 
+6. [Obscure Rule] The name of the structured type (if any) associated with
    the Table.
 
-7. [Obscure Rule] Whether the Table's rows have the ``REF VALUE`` 
+7. [Obscure Rule] Whether the Table's rows have the ``REF VALUE``
    characteristic.
 
-8. [Obscure Rule] A list (possibly empty) of the names of the Table's direct 
+8. [Obscure Rule] A list (possibly empty) of the names of the Table's direct
    supertables.
 
-9. [Obscure Rule] A list (possibly empty) of the names of the Table's direct 
+9. [Obscure Rule] A list (possibly empty) of the names of the Table's direct
    subtables.
 
 10. [Obscure Rule] The Table's row type.
@@ -174,17 +176,17 @@ A Base table is defined by a descriptor that contains 13 pieces of information:
 
 12. [Obscure Rule] A non-empty set of the Table's candidate keys.
 
-13. [Obscure Rule] An identification of the Table's preferred candidate key 
+13. [Obscure Rule] An identification of the Table's preferred candidate key
     (this may or may not be defined as the Table's ``PRIMARY KEY``).
 
-The data contained in a Base table is always updatable via the SQL statements 
-``INSERT``, ``UPDATE`` and ``DELETE``. To create a Base table, use the ``CREATE 
-TABLE`` statement (either as a stand-alone SQL statement or within a ``CREATE 
-SCHEMA`` statement). ``CREATE TABLE`` specifies the enclosing Schema, names the 
-Table and defines the Table's Columns and Constraints. To change an existing 
-Base table, use the ``ALTER TABLE`` statement. To destroy a Base table, use the 
-``DROP TABLE`` statement. To declare a temporary Table for a Module, use the 
-``DECLARE TABLE`` statement. 
+The data contained in a Base table is always updatable via the SQL statements
+``INSERT``, ``UPDATE`` and ``DELETE``. To create a Base table, use the ``CREATE
+TABLE`` statement (either as a stand-alone SQL statement or within a ``CREATE
+SCHEMA`` statement). ``CREATE TABLE`` specifies the enclosing Schema, names the
+Table and defines the Table's Columns and Constraints. To change an existing
+Base table, use the ``ALTER TABLE`` statement. To destroy a Base table, use the
+``DROP TABLE`` statement. To declare a temporary Table for a Module, use the
+``DECLARE TABLE`` statement.
 
 *View*
 ------
@@ -193,10 +195,10 @@ A *View* is a named, derived (or "virtual") Table: it doesn't physically exist,
 although its definition is persistent. Instead, a View is logically derived
 from one or more existing Tables, and can be thought of as another way of
 looking at the presented data. Views are either updatable or read-only,
-depending on their definitions. A View is defined by a descriptor that 
+depending on their definitions. A View is defined by a descriptor that
 contains ten pieces of information:
 
-1. The <Table name>, qualified by the <Schema name> of the Schema the View 
+1. The <Table name>, qualified by the <Schema name> of the Schema the View
    belongs to.
 
 2. The degree of the View: the number of Columns that are part of the View.
@@ -207,28 +209,28 @@ contains ten pieces of information:
 
 5. Whether the View is updatable or not.
 
-6. Whether the View definition includes a ``CHECK OPTION`` clause and, if 
+6. Whether the View definition includes a ``CHECK OPTION`` clause and, if
    so, whether the clause ``CHECK OPTION CASCADED`` or ``CHECK OPTION LOCAL``.
 
-7. [Obscure Rule] The name of the structured type (if any) associated with the 
+7. [Obscure Rule] The name of the structured type (if any) associated with the
    View.
 
-8. [Obscure Rule] Whether the View's rows have the ``REF VALUE`` 
+8. [Obscure Rule] Whether the View's rows have the ``REF VALUE``
    characteristic.
 
-9. [Obscure Rule] A list (possibly empty) of the names of the View's direct 
+9. [Obscure Rule] A list (possibly empty) of the names of the View's direct
    supertables.
 
-10. [Obscure Rule] A list (possibly empty) of the names of the Views's 
+10. [Obscure Rule] A list (possibly empty) of the names of the Views's
     direct subtables.
 
-Depending on the View's definition, the data shown through a View may be 
-updatable via the SQL statements ``INSERT``, ``UPDATE`` and ``DELETE``. To 
-create a View, use the ``CREATE VIEW`` statement (either as a stand-alone SQL 
-statement or within a ``CREATE SCHEMA`` statement). ``CREATE VIEW`` specifies 
-the enclosing Schema, names the View and its Columns and defines the <query 
-expression> that determines how the View is derived and updated. To change an 
-existing View, destroy and then redefine it. To destroy a View, use the ``DROP 
+Depending on the View's definition, the data shown through a View may be
+updatable via the SQL statements ``INSERT``, ``UPDATE`` and ``DELETE``. To
+create a View, use the ``CREATE VIEW`` statement (either as a stand-alone SQL
+statement or within a ``CREATE SCHEMA`` statement). ``CREATE VIEW`` specifies
+the enclosing Schema, names the View and its Columns and defines the <query
+expression> that determines how the View is derived and updated. To change an
+existing View, destroy and then redefine it. To destroy a View, use the ``DROP
 VIEW`` statement.
 
 Table names
@@ -241,7 +243,7 @@ ambiguity and to make your SQL statements easier to read.
 *<Table name>*
 --------------
 
-A <Table name> identifies a Base table or a View. The required syntax for a 
+A <Table name> identifies a Base table or a View. The required syntax for a
 <Table name> is either:
 
 ::
@@ -256,19 +258,19 @@ or, for a declared ``LOCAL TEMPORARY`` Table only:
     <Table name> ::=
     [ MODULE. ] unqualified name
 
-A <Table name> is a <regular identifier> or a <delimited identifier> that is 
-unique (for all Base tables and Views) within the Schema it belongs to. The 
-<Schema name> that qualifies a <Table name> names the Schema that the Table 
-belongs to and can either be explicitly stated, or a default will be supplied 
-by your DBMS, as follows: 
+A <Table name> is a <regular identifier> or a <delimited identifier> that is
+unique (for all Base tables and Views) within the Schema it belongs to. The
+<Schema name> that qualifies a <Table name> names the Schema that the Table
+belongs to and can either be explicitly stated, or a default will be supplied
+by your DBMS, as follows:
 
-* If a <Table name> in a ``CREATE SCHEMA`` statement isn't qualified, the 
-  default qualifier is the name of the Schema you're creating. 
+* If a <Table name> in a ``CREATE SCHEMA`` statement isn't qualified, the
+  default qualifier is the name of the Schema you're creating.
 
-* If the unqualified <Table name> is found in any other SQL statement in a 
-  Module, the default qualifier is the name of the Schema identified in the 
-  ``SCHEMA`` clause or ``AUTHORIZATION`` clause of the ``MODULE`` statement 
-  which defines that Module. 
+* If the unqualified <Table name> is found in any other SQL statement in a
+  Module, the default qualifier is the name of the Schema identified in the
+  ``SCHEMA`` clause or ``AUTHORIZATION`` clause of the ``MODULE`` statement
+  which defines that Module.
 
 Here are some examples of <Table name>s:
 
@@ -308,8 +310,8 @@ for a <Correlation name> is:
 
 A <Correlation name> is a <regular identifier> or a <delimited identifier>
 that is unique within the Table it represents for the period of a transaction.
-The scope of a <Correlation name> is either a ``SELECT`` statement (or some 
-other query form), a Trigger definition or both (correlation scopes may be 
+The scope of a <Correlation name> is either a ``SELECT`` statement (or some
+other query form), a Trigger definition or both (correlation scopes may be
 nested). Here is an example of a <Correlation name>:
 
 ::
@@ -328,7 +330,7 @@ A <Table reference> is a reference to some Table -- this is usually a named
 Table (that is, a Base table or a View), but could also be an unnamed Table
 (for example, the result of a join, a subquery or a query expression). Most
 often, a <Table reference> is just a <Table name> and we'll use only that form
-for now. Here are two equivalent examples (the <keyword> ``AS`` is noise and 
+for now. Here are two equivalent examples (the <keyword> ``AS`` is noise and
 can be omitted):
 
 ::
@@ -341,22 +343,22 @@ can be omitted):
       FROM Table_1 First, Table_1 Second
       WHERE First.column_2 = Second.column_2;
 
-These SQL statements execute a join of ``TABLE_1`` with itself, over matching 
-``COLUMN_2`` values. What the ``SELECT``\ s are doing is looking at all 
-possible pairs of ``TABLE_1`` rows and retrieving the ``COLUMN_1`` values from 
-each row where the ``COLUMN_2`` values are equal to one another. To do so, the 
-DBMS must be able to refer to two rows of ``TABLE_1`` at once -- and this 
-requires that it be able to distinguish between the two references. The 
-<Correlation name> allows the DBMS to do this: it calls the one row ``FIRST``, 
-and the other row ``SECOND``, just like the <Correlation name>s specified in 
-the SQL statements. To further clarify the request, each <Column name> 
-specified is qualified with the appropriate <Correlation name>, so that the 
-DBMS knows which Column belongs to which of the rows it's looking at. 
+These SQL statements execute a join of ``TABLE_1`` with itself, over matching
+``COLUMN_2`` values. What the ``SELECT``\ s are doing is looking at all
+possible pairs of ``TABLE_1`` rows and retrieving the ``COLUMN_1`` values from
+each row where the ``COLUMN_2`` values are equal to one another. To do so, the
+DBMS must be able to refer to two rows of ``TABLE_1`` at once -- and this
+requires that it be able to distinguish between the two references. The
+<Correlation name> allows the DBMS to do this: it calls the one row ``FIRST``,
+and the other row ``SECOND``, just like the <Correlation name>s specified in
+the SQL statements. To further clarify the request, each <Column name>
+specified is qualified with the appropriate <Correlation name>, so that the
+DBMS knows which Column belongs to which of the rows it's looking at.
 
 Since a <Table reference> can also refer to an unnamed Table that results from
 a query, it's sometimes necessary (or at least useful) to be able to name the
 Columns of the <Table reference> result. The optional derived <Column name>
-list with the ``AS`` <Correlation name> clause allows you to do this. Here's 
+list with the ``AS`` <Correlation name> clause allows you to do this. Here's
 an example:
 
 ::
@@ -366,15 +368,15 @@ an example:
           (joined_col_1, joined_col_2, joined_col_3, joined_col_4)
    ...
 
-In this example, ``Table_1 NATURAL JOIN Table_2`` is a <Table reference> that 
-evaluates to the Table resulting from the ``NATURAL JOIN`` operation -- and 
-``JOINED_TABLE`` is the <Correlation name> for that result. The Columns of 
-``JOINED_TABLE`` are explicitly given the names ``JOINED_COL_1``, 
-``JOINED_COL_2``, ``JOINED_COL_3`` and ``JOINED_COL_4``, and these are the 
-names that are used to refer to those Columns throughout the SQL statement. If 
-you use this option, you must specify a unique, unqualified name for every 
-Column of the result Table, even if you're never going to refer to some of the 
-Columns again. 
+In this example, ``Table_1 NATURAL JOIN Table_2`` is a <Table reference> that
+evaluates to the Table resulting from the ``NATURAL JOIN`` operation -- and
+``JOINED_TABLE`` is the <Correlation name> for that result. The Columns of
+``JOINED_TABLE`` are explicitly given the names ``JOINED_COL_1``,
+``JOINED_COL_2``, ``JOINED_COL_3`` and ``JOINED_COL_4``, and these are the
+names that are used to refer to those Columns throughout the SQL statement. If
+you use this option, you must specify a unique, unqualified name for every
+Column of the result Table, even if you're never going to refer to some of the
+Columns again.
 
 Column
 ======
@@ -387,61 +389,61 @@ belongs to -- and are created, altered and dropped using standard SQL
 statements. The Objects that may belong to a Column are Column Constraints;
 they depend on some Column.
 
-Columns are ordered within the Table they belong to, from left to right -- 
-their ordinal position matches the ordinal position of the <Column definition> 
-in the Table's definition. All Columns have a nullability characteristic: it 
-determines *(a)* whether an attempt to ``INSERT`` the null value into the 
-Column will fail and *(b)* whether a ``SELECT`` from the Column can ever return 
-the null value. A Column's nullability characteristic is "possibly nullable" 
-unless one of these situations apply: 
+Columns are ordered within the Table they belong to, from left to right --
+their ordinal position matches the ordinal position of the <Column definition>
+in the Table's definition. All Columns have a nullability characteristic: it
+determines *(a)* whether an attempt to ``INSERT`` the null value into the
+Column will fail and *(b)* whether a ``SELECT`` from the Column can ever return
+the null value. A Column's nullability characteristic is "possibly nullable"
+unless one of these situations apply:
 
 
 
-* A Column's nullability characteristic is "known not nullable" if a 
-  non-deferrable Constraint/Assertion on the Column evaluates to ``Column IS 
-  NOT NULL`` or if the Column is based on a Domain and a non-deferrable 
-  Constraint/Assertion on that Domain evaluates to ``VALUE IS NOT NULL``. 
+* A Column's nullability characteristic is "known not nullable" if a
+  non-deferrable Constraint/Assertion on the Column evaluates to ``Column IS
+  NOT NULL`` or if the Column is based on a Domain and a non-deferrable
+  Constraint/Assertion on that Domain evaluates to ``VALUE IS NOT NULL``.
 
 
-* A Column's nullability characteristic is "known not nullable" if a 
+* A Column's nullability characteristic is "known not nullable" if a
   non-deferrable Constraint on the Column is a ``PRIMARY KEY`` Constraint.
 
 A Column is defined by a descriptor that contains nine pieces of information:
 
 1. The <Column name>, qualified by the <Table name> of the Table it
-   belongs to. (It is possible to have a Column with a default name, rather 
-   than a name you defined for it yourself. In this case, the Column's 
-   descriptor also indicates that the name is an implementation-dependent, 
+   belongs to. (It is possible to have a Column with a default name, rather
+   than a name you defined for it yourself. In this case, the Column's
+   descriptor also indicates that the name is an implementation-dependent,
    or default, name.)
 
-2. The ordinal position of the Column in its Table. (A Table may contain 
+2. The ordinal position of the Column in its Table. (A Table may contain
    only one referenceable Column: it must be the first Column in the Table.)
 
-3. The Column's <data type> specification, including its name, length, 
-   precision and scale, as applicable (or, if the Column is based on a 
-   Domain, the <Domain name>). 
+3. The Column's <data type> specification, including its name, length,
+   precision and scale, as applicable (or, if the Column is based on a
+   Domain, the <Domain name>).
 
 4. The name of the Character set that the Column's set of values must belong to
    (for character string types).
 
-5. The name of the Column's default Collation. (This is the Collation that may 
-   be used to compare a character string Column's values in the absence of an 
+5. The name of the Column's default Collation. (This is the Collation that may
+   be used to compare a character string Column's values in the absence of an
    explicit ``COLLATE`` clause.)
 
-6. Whether reference values must be checked and whether <reference scope 
+6. Whether reference values must be checked and whether <reference scope
    check action> specifies ``RESTRICT`` or ``SET NULL`` (for ``REF`` types).
 
-7. Whether the Column is a system-generated Column or not (that is, whether the 
-   Column's <data type> is ``REF`` with ``VALUES ARE SYSTEM GENERATED``). If it 
-   is, the Table that the Column belongs to is a referenceable Base Table. 
+7. Whether the Column is a system-generated Column or not (that is, whether the
+   Column's <data type> is ``REF`` with ``VALUES ARE SYSTEM GENERATED``). If it
+   is, the Table that the Column belongs to is a referenceable Base Table.
 
 8. The Column's default value (if any).
 
-9. The Column's nullability characteristic: either "known not nullable" or 
+9. The Column's nullability characteristic: either "known not nullable" or
    "possibly nullable".
 
-To create a Column, use a <Column definition> in a ``CREATE TABLE`` or ``ALTER 
-TABLE`` statement. To change or destroy an existing Column, use the ``ALTER 
+To create a Column, use a <Column definition> in a ``CREATE TABLE`` or ``ALTER
+TABLE`` statement. To change or destroy an existing Column, use the ``ALTER
 TABLE`` statement.
 
 *Column names*
@@ -476,7 +478,7 @@ a <Column name>:
 <Column reference>
 ..................
 
-The required syntax for a <Column reference>, valid only outside of a 
+The required syntax for a <Column reference>, valid only outside of a
 <Column definition> is either:
 
 ::
@@ -500,7 +502,7 @@ by ``MODULE.<Table name>``. The Table specification which qualifies a <Column
 name> identifies the Table that the Column belongs to, and is either that
 Table's name or a <Correlation name> that identifies that Table. If you omit
 the Table specification from a <Column reference>, it will default to the
-<Table name> of the Table that owns the Column. Here are some examples of 
+<Table name> of the Table that owns the Column. Here are some examples of
 <Column reference>s:
 
 ::
@@ -518,7 +520,7 @@ CREATE TABLE Statement
 ======================
 
 The ``CREATE TABLE`` statement names a new Base table and defines the Table's
-Columns and Constraints. The required syntax for the ``CREATE TABLE`` 
+Columns and Constraints. The required syntax for the ``CREATE TABLE``
 statement is:
 
 ::
@@ -551,24 +553,24 @@ statement is:
                 [ <Column Constraint>... ]
                 [ COLLATE <Collation name> ]
 
-``CREATE TABLE`` defines a new persistent Base table. ``CREATE GLOBAL TEMPORARY 
-TABLE`` defines a new global temporary Base table. ``CREATE LOCAL TEMPORARY 
-TABLE`` defines a new created local temporary Base table. A Table is owned by 
-the Schema it belongs to. 
+``CREATE TABLE`` defines a new persistent Base table. ``CREATE GLOBAL TEMPORARY
+TABLE`` defines a new global temporary Base table. ``CREATE LOCAL TEMPORARY
+TABLE`` defines a new created local temporary Base table. A Table is owned by
+the Schema it belongs to.
 
 * The <Table name> identifies the Table and the Schema that it belongs
   to. A <Table name> that includes an explicit <Schema name> qualifier belongs
   to the Schema named. A <Table name> that does not include an explicit <Schema
   name> qualifier belongs to the SQL-session default Schema. The <Table name>
-  must be unique (for all Base tables and Views) within the Schema that owns 
+  must be unique (for all Base tables and Views) within the Schema that owns
   it.
 
-If ``CREATE TABLE`` is part of a ``CREATE SCHEMA`` statement, the <Table name>, 
-if explicitly qualified, must include the <Schema name> of the Schema being 
-created; that is, it isn't possible to create a Base table belonging to a 
-different Schema from within ``CREATE SCHEMA``. For example, this SQL statement 
-will not return an error because the <Table name> will default to include the 
-qualifying <Schema name>: 
+If ``CREATE TABLE`` is part of a ``CREATE SCHEMA`` statement, the <Table name>,
+if explicitly qualified, must include the <Schema name> of the Schema being
+created; that is, it isn't possible to create a Base table belonging to a
+different Schema from within ``CREATE SCHEMA``. For example, this SQL statement
+will not return an error because the <Table name> will default to include the
+qualifying <Schema name>:
 
 ::
 
@@ -604,33 +606,33 @@ temporary Tables invoked during the SQL-session are dropped. Because temporary
 Tables are materialized only when invoked, the Schema they belong to is
 actually defined by your DBMS.
 
-* If you're creating a temporary Table with ``CREATE GLOBAL TEMPORARY TABLE``, 
-  the <Table name> may not be explicitly qualified. Because a global temporary 
-  Table is distinct within an SQL-session, the Schema it belongs to is a Schema 
-  determined by your DBMS -- in effect, it fixes a qualifying <Schema name> for 
-  the Table based on the Schema in which the global temporary Table is defined, 
-  coupled with the DBMS's name for the SQL-session in which you invoke that 
-  Table. 
+* If you're creating a temporary Table with ``CREATE GLOBAL TEMPORARY TABLE``,
+  the <Table name> may not be explicitly qualified. Because a global temporary
+  Table is distinct within an SQL-session, the Schema it belongs to is a Schema
+  determined by your DBMS -- in effect, it fixes a qualifying <Schema name> for
+  the Table based on the Schema in which the global temporary Table is defined,
+  coupled with the DBMS's name for the SQL-session in which you invoke that
+  Table.
 
-* If you're creating a temporary Table with ``CREATE LOCAL TEMPORARY TABLE``, 
-  the <Table name> may not be explicitly qualified. Because a local temporary 
-  Table is distinct within an SQL-client Module within an SQL-session, the 
-  Schema it belongs to is a Schema determined by your DBMS -- in effect, it 
-  fixes a qualifying <Schema name> for the Table based on the Schema in 
-  which the global temporary Table is defined, coupled with the DBMS's name 
-  for the SQL-session in which you invoke that Table, coupled with the 
-  DBMS's name for the SQL-client Module that refers to that Table. 
+* If you're creating a temporary Table with ``CREATE LOCAL TEMPORARY TABLE``,
+  the <Table name> may not be explicitly qualified. Because a local temporary
+  Table is distinct within an SQL-client Module within an SQL-session, the
+  Schema it belongs to is a Schema determined by your DBMS -- in effect, it
+  fixes a qualifying <Schema name> for the Table based on the Schema in
+  which the global temporary Table is defined, coupled with the DBMS's name
+  for the SQL-session in which you invoke that Table, coupled with the
+  DBMS's name for the SQL-client Module that refers to that Table.
 
-If ``CREATE TABLE`` is executed as a stand-alone SQL statement, the current 
-<AuthorizationID> must either be the owner of the Schema that this new Table 
-belongs to, or the Schema's owner must be a Role that the current 
-<AuthorizationID> may use. That is, only the owner of a Schema can create 
-Tables for that Schema. In addition to creating a Table, ``CREATE TABLE`` also 
-causes the SQL special grantor, "``_SYSTEM``", to grant grantable ``INSERT``, 
-``SELECT``, ``UPDATE``, ``DELETE``, ``TRIGGER`` and ``REFERENCES`` Privileges 
-on the new Table, as well as grantable ``SELECT``, ``INSERT``, ``UPDATE`` and 
-``REFERENCES`` Privileges on every Column in the new Table, to the Schema owner 
-<AuthorizationID> (that is, the <AuthorizationID creating the Table). 
+If ``CREATE TABLE`` is executed as a stand-alone SQL statement, the current
+<AuthorizationID> must either be the owner of the Schema that this new Table
+belongs to, or the Schema's owner must be a Role that the current
+<AuthorizationID> may use. That is, only the owner of a Schema can create
+Tables for that Schema. In addition to creating a Table, ``CREATE TABLE`` also
+causes the SQL special grantor, "``_SYSTEM``", to grant grantable ``INSERT``,
+``SELECT``, ``UPDATE``, ``DELETE``, ``TRIGGER`` and ``REFERENCES`` Privileges
+on the new Table, as well as grantable ``SELECT``, ``INSERT``, ``UPDATE`` and
+``REFERENCES`` Privileges on every Column in the new Table, to the Schema owner
+<AuthorizationID> (that is, the <AuthorizationID creating the Table).
 
 *<table contents source clause>*
 --------------------------------
@@ -641,49 +643,49 @@ either a list of elements, such as Column and Table Constraint definitions, or
 an ``OF`` clause that defines the UDT structure that makes up the Table. Every
 <table element list> has to contain at least one <Column definition>.
 
-[Obscure Rule] If ``CREATE TABLE`` includes the ``OF`` clause, then <UDT name> 
-must identify a structured type. If the ``OF`` clause also includes the 
-(optional) <table element list>, the list *(a)* may not contain a ``LIKE`` 
-clause and *(b)* may contain only one <table element> that is a <Column 
-definition>: it must define a Column with a ``REF`` <data type> that specifies 
-``VALUES ARE SYSTEM GENERATED``. The optional ``UNDER`` sub-clause in the 
-``OF`` clause contains a list of <Table name>s. Each <Table name> in the list 
-identifies a direct supertable of the Table being created and must therefore 
-belong to the same Schema that owns this new Table. (The Schema owner 
-<AuthorizationID> must have the ``UNDER`` Privilege on each supertable named.) 
-A <Table name> may appear in the ``UNDER`` list only once. The new Table is a 
-direct subtable of each of its direct supertables: this subtable family must 
-have exactly one maximal supertable. (The effect of ``CREATE TABLE`` on the new 
-Table's supertables is that its name is added to the list of direct subtables 
-in each supertable's definition.) If you add the ``UNDER`` sub-clause to a 
-``CREATE TABLE`` statement: *(a)* the structured type identified by <UDT name> 
-must be a direct subtype of the structured type of every direct supertable of 
-the new Table, *(b)* your Table definition may not include a ``PRIMARY KEY`` 
-Constraint, *(c)* one of the supertables of the new Table must include a 
-``UNIQUE`` Constraint that constrains a Column with a nullability 
-characteristic of "known not nullable" and *(d)* the Schema owner's 
-<AuthorizationID> is granted grantable ``SELECT``, ``UPDATE`` and 
-``REFERENCES`` Privileges for every inherited Column of the new Table. (The 
-grantor of these Privileges is the SQL special grantor, "``_SYSTEM``".) Note 
-that if a direct supertable of the new Table is a referenceable Base table, 
-then this new Table is also a referenceable Base table. In this case, your 
-``OF`` clause, if it contains a <table element list>, may not include a <Column 
-definition>. If any <table element> contains a <scope clause> the Base table(s) 
-referred to therein must be either *(a)* persistent Base tables, if ``CREATE 
-TABLE`` contains no <table scope>, *(b)* ``GLOBAL TEMPORARY`` Base tables if 
-you're creating a ``GLOBAL TEMPORARY`` Base table or *(c)* created ``LOCAL 
-TEMPORARY`` Base tables if you're creating a ``LOCAL TEMPORARY`` Base table. 
-For further details, refer to our chapter on User-defined Types. 
+[Obscure Rule] If ``CREATE TABLE`` includes the ``OF`` clause, then <UDT name>
+must identify a structured type. If the ``OF`` clause also includes the
+(optional) <table element list>, the list *(a)* may not contain a ``LIKE``
+clause and *(b)* may contain only one <table element> that is a <Column
+definition>: it must define a Column with a ``REF`` <data type> that specifies
+``VALUES ARE SYSTEM GENERATED``. The optional ``UNDER`` sub-clause in the
+``OF`` clause contains a list of <Table name>s. Each <Table name> in the list
+identifies a direct supertable of the Table being created and must therefore
+belong to the same Schema that owns this new Table. (The Schema owner
+<AuthorizationID> must have the ``UNDER`` Privilege on each supertable named.)
+A <Table name> may appear in the ``UNDER`` list only once. The new Table is a
+direct subtable of each of its direct supertables: this subtable family must
+have exactly one maximal supertable. (The effect of ``CREATE TABLE`` on the new
+Table's supertables is that its name is added to the list of direct subtables
+in each supertable's definition.) If you add the ``UNDER`` sub-clause to a
+``CREATE TABLE`` statement: *(a)* the structured type identified by <UDT name>
+must be a direct subtype of the structured type of every direct supertable of
+the new Table, *(b)* your Table definition may not include a ``PRIMARY KEY``
+Constraint, *(c)* one of the supertables of the new Table must include a
+``UNIQUE`` Constraint that constrains a Column with a nullability
+characteristic of "known not nullable" and *(d)* the Schema owner's
+<AuthorizationID> is granted grantable ``SELECT``, ``UPDATE`` and
+``REFERENCES`` Privileges for every inherited Column of the new Table. (The
+grantor of these Privileges is the SQL special grantor, "``_SYSTEM``".) Note
+that if a direct supertable of the new Table is a referenceable Base table,
+then this new Table is also a referenceable Base table. In this case, your
+``OF`` clause, if it contains a <table element list>, may not include a <Column
+definition>. If any <table element> contains a <scope clause> the Base table(s)
+referred to therein must be either *(a)* persistent Base tables, if ``CREATE
+TABLE`` contains no <table scope>, *(b)* ``GLOBAL TEMPORARY`` Base tables if
+you're creating a ``GLOBAL TEMPORARY`` Base table or *(c)* created ``LOCAL
+TEMPORARY`` Base tables if you're creating a ``LOCAL TEMPORARY`` Base table.
+For further details, refer to our chapter on User-defined Types.
 
-The common form of ``CREATE TABLE`` uses a parenthesized <table element list> 
-as its <table contents source> clause. A <table element> is either a <Column 
-definition> (see "<Column definition>" in this chapter , a <Table Constraint> 
-(see our chapter on Constraints and Assertions), a ``LIKE`` clause or a <column 
-options> clause. Multiple <table element>s must be separated by commas. 
+The common form of ``CREATE TABLE`` uses a parenthesized <table element list>
+as its <table contents source> clause. A <table element> is either a <Column
+definition> (see "<Column definition>" in this chapter , a <Table Constraint>
+(see our chapter on Constraints and Assertions), a ``LIKE`` clause or a <column
+options> clause. Multiple <table element>s must be separated by commas.
 
 
 
-The effect of ``CREATE TABLE`` <Table name> (<Column definition>,<Column 
+The effect of ``CREATE TABLE`` <Table name> (<Column definition>,<Column
 definition>), e.g.:
 
 ::
@@ -692,12 +694,12 @@ definition>), e.g.:
       column_1 SMALLINT,
       column_2 DATE);
 
-is to create a Table, called ``TABLE_1``, that contains two Columns, called 
-``COLUMN_1`` and ``COLUMN_2``. At least one Column must be defined in a <table 
-element list>. The row type of the new Table is the set of pairs (<Column 
-name>, <data type>) defined for the Table. 
+is to create a Table, called ``TABLE_1``, that contains two Columns, called
+``COLUMN_1`` and ``COLUMN_2``. At least one Column must be defined in a <table
+element list>. The row type of the new Table is the set of pairs (<Column
+name>, <data type>) defined for the Table.
 
-The effect of ``CREATE TABLE`` <Table name> (<Column definition>,<Table 
+The effect of ``CREATE TABLE`` <Table name> (<Column definition>,<Table
 Constraint>), e.g.:
 
 ::
@@ -706,18 +708,18 @@ Constraint>), e.g.:
       column_1 SMALLINT,
       CONSTRAINT constraint_1 PRIMARY KEY(column_1));
 
-is to create a Table, called ``TABLE_1``, that contains one Column, called 
-``COLUMN_1``, and one <Table Constraint> that defines ``COLUMN_1`` as the 
-Table's primary key. Zero or more <Table Constraint>s may be defined in a 
-<table element list>. If the new Table is a temporary Base table, then all 
-Tables referred to in the new Table's <Table Constraint>s must also be 
-temporary Base tables. 
+is to create a Table, called ``TABLE_1``, that contains one Column, called
+``COLUMN_1``, and one <Table Constraint> that defines ``COLUMN_1`` as the
+Table's primary key. Zero or more <Table Constraint>s may be defined in a
+<table element list>. If the new Table is a temporary Base table, then all
+Tables referred to in the new Table's <Table Constraint>s must also be
+temporary Base tables.
 
-The effect of ``CREATE TABLE`` <Table name> (``LIKE`` <Table name>) is to 
-create a Table whose <Column definitions>s are copied from another Table. In 
-the ``LIKE`` clause, <Table name> identifies the Table whose <Column 
-definition>s you want to copy into the new Table. For example, this SQL 
-statement creates a Table in the usual manner: 
+The effect of ``CREATE TABLE`` <Table name> (``LIKE`` <Table name>) is to
+create a Table whose <Column definitions>s are copied from another Table. In
+the ``LIKE`` clause, <Table name> identifies the Table whose <Column
+definition>s you want to copy into the new Table. For example, this SQL
+statement creates a Table in the usual manner:
 
 ::
 
@@ -727,15 +729,15 @@ statement creates a Table in the usual manner:
       column_3 CHAR(8),
       CONSTRAINT constraint_1 CHECK (column_1 BETWEEN 50 AND 5000));
 
-And this SQL statement uses the ``LIKE`` clause to create another Table with 
-the same <Column definition>s: 
+And this SQL statement uses the ``LIKE`` clause to create another Table with
+the same <Column definition>s:
 
 ::
 
     CREATE TABLE Table_2 (LIKE Table_1);
 
-The result is a Table, called ``TABLE_2``, whose structure will be exactly as 
-if it had been defined with this SQL statement: 
+The result is a Table, called ``TABLE_2``, whose structure will be exactly as
+if it had been defined with this SQL statement:
 
 ::
 
@@ -744,12 +746,12 @@ if it had been defined with this SQL statement:
       column_2 DATE,
       column_3 CHAR(8));
 
-Note that the <Table Constraint> from ``TABLE_1``'s definition is not recopied 
-into ``TABLE_2``'s definition: the ``LIKE`` clause copies only <Column 
-definition>s. However, because a <Column Constraint> is effectively replaced by 
-a <Table Constraint> in a Table's definition, the ``LIKE`` clause also won't 
-copy any <Column Constraint>s from the existing Table into the new Table. For 
-example, for these two SQL statements: 
+Note that the <Table Constraint> from ``TABLE_1``'s definition is not recopied
+into ``TABLE_2``'s definition: the ``LIKE`` clause copies only <Column
+definition>s. However, because a <Column Constraint> is effectively replaced by
+a <Table Constraint> in a Table's definition, the ``LIKE`` clause also won't
+copy any <Column Constraint>s from the existing Table into the new Table. For
+example, for these two SQL statements:
 
 ::
 
@@ -760,8 +762,8 @@ example, for these two SQL statements:
 
    CREATE TABLE Table_2 (LIKE Table_1);
 
-the result in the first case is a Table, called ``TABLE_1``, whose structure 
-will be exactly as if it had been defined with this SQL statement: 
+the result in the first case is a Table, called ``TABLE_1``, whose structure
+will be exactly as if it had been defined with this SQL statement:
 
 ::
 
@@ -781,22 +783,22 @@ structure will be exactly as if it had been defined with this SQL statement:
       column_2 DATE,
       column_3 CHAR(8));
 
-If ``CREATE TABLE`` includes a ``LIKE`` clause, the current <AuthorizationID> 
-must have the ``SELECT`` Privilege on the Table named. 
+If ``CREATE TABLE`` includes a ``LIKE`` clause, the current <AuthorizationID>
+must have the ``SELECT`` Privilege on the Table named.
 
-The effect of ``CREATE TABLE`` <Table name> (<Column definition,<Column name> 
-``WITH OPTIONS`` <column option list>) is to create a Table containing one or 
-more Columns whose definitions are further outlined by the <column option>(s) 
-chosen. 
+The effect of ``CREATE TABLE`` <Table name> (<Column definition,<Column name>
+``WITH OPTIONS`` <column option list>) is to create a Table containing one or
+more Columns whose definitions are further outlined by the <column option>(s)
+chosen.
 
 *Temporary Tables*
 ------------------
 
-If you're creating a temporary Table, you may also use the ``ON COMMIT`` clause 
-to specify whether you want the Table to be emptied whenever a ``COMMIT`` 
-statement is executed. If you omit the ``ON COMMIT`` clause from ``CREATE 
-TEMPORARY TABLE``, it defaults to ``ON COMMIT DELETE ROWS``. For example, these 
-two SQL statements are equivalent: 
+If you're creating a temporary Table, you may also use the ``ON COMMIT`` clause
+to specify whether you want the Table to be emptied whenever a ``COMMIT``
+statement is executed. If you omit the ``ON COMMIT`` clause from ``CREATE
+TEMPORARY TABLE``, it defaults to ``ON COMMIT DELETE ROWS``. For example, these
+two SQL statements are equivalent:
 
 ::
 
@@ -816,9 +818,9 @@ Based on this Table definition, the effect of these two SQL statements:
 
    COMMIT;
 
-is that ``TABLE_1`` is first materialized and has data inserted into it, and 
-then the rows are deleted. That is, at ``COMMIT`` time, your DBMS effectively 
-executes this SQL statement: 
+is that ``TABLE_1`` is first materialized and has data inserted into it, and
+then the rows are deleted. That is, at ``COMMIT`` time, your DBMS effectively
+executes this SQL statement:
 
 ::
 
@@ -838,23 +840,23 @@ since the definition of ``TABLE_1`` states that the Table is to be emptied at
 
    COMMIT;
 
-is that ``TABLE_1`` is created, materialized and has data inserted into it, and 
-then the rows are committed. That is, at ``COMMIT`` time, your DBMS does not 
-delete the rows, since ``TABLE_1``'s definition explicitly says not to. (The 
-rows will, however, be deleted at the end of the SQL-session.) 
+is that ``TABLE_1`` is created, materialized and has data inserted into it, and
+then the rows are committed. That is, at ``COMMIT`` time, your DBMS does not
+delete the rows, since ``TABLE_1``'s definition explicitly says not to. (The
+rows will, however, be deleted at the end of the SQL-session.)
 
-If you want to restrict your code to Core SQL, don't create any temporary Base 
-tables, don't use a ``LIKE`` clause as a <table element>, don't use an ``OF`` 
-clause as a <table element> and don't add a <column scope clause> to any 
-``CREATE TABLE`` statement. 
+If you want to restrict your code to Core SQL, don't create any temporary Base
+tables, don't use a ``LIKE`` clause as a <table element>, don't use an ``OF``
+clause as a <table element> and don't add a <column scope clause> to any
+``CREATE TABLE`` statement.
 
 <Column definition>
 ===================
 
-A <Column definition> is used to create or alter a Column of a Base table. Used 
-in a ``CREATE TABLE`` or an ``ALTER TABLE`` statement, it names a Column and 
-defines the Column's <data type>, default value and Constraints. The required 
-syntax for a <Column definition> is: 
+A <Column definition> is used to create or alter a Column of a Base table. Used
+in a ``CREATE TABLE`` or an ``ALTER TABLE`` statement, it names a Column and
+defines the Column's <data type>, default value and Constraints. The required
+syntax for a <Column definition> is:
 
 ::
 
@@ -880,29 +882,29 @@ syntax for a <Column definition> is:
 
           <reference scope check action> ::= RESTRICT | SET NULL
 
-A <Column definition> defines a new Column for a Base table. A Column is owned 
-by the Table it belongs to. The <Column name> identifies the Column and the 
-Table that it belongs to. A <Column name> in a <Column definition> may not be 
-qualified: it belongs to the Table named in the enclosing ``CREATE TABLE`` or 
-``ALTER TABLE`` statement. The <Column name> must be unique within the Table 
-that owns it. 
+A <Column definition> defines a new Column for a Base table. A Column is owned
+by the Table it belongs to. The <Column name> identifies the Column and the
+Table that it belongs to. A <Column name> in a <Column definition> may not be
+qualified: it belongs to the Table named in the enclosing ``CREATE TABLE`` or
+``ALTER TABLE`` statement. The <Column name> must be unique within the Table
+that owns it.
 
 *<data type>*
 -------------
 
-A Column must be defined to accept a certain type of data. This is done in one 
-of two ways: you can either define a Column with a <data type> specification> 
-or you can define it as being based on a Domain. If you base a Column on a 
-Domain, your current <AuthorizationID> must have the ``USAGE`` Privilege on 
-that Domain. The Column's specified <data type> (or the <data type> of the 
-Domain it is based on) constrains the values that can be accepted by the 
-Column. The <data type> specification includes length, precision and scale as 
-applicable. Valid <data type>s are: ``INT``, ``SMALLINT``, ``NUMERIC(p,s)``, 
-``DECIMAL(p,s)``, ``FLOAT(p)``, ``REAL``, ``DOUBLE PRECISION``, ``BIT(l)``, 
-``BIT VARYING(l)``, ``BLOB(l)``, ``CHAR(l)``, ``NCHAR(l)``, ``VARCHAR(l)``, 
-``NCHAR VARYING(l)``, ``CLOB(l)``, ``NCLOB(l)``, ``DATE``, ``TIME(p)``, 
-``TIME(p) WITH TIME ZONE``, ``TIMESTAMP(p)``, ``TIMESTAMP(p) WITH TIME ZONE``, 
-``INTERVAL`` <interval qualifier>, ``BOOLEAN``, ``ARRAY``, ``ROW`` and ``REF``. 
+A Column must be defined to accept a certain type of data. This is done in one
+of two ways: you can either define a Column with a <data type> specification>
+or you can define it as being based on a Domain. If you base a Column on a
+Domain, your current <AuthorizationID> must have the ``USAGE`` Privilege on
+that Domain. The Column's specified <data type> (or the <data type> of the
+Domain it is based on) constrains the values that can be accepted by the
+Column. The <data type> specification includes length, precision and scale as
+applicable. Valid <data type>s are: ``INT``, ``SMALLINT``, ``NUMERIC(p,s)``,
+``DECIMAL(p,s)``, ``FLOAT(p)``, ``REAL``, ``DOUBLE PRECISION``, ``BIT(l)``,
+``BIT VARYING(l)``, ``BLOB(l)``, ``CHAR(l)``, ``NCHAR(l)``, ``VARCHAR(l)``,
+``NCHAR VARYING(l)``, ``CLOB(l)``, ``NCLOB(l)``, ``DATE``, ``TIME(p)``,
+``TIME(p) WITH TIME ZONE``, ``TIMESTAMP(p)``, ``TIMESTAMP(p) WITH TIME ZONE``,
+``INTERVAL`` <interval qualifier>, ``BOOLEAN``, ``ARRAY``, ``ROW`` and ``REF``.
 
 The effect of the syntax ``CREATE TABLE <Table name> (<Column name> <data
 type>)`` is to define a Column with a <data type> specification. For example,
@@ -926,26 +928,26 @@ these SQL statements is also a Table with a Column that has a <data type> of
    CREATE TABLE Table_1 (
       column_1 domain_1;
 
-[Obscure Rule] If the <data type> of a Column is ``CHAR``, ``VARCHAR`` or 
-``CLOB``, the Character set that the Column's values must belong to is 
-determined as 
+[Obscure Rule] If the <data type> of a Column is ``CHAR``, ``VARCHAR`` or
+``CLOB``, the Character set that the Column's values must belong to is
+determined as
 
 follows:
 
 * If the <Column definition> contains a <data type> specification that
-  includes a ``CHARACTER SET`` clause, the Column's Character set is the 
-  Character set named. Your current <AuthorizationID> must have the 
+  includes a ``CHARACTER SET`` clause, the Column's Character set is the
+  Character set named. Your current <AuthorizationID> must have the
   ``USAGE`` Privilege on that Character set.
 
-* If the <Column definition> does not include a <data type> specification, 
-  but the Column is based on a Domain whose definition includes a 
-  ``CHARACTER SET`` clause, the Column's Character set is the Character set 
+* If the <Column definition> does not include a <data type> specification,
+  but the Column is based on a Domain whose definition includes a
+  ``CHARACTER SET`` clause, the Column's Character set is the Character set
   named.
 
 * If the <Column definition> does not include any ``CHARACTER SET`` clause
   at all -- either through a <data type> specification or through a Domain
   definition -- the Column's Character set is the Character set named in the
-  ``DEFAULT CHARACTER SET`` clause of the ``CREATE SCHEMA`` statement that 
+  ``DEFAULT CHARACTER SET`` clause of the ``CREATE SCHEMA`` statement that
   defines the Schema that the Column belongs to.
 
 For example, the effect of these two SQL statements:
@@ -973,31 +975,31 @@ The effect of these two SQL statements:
    CREATE TABLE Table_1 (
       column_1 CHAR(10) CHARACTER SET INFORMATION_SCHEMA.SQL_CHARACTER);
 
-is to create the same Table with one difference: this time, its Column's values 
-must consist only of characters found in the 
-``INFORMATION_SCHEMA.SQL_CHARACTER`` Character set -- the explicit Character 
-set specification in ``CREATE TABLE`` constrains the Column's set of values. 
-The Schema's default Character set does not. 
+is to create the same Table with one difference: this time, its Column's values
+must consist only of characters found in the
+``INFORMATION_SCHEMA.SQL_CHARACTER`` Character set -- the explicit Character
+set specification in ``CREATE TABLE`` constrains the Column's set of values.
+The Schema's default Character set does not.
 
-[Obscure Rule] If the <data type> of a Column is ``CHAR``, ``VARCHAR``, 
-``CLOB``, ``NCHAR``, ``NCHAR VARYING`` or ``NCLOB``, and your <Column 
-definition> does not include a ``COLLATE`` clause, the Column has a 
-coercibility attribute of ``COERCIBLE`` -- but if your <Column definition> 
-includes a ``COLLATE`` clause, the Column has a coercibility attribute of 
-``IMPLICIT``. In either case, the Column's default Collation is determined as 
-follows: 
+[Obscure Rule] If the <data type> of a Column is ``CHAR``, ``VARCHAR``,
+``CLOB``, ``NCHAR``, ``NCHAR VARYING`` or ``NCLOB``, and your <Column
+definition> does not include a ``COLLATE`` clause, the Column has a
+coercibility attribute of ``COERCIBLE`` -- but if your <Column definition>
+includes a ``COLLATE`` clause, the Column has a coercibility attribute of
+``IMPLICIT``. In either case, the Column's default Collation is determined as
+follows:
 
 * If the <Column definition> includes a ``COLLATE`` clause, the Column's
   default Collation is the Collation named. Your current <AuthorizationID> must
   have the ``USAGE`` Privilege on that Collation.
 
 * If the <Column definition> does not include a ``COLLATE`` clause, but
-  does contain a <data type> specification that includes a ``COLLATE`` 
+  does contain a <data type> specification that includes a ``COLLATE``
   clause, the Column's default Collation is the Collation named. Your current
   <AuthorizationID> must have the ``USAGE`` Privilege on that Collation.
 
 * If the <Column definition> does not include a ``COLLATE`` clause, but the
-  Column is based on a Domain whose definition includes a ``COLLATE`` 
+  Column is based on a Domain whose definition includes a ``COLLATE``
   clause, the Column's default Collation is the Collation named.
 
 * If the <Column definition> does not include any ``COLLATE`` clause at all
@@ -1005,54 +1007,54 @@ follows:
   definition -- the Column's default Collation is the default Collation of the
   Column's Character set.
 
-[Obscure Rule] If the <data type> of a Column is ``REF``\(UDT), your current 
-<AuthorizationID> must have the ``USAGE`` Privilege on that UDT. If the <data 
-type> of a Column includes ``REF`` with a <scope clause>, your <Column 
-definition> must also include a <reference scope check> clause, to indicate 
-whether references are to be checked or not (don't add a <reference scope 
-check> clause under any other circumstances). In this case, you may also add 
-the optional <reference scope check action> clause, to indicate the action to 
-be taken when the Column is the subject of a ``DELETE`` statement. If you omit 
-the <reference scope check action> clause, it defaults to ``ON DELETE 
-RESTRICT``. 
+[Obscure Rule] If the <data type> of a Column is ``REF``\(UDT), your current
+<AuthorizationID> must have the ``USAGE`` Privilege on that UDT. If the <data
+type> of a Column includes ``REF`` with a <scope clause>, your <Column
+definition> must also include a <reference scope check> clause, to indicate
+whether references are to be checked or not (don't add a <reference scope
+check> clause under any other circumstances). In this case, you may also add
+the optional <reference scope check action> clause, to indicate the action to
+be taken when the Column is the subject of a ``DELETE`` statement. If you omit
+the <reference scope check action> clause, it defaults to ``ON DELETE
+RESTRICT``.
 
 * If a Column is defined with ``REFERENCES ARE CHECKED`` and a <scope
-  clause> naming one or more Tables is included in the <Column definition>, 
-  then there is an implied ``DEFERRABLE INITIALLY IMMEDIATE`` Constraint on 
-  the new Column which checks that the Column's values are also found in the 
-  system generated Column of each Table named in the <scope clause>. In this 
-  case, if the <reference scope check action> is ``SET NULL`` then, prior to 
-  deleting any rows from the Table that owns this Column, your DBMS will 
-  *(a)* execute a ``SET CONSTRAINT`` statement that sets the implied 
-  Constraint's constraint check time to ``DEFERRED``, *(b)* ``DELETE`` the 
-  rows as required, *(c)* set the value of the system generated Column in 
-  each Table named in the <scope clause> to ``NULL``, for each row that 
+  clause> naming one or more Tables is included in the <Column definition>,
+  then there is an implied ``DEFERRABLE INITIALLY IMMEDIATE`` Constraint on
+  the new Column which checks that the Column's values are also found in the
+  system generated Column of each Table named in the <scope clause>. In this
+  case, if the <reference scope check action> is ``SET NULL`` then, prior to
+  deleting any rows from the Table that owns this Column, your DBMS will
+  *(a)* execute a ``SET CONSTRAINT`` statement that sets the implied
+  Constraint's constraint check time to ``DEFERRED``, *(b)* ``DELETE`` the
+  rows as required, *(c)* set the value of the system generated Column in
+  each Table named in the <scope clause> to ``NULL``, for each row that
   matched the deleted rows and *(d)* execute a ``SET CONSTRAINT`` statement
   that sets the implied Constraint's constraint check time to ``IMMEDIATE``.
 
 *DEFAULT Clause*
 ----------------
 
-The optional ``DEFAULT`` clause defines the Column's default value: the value 
-to insert whenever this Column is the target of an ``INSERT`` statement that 
-doesn't include an explicit value for it. The ``DEFAULT`` options are: 
-``DEFAULT`` <literal>, ``DEFAULT CURRENT_DATE``, ``DEFAULT CURRENT_TIME(p)``, 
-``DEFAULT CURRENT_TIMESTAMP(p)``, ``DEFAULT LOCALTIME(p)``, ``DEFAULT 
-LOCALTIMESTAMP(p)``, ``DEFAULT USER``, ``DEFAULT CURRENT_USER``, ``DEFAULT 
-SESSION_USER``, ``DEFAULT SYSTEM_USER``, ``DEFAULT CURRENT_PATH``, ``DEFAULT 
-ARRAY[]``, ``DEFAULT ARRAY??(??)`` and ``DEFAULT NULL -- see "<default 
-clause>", later in this chapter. The ``DEFAULT`` clause is optional whether or 
-not the Column is based on a Domain that has a defined default value, so a 
-Column's default value is determined as follows: 
+The optional ``DEFAULT`` clause defines the Column's default value: the value
+to insert whenever this Column is the target of an ``INSERT`` statement that
+doesn't include an explicit value for it. The ``DEFAULT`` options are:
+``DEFAULT`` <literal>, ``DEFAULT CURRENT_DATE``, ``DEFAULT CURRENT_TIME(p)``,
+``DEFAULT CURRENT_TIMESTAMP(p)``, ``DEFAULT LOCALTIME(p)``, ``DEFAULT
+LOCALTIMESTAMP(p)``, ``DEFAULT USER``, ``DEFAULT CURRENT_USER``, ``DEFAULT
+SESSION_USER``, ``DEFAULT SYSTEM_USER``, ``DEFAULT CURRENT_PATH``, ``DEFAULT
+ARRAY[]``, ``DEFAULT ARRAY??(??)`` and ``DEFAULT NULL -- see "<default
+clause>", later in this chapter. The ``DEFAULT`` clause is optional whether or
+not the Column is based on a Domain that has a defined default value, so a
+Column's default value is determined as follows:
 
 * If a <Column definition> that contains a <data type> specification
   omits the ``DEFAULT`` clause, the Column has no default value.
 
 * If a <Column definition> that contains a <data type> specification
-  includes the ``DEFAULT`` clause, the Column's default value is the default 
-  value specified -- that is, the syntax ``CREATE TABLE <Table name> 
-  (<Column name> DEFAULT default value)`` defines a Column with an explicit 
-  default value. For example, this SQL statement creates a Table with a 
+  includes the ``DEFAULT`` clause, the Column's default value is the default
+  value specified -- that is, the syntax ``CREATE TABLE <Table name>
+  (<Column name> DEFAULT default value)`` defines a Column with an explicit
+  default value. For example, this SQL statement creates a Table with a
   Column whose default value is the <character string literal> ``'bobby'``:
 
 ::
@@ -1061,10 +1063,10 @@ Column's default value is determined as follows:
       column_1 CHAR(5) DEFAULT 'bobby');
 
 * If a Column is based on a Domain and the <Column definition> omits
-  the ``DEFAULT`` clause, the Column's default value is the Domain's default 
-  value. If the Domain has no defined default value, then the Column has no 
-  default value either. For example, the effect of these two SQL statements 
-  is to define a Column whose default value is the <character string 
+  the ``DEFAULT`` clause, the Column's default value is the Domain's default
+  value. If the Domain has no defined default value, then the Column has no
+  default value either. For example, the effect of these two SQL statements
+  is to define a Column whose default value is the <character string
   literal> ``'bobby'`` -- taken from the Domain that the Column is based on:
 
 ::
@@ -1075,15 +1077,15 @@ Column's default value is determined as follows:
    CREATE TABLE Table_1 (
       column_1 domain_1);
 
-If a Column is based on a Domain and the <Column definition> includes 
-the ``DEFAULT`` clause, the Column's default value is the default value 
-specified -- even if the Domain has a defined default value. The <Column 
-definition>'s ``DEFAULT`` clause always over-rides any default value 
-defined for the Domain that a Column is based on. For example, the 
-effect of these two SQL statements is to define a Column whose default 
-value is the <character string literal> ``'bobby'`` -- despite the fact 
-that the Domain that the Column is based on has a default value that is 
-the <character string literal> ``'sammy'``: 
+If a Column is based on a Domain and the <Column definition> includes
+the ``DEFAULT`` clause, the Column's default value is the default value
+specified -- even if the Domain has a defined default value. The <Column
+definition>'s ``DEFAULT`` clause always over-rides any default value
+defined for the Domain that a Column is based on. For example, the
+effect of these two SQL statements is to define a Column whose default
+value is the <character string literal> ``'bobby'`` -- despite the fact
+that the Domain that the Column is based on has a default value that is
+the <character string literal> ``'sammy'``:
 
 ::
 
@@ -1127,16 +1129,16 @@ value <Column Constraint>)`` also defines Columns whose definitions include a
          CONSTRAINT constraint_2 CHECK (column_2 IS NOT NULL);
       -- column_1 is the Table's primary key and column_2 excludes null values
 
-A <Column Constraint> is valid only in a <Column definition> because, 
-once defined, <Column Constraint>s logically become <Table Constraint>s 
-of the Table that the Column belongs to. To change or drop a <Column 
-Constraint>, or to add a <Column Constraint> to a Table once ``CREATE 
-TABLE`` has been executed, use the ``ALTER TABLE`` statement. 
+A <Column Constraint> is valid only in a <Column definition> because,
+once defined, <Column Constraint>s logically become <Table Constraint>s
+of the Table that the Column belongs to. To change or drop a <Column
+Constraint>, or to add a <Column Constraint> to a Table once ``CREATE
+TABLE`` has been executed, use the ``ALTER TABLE`` statement.
 
-If you want to restrict your code to Core SQL, don't add a ``COLLATE`` 
-clause to your <Column definition>s, don't base your Columns on Domains, 
-don't name your <Column Constraint>s and don't define a <Column 
-Constraint> with a <referential triggered action>. 
+If you want to restrict your code to Core SQL, don't add a ``COLLATE``
+clause to your <Column definition>s, don't base your Columns on Domains,
+don't name your <Column Constraint>s and don't define a <Column
+Constraint> with a <referential triggered action>.
 
 <default clause>
 ================
@@ -1165,26 +1167,26 @@ attribute of a UDT. The required syntax for a <default clause> is:
        ARRAY??(??) |
        NULL
 
-The default value of an Object is the data value that will be inserted 
-into the Object whenever it is the target of an ``INSERT`` statement 
-that does not provide an explicit data value for that Object. If the 
-definition of an Object does not include a <default clause>, no default 
-value is assigned to it -- so when the Object is the target of an 
-``INSERT`` statement that does not provide an explicit data value for 
-it, your DBMS will ``INSERT`` a null value. (If the Object doesn't allow 
-nulls, the ``INSERT`` will, of course, fail.) The <data type> of a 
-default value must match the Object's <data type> (that is, the default 
+The default value of an Object is the data value that will be inserted
+into the Object whenever it is the target of an ``INSERT`` statement
+that does not provide an explicit data value for that Object. If the
+definition of an Object does not include a <default clause>, no default
+value is assigned to it -- so when the Object is the target of an
+``INSERT`` statement that does not provide an explicit data value for
+it, your DBMS will ``INSERT`` a null value. (If the Object doesn't allow
+nulls, the ``INSERT`` will, of course, fail.) The <data type> of a
+default value must match the Object's <data type> (that is, the default
 value and the Object's <data type> must be mutually assignable).
 
-* If the <data type> of an Object is a <reference type>, the <default 
+* If the <data type> of an Object is a <reference type>, the <default
   clause> must be ``DEFAULT NULL``.
 
-* If the <data type> of an Object is a <collection type>, the <default 
-  clause> must be ``DEFAULT NULL`` or ``DEFAULT ARRAY[]`` or ``DEFAULT 
+* If the <data type> of an Object is a <collection type>, the <default
+  clause> must be ``DEFAULT NULL`` or ``DEFAULT ARRAY[]`` or ``DEFAULT
   ARRAY??(??)`` or ``DEFAULT <literal>``.
 
-If a <default clause> is ``DEFAULT`` <literal>, the value represented by the 
-<literal> is the target Object’s default value. Here are some examples of 
+If a <default clause> is ``DEFAULT`` <literal>, the value represented by the
+<literal> is the target Object’s default value. Here are some examples of
 <default clause>s with a <literal> as the default value:
 
 ::
@@ -1209,13 +1211,13 @@ If a <default clause> is ``DEFAULT`` <literal>, the value represented by the
 
    CREATE DOMAIN domain_1 AS BOOLEAN DEFAULT FALSE
 
-If a <default clause> is ``DEFAULT USER``, ``DEFAULT CURRENT_USER``, 
-``DEFAULT SESSION_USER`` or ``DEFAULT SYSTEM_USER``, the value returned 
-by the function is the target Object's default value. In this case, the 
-target Object must have a character string <data type> with a defined 
-length of at least 128 characters and must belong to the ``SQL_TEXT`` 
-Character set. Here are some examples of <default clause>s with a 
-<niladic user function> as the default value: 
+If a <default clause> is ``DEFAULT USER``, ``DEFAULT CURRENT_USER``,
+``DEFAULT SESSION_USER`` or ``DEFAULT SYSTEM_USER``, the value returned
+by the function is the target Object's default value. In this case, the
+target Object must have a character string <data type> with a defined
+length of at least 128 characters and must belong to the ``SQL_TEXT``
+Character set. Here are some examples of <default clause>s with a
+<niladic user function> as the default value:
 
 ::
 
@@ -1225,12 +1227,12 @@ Character set. Here are some examples of <default clause>s with a
    CREATE TABLE Table_1 (
       column_1 VARCHAR(256) CHARACTER SET SQL_TEXT DEFAULT SESSION_USER;
 
-If a <default clause> is ``DEFAULT CURRENT_PATH``, the value returned by 
-the function is the target Object's default value. In this case, the 
-target Object must have a character string <data type> with a defined 
-length of at least 1031 characters and must belong to the ``SQL_TEXT`` 
-Character set. Here are some examples of <default clause>s with 
-``CURRENT_PATH`` as the default value: 
+If a <default clause> is ``DEFAULT CURRENT_PATH``, the value returned by
+the function is the target Object's default value. In this case, the
+target Object must have a character string <data type> with a defined
+length of at least 1031 characters and must belong to the ``SQL_TEXT``
+Character set. Here are some examples of <default clause>s with
+``CURRENT_PATH`` as the default value:
 
 ::
 
@@ -1240,13 +1242,13 @@ Character set. Here are some examples of <default clause>s with
    CREATE TABLE Table_1 (
       column_1 VARCHAR(2000) CHARACTER SET SQL_TEXT DEFAULT CURRENT_PATH;
 
-If a <default clause> is ``DEFAULT CURRENT_DATE``, ``DEFAULT 
-CURRENT_TIME[(p)]``, ``DEFAULT CURRENT_TIMESTAMP[(p)]``, ``DEFAULT 
-LOCALTIME[(p)]`` or ``DEFAULT LOCALTIMESTAMP[(p)]``, the value returned 
-by the function is the target Object's default value. In this case, the 
-target Object must have a datetime <data type> that matches the 
-function's <data type>. Here are some examples of <default clause>s with 
-a <datetime value function> as the default value: 
+If a <default clause> is ``DEFAULT CURRENT_DATE``, ``DEFAULT
+CURRENT_TIME[(p)]``, ``DEFAULT CURRENT_TIMESTAMP[(p)]``, ``DEFAULT
+LOCALTIME[(p)]`` or ``DEFAULT LOCALTIMESTAMP[(p)]``, the value returned
+by the function is the target Object's default value. In this case, the
+target Object must have a datetime <data type> that matches the
+function's <data type>. Here are some examples of <default clause>s with
+a <datetime value function> as the default value:
 
 ::
 
@@ -1262,20 +1264,20 @@ a <datetime value function> as the default value:
    CREATE TABLE Table_1 (
       column_1 TIME(4) DEFAULT LOCALTIME(4);
 
-If a <default clause> is ``DEFAULT ARRAY[]`` or ``DEFAULT ARRAY??(??)``, 
-an empty array value is the target <collection type>'s default value. 
-Here is an example of a <default clause> with an empty array as the 
-default value: 
+If a <default clause> is ``DEFAULT ARRAY[]`` or ``DEFAULT ARRAY??(??)``,
+an empty array value is the target <collection type>'s default value.
+Here is an example of a <default clause> with an empty array as the
+default value:
 
 ::
 
    CREATE DOMAIN domain_1 AS
       INT ARRAY[3] DEFAULT ARRAY[];
 
-If a <default clause> is ``DEFAULT NULL``, the null value is the target 
-Object's default value. (The Object can't, of course, have a ``NOT 
-NULL`` Constraint.) Here is an example of a <default clause> with a null 
-value as the default value: 
+If a <default clause> is ``DEFAULT NULL``, the null value is the target
+Object's default value. (The Object can't, of course, have a ``NOT
+NULL`` Constraint.) Here is an example of a <default clause> with a null
+value as the default value:
 
 ::
 
@@ -1287,13 +1289,13 @@ defines a default value that can't be represented in ``INFORMATION_SCHEMA``
 without truncation, your DBMS will return the ``SQLSTATE warning 0100B
 "warning-default value too long for information schema``.
 
-If you want to restrict your code to Core SQL, don't use ``DEFAULT 
+If you want to restrict your code to Core SQL, don't use ``DEFAULT
 CURRENT_PATH`` when defining a <default clause>.
 
 ALTER TABLE Statement
 =====================
 
-The ``ALTER TABLE`` statement changes a Base table's definition. The 
+The ``ALTER TABLE`` statement changes a Base table's definition. The
 required syntax for the ``ALTER TABLE`` statement is:
 
 ::
@@ -1313,18 +1315,18 @@ required syntax for the ``ALTER TABLE`` statement is:
    (<Table name> [ {,<Table name>}... ]) |
    <Table name>
 
-The <Table name> must identify an existing Base table whose owner is 
-either the current <AuthorizationID> or a Role that the current 
-<AuthorizationID> may use. That is, only the <AuthorizationID> that owns 
-the Table may alter it. ``ALTER TABLE`` can be used to change a 
-persistent Base table, a ``GLOBAL TEMPORARY`` Base table or a created 
-``LOCAL TEMPORARY`` Base table, but you can't use it to change a 
-declared ``LOCAL TEMPORARY`` Base table. 
+The <Table name> must identify an existing Base table whose owner is
+either the current <AuthorizationID> or a Role that the current
+<AuthorizationID> may use. That is, only the <AuthorizationID> that owns
+the Table may alter it. ``ALTER TABLE`` can be used to change a
+persistent Base table, a ``GLOBAL TEMPORARY`` Base table or a created
+``LOCAL TEMPORARY`` Base table, but you can't use it to change a
+declared ``LOCAL TEMPORARY`` Base table.
 
 *ADD [ COLUMN ] Clause*
 -----------------------
 
-The effect of ``ALTER TABLE`` <Table name> ``ADD [COLUMN]`` <Column 
+The effect of ``ALTER TABLE`` <Table name> ``ADD [COLUMN]`` <Column
 definition>, e.g.:
 
 ::
@@ -1333,10 +1335,10 @@ definition>, e.g.:
       column_1 SMALLINT DEFAULT 150
          CONSTRAINT constraint_1 NOT NULL NOT DEFERRABLE;
 
-is that the Table named will increase in size by one Column: the Column 
-defined by the <Column definition>. The <keyword> ``COLUMN`` in the 
-``ADD [COLUMN]`` clause is noise and can be omitted. For example, these 
-two SQL statements are equivalent: 
+is that the Table named will increase in size by one Column: the Column
+defined by the <Column definition>. The <keyword> ``COLUMN`` in the
+``ADD [COLUMN]`` clause is noise and can be omitted. For example, these
+two SQL statements are equivalent:
 
 ::
 
@@ -1349,13 +1351,13 @@ two SQL statements are equivalent:
 Adding a new Column to a Table has a four-fold effect:
 
 1. The degree (i.e.: the number of Columns) of the Table is increased by
-   1; the new Column's ordinal position in the Table is the new degree of 
+   1; the new Column's ordinal position in the Table is the new degree of
    the Table.
 
 2. Every <AuthorizationID> that has a ``SELECT``, ``UPDATE``, ``INSERT`` or
-   ``REFERENCES`` Privilege on all existing Columns of the Table receives a 
-   matching set of Privileges on the new Column. The grantor of the new 
-   Privilege(s) is the same as the grantor of the previous Privileges(s) and 
+   ``REFERENCES`` Privilege on all existing Columns of the Table receives a
+   matching set of Privileges on the new Column. The grantor of the new
+   Privilege(s) is the same as the grantor of the previous Privileges(s) and
    so is the grantability of the new Privilege(s).
 
 3. The value of the new Column for every existing row of the Table is
@@ -1364,14 +1366,14 @@ Adding a new Column to a Table has a four-fold effect:
 4. The Column is added to the Column list of every ``UPDATE`` Trigger event
    for all Triggers that act on the Table. However, adding a new Column to a
    Table has no effect on any existing View definition or Constraint definition
-   that refers to the Table because implicit <Column name>s in these 
-   definitions are replaced by explicit <Column name>s the first time the 
+   that refers to the Table because implicit <Column name>s in these
+   definitions are replaced by explicit <Column name>s the first time the
    View or Constraint is evaluated.
 
 *ALTER [ COLUMN ] ... SET DEFAULT Clause*
 -----------------------------------------
 
-The effect of ``ALTER TABLE`` <Table name> ``ALTER [COLUMN]`` <Column name> 
+The effect of ``ALTER TABLE`` <Table name> ``ALTER [COLUMN]`` <Column name>
 ``SET DEFAULT`` default value, e.g.:
 
 ::
@@ -1382,7 +1384,7 @@ The effect of ``ALTER TABLE`` <Table name> ``ALTER [COLUMN]`` <Column name>
 is that the default value of the Column named will be changed. (You can use
 this version of ``ALTER TABLE`` either to add a default value to a <Column
 definition> or to change a Column's existing default value.) The <keyword>
-``COLUMN`` in the ``ALTER [COLUMN]`` clause is noise and can be omitted. For 
+``COLUMN`` in the ``ALTER [COLUMN]`` clause is noise and can be omitted. For
 example, these two SQL statements are equivalent:
 
 ::
@@ -1393,18 +1395,18 @@ example, these two SQL statements are equivalent:
    ALTER TABLE Table_1 ALTER
       column_1 SET DEFAULT CURRENT_TIME;
 
-The ``ALTER [COLUMN] ... SET DEFAULT`` options are: ``DEFAULT`` 
-<literal>, ``DEFAULT CURRENT_DATE``, ``DEFAULT CURRENT_TIME(p)``, 
-``DEFAULT CURRENT_TIMESTAMP(p)``, ``DEFAULT LOCALTIME(p)``, ``DEFAULT 
-LOCALTIMESTAMP(p)``, ``DEFAULT USER``, ``DEFAULT CURRENT_USER``, 
-``DEFAULT SESSION_USER``, ``DEFAULT SYSTEM_USER``, ``DEFAULT 
-CURRENT_PATH``, ``DEFAULT ARRAY[]``, ``DEFAULT ARRAY??(??)`` and 
-``DEFAULT NULL`` -- see "<default clause>", earlier in this chapter. 
+The ``ALTER [COLUMN] ... SET DEFAULT`` options are: ``DEFAULT``
+<literal>, ``DEFAULT CURRENT_DATE``, ``DEFAULT CURRENT_TIME(p)``,
+``DEFAULT CURRENT_TIMESTAMP(p)``, ``DEFAULT LOCALTIME(p)``, ``DEFAULT
+LOCALTIMESTAMP(p)``, ``DEFAULT USER``, ``DEFAULT CURRENT_USER``,
+``DEFAULT SESSION_USER``, ``DEFAULT SYSTEM_USER``, ``DEFAULT
+CURRENT_PATH``, ``DEFAULT ARRAY[]``, ``DEFAULT ARRAY??(??)`` and
+``DEFAULT NULL`` -- see "<default clause>", earlier in this chapter.
 
 *ALTER [ COLUMN ] ... DROP DEFAULT Clause*
 ------------------------------------------
 
-The effect of ``ALTER TABLE`` <Table name> ``ALTER [COLUMN]`` <Column name> 
+The effect of ``ALTER TABLE`` <Table name> ``ALTER [COLUMN]`` <Column name>
 ``DROP DEFAULT``, e.g.:
 
 ::
@@ -1412,11 +1414,11 @@ The effect of ``ALTER TABLE`` <Table name> ``ALTER [COLUMN]`` <Column name>
   ALTER TABLE Table_1 ALTER COLUMN
       column_1 DROP DEFAULT;
 
-is that the default value of the Column named will be removed from the 
-<Column definition>. (You'll get a syntax error if the Column's 
-definition doesn't include a default value.) The <keyword> ``COLUMN`` in 
-the ``ALTER [COLUMN]`` clause is noise and can be omitted. For example, 
-these two SQL statements are equivalent: 
+is that the default value of the Column named will be removed from the
+<Column definition>. (You'll get a syntax error if the Column's
+definition doesn't include a default value.) The <keyword> ``COLUMN`` in
+the ``ALTER [COLUMN]`` clause is noise and can be omitted. For example,
+these two SQL statements are equivalent:
 
 ::
 
@@ -1429,7 +1431,7 @@ these two SQL statements are equivalent:
 *ALTER [ COLUMN ] ... ADD SCOPE Clause*
 ---------------------------------------
 
-The effect of ``ALTER TABLE`` <Table name> ``ALTER [COLUMN]`` <Column name> 
+The effect of ``ALTER TABLE`` <Table name> ``ALTER [COLUMN]`` <Column name>
 ``ADD SCOPE`` <Table name list>, e.g.:
 
 ::
@@ -1437,16 +1439,16 @@ The effect of ``ALTER TABLE`` <Table name> ``ALTER [COLUMN]`` <Column name>
    ALTER TABLE Table_2 ALTER COLUMN
       column_1 ADD SCOPE Table_1;
 
-is that a non-empty scope is added to the <Column definition> of the 
-Column named. This version of ``ALTER TABLE`` can only be used *(a)* for 
-Columns with a ``REF``\(UDT) <data type>, where the <reference type> 
-descriptor includes an empty scope and *(b)* where the Column named is 
-not the referenceable Column of its Table. (The Tables named in the 
-``SCOPE`` clause must, of course, be referenceable Base tables whose 
-structured type is the same as the structured type of the referenced 
-UDT.) The <keyword> ``COLUMN`` in the ``ALTER [COLUMN]`` clause is noise 
-and can be omitted. For example, these two SQL statements are 
-equivalent: 
+is that a non-empty scope is added to the <Column definition> of the
+Column named. This version of ``ALTER TABLE`` can only be used *(a)* for
+Columns with a ``REF``\(UDT) <data type>, where the <reference type>
+descriptor includes an empty scope and *(b)* where the Column named is
+not the referenceable Column of its Table. (The Tables named in the
+``SCOPE`` clause must, of course, be referenceable Base tables whose
+structured type is the same as the structured type of the referenced
+UDT.) The <keyword> ``COLUMN`` in the ``ALTER [COLUMN]`` clause is noise
+and can be omitted. For example, these two SQL statements are
+equivalent:
 
 ::
 
@@ -1459,7 +1461,7 @@ equivalent:
 *ALTER [ COLUMN ] ... DROP SCOPE clause*
 ----------------------------------------
 
-The effect of ``ALTER TABLE`` <Table name> ``ALTER [COLUMN]`` <Column name> 
+The effect of ``ALTER TABLE`` <Table name> ``ALTER [COLUMN]`` <Column name>
 ``DROP SCOPE RESTRICT``, e.g.:
 
 ::
@@ -1467,36 +1469,36 @@ The effect of ``ALTER TABLE`` <Table name> ``ALTER [COLUMN]`` <Column name>
    ALTER TABLE Table_2 ALTER COLUMN
       column_1 DROP SCOPE RESTRICT;
 
-is that the ``SCOPE`` clause in the definition of the Column named 
-becomes empty, provided that no impacted dereference operation is 
-contained in an SQL routine, in a View definition, in a Constraint or 
-Assertion definition or in the triggered action of a Trigger definition. 
-(An impacted dereference operation is a <dereference operation> that 
-operates on the Column named, a <method reference> that operates on the 
-Column named or a <reference resolution> that operates on the Column 
-named.) That is, ``RESTRICT`` ensures that only a scope with no 
-dependent Objects can be made empty. If the Column is operated on by any 
-impacted dereference operation, ``ALTER TABLE ... DROP SCOPE RESTRICT`` 
-will fail. 
+is that the ``SCOPE`` clause in the definition of the Column named
+becomes empty, provided that no impacted dereference operation is
+contained in an SQL routine, in a View definition, in a Constraint or
+Assertion definition or in the triggered action of a Trigger definition.
+(An impacted dereference operation is a <dereference operation> that
+operates on the Column named, a <method reference> that operates on the
+Column named or a <reference resolution> that operates on the Column
+named.) That is, ``RESTRICT`` ensures that only a scope with no
+dependent Objects can be made empty. If the Column is operated on by any
+impacted dereference operation, ``ALTER TABLE ... DROP SCOPE RESTRICT``
+will fail.
 
-The effect of ``ALTER TABLE`` <Table name> ``ALTER [COLUMN]`` <Column 
-name> ``DROP SCOPE CASCADE``, e.g.: 
+The effect of ``ALTER TABLE`` <Table name> ``ALTER [COLUMN]`` <Column
+name> ``DROP SCOPE CASCADE``, e.g.:
 
 ::
 
    ALTER TABLE Table_2 ALTER COLUMN
       column_1 DROP SCOPE CASCADE;
 
-is that the ``SCOPE`` clause in the definition of the Column named 
-becomes empty and that all Objects which contain an impacted dereference 
-operation for the Column are also dropped, with the ``CASCADE`` drop 
-behaviour (except for Assertions, where this is not applicable). This 
-version of ``ALTER TABLE`` can only be used *(a)* for Columns with a 
-``REF``\(UDT) <data type>, where the <reference type> descriptor 
-includes a ``SCOPE`` clause and *(b)* where the Column named is not the 
-referenceable Column of its Table. The <keyword> ``COLUMN`` in the 
-``ALTER [COLUMN]`` clause is noise and can be omitted. For example, 
-these two SQL statements are equivalent: 
+is that the ``SCOPE`` clause in the definition of the Column named
+becomes empty and that all Objects which contain an impacted dereference
+operation for the Column are also dropped, with the ``CASCADE`` drop
+behaviour (except for Assertions, where this is not applicable). This
+version of ``ALTER TABLE`` can only be used *(a)* for Columns with a
+``REF``\(UDT) <data type>, where the <reference type> descriptor
+includes a ``SCOPE`` clause and *(b)* where the Column named is not the
+referenceable Column of its Table. The <keyword> ``COLUMN`` in the
+``ALTER [COLUMN]`` clause is noise and can be omitted. For example,
+these two SQL statements are equivalent:
 
 ::
 
@@ -1509,7 +1511,7 @@ these two SQL statements are equivalent:
 *DROP [ COLUMN ] Clause*
 ------------------------
 
-The effect of ``ALTER TABLE`` <Table name> ``DROP [COLUMN]`` <Column name> 
+The effect of ``ALTER TABLE`` <Table name> ``DROP [COLUMN]`` <Column name>
 ``RESTRICT``, e.g.:
 
 ::
@@ -1517,34 +1519,34 @@ The effect of ``ALTER TABLE`` <Table name> ``DROP [COLUMN]`` <Column name>
    ALTER TABLE Table_1 DROP COLUMN
       column_1 RESTRICT;
 
-is that the Column named is removed from the definition of the Table 
-that owns it, provided that the Column is not referred to in any View 
-definition, SQL routine, Trigger definition or in any Constraint or 
-Assertion definition (with one exception) -- and, if the Column is the 
-system-generated Column of its Table, provided that the Table is not 
-named in any ``SCOPE`` clause. That is, ``RESTRICT`` ensures that only a 
-Column with no dependent Objects can be destroyed. If the Column is used 
-by any other Object, ``ALTER TABLE ... DROP COLUMN RESTRICT`` will fail. 
-(Note: A Column referred to in a <Table Constraint> of the Table that 
-owns the Column can be dropped despite the ``RESTRICT <keyword>`` if it 
-is the only Column that the <Table Constraint> operates on.) The Column 
-named may not be the only Column in its Table, since a Table must always 
-contain at least one Column. If the Table is a typed Base table, the 
-Column named must be the Table's referenceable Column. 
+is that the Column named is removed from the definition of the Table
+that owns it, provided that the Column is not referred to in any View
+definition, SQL routine, Trigger definition or in any Constraint or
+Assertion definition (with one exception) -- and, if the Column is the
+system-generated Column of its Table, provided that the Table is not
+named in any ``SCOPE`` clause. That is, ``RESTRICT`` ensures that only a
+Column with no dependent Objects can be destroyed. If the Column is used
+by any other Object, ``ALTER TABLE ... DROP COLUMN RESTRICT`` will fail.
+(Note: A Column referred to in a <Table Constraint> of the Table that
+owns the Column can be dropped despite the ``RESTRICT <keyword>`` if it
+is the only Column that the <Table Constraint> operates on.) The Column
+named may not be the only Column in its Table, since a Table must always
+contain at least one Column. If the Table is a typed Base table, the
+Column named must be the Table's referenceable Column.
 
-The effect of ``ALTER TABLE`` <Table name> ``DROP [COLUMN]`` <Column 
-name> ``CASCADE``, e.g.: 
+The effect of ``ALTER TABLE`` <Table name> ``DROP [COLUMN]`` <Column
+name> ``CASCADE``, e.g.:
 
 ::
 
    ALTER TABLE Table_1 DROP COLUMN
       column_1 CASCADE;
 
-is that the Column named is removed from the definition of the Table 
-that owns it and that all Objects which are dependent on the Column are 
-also dropped. The <keyword> ``COLUMN`` in the ``DROP [COLUMN]`` clause 
-is noise and can be omitted. For example, these two SQL statements are 
-equivalent: 
+is that the Column named is removed from the definition of the Table
+that owns it and that all Objects which are dependent on the Column are
+also dropped. The <keyword> ``COLUMN`` in the ``DROP [COLUMN]`` clause
+is noise and can be omitted. For example, these two SQL statements are
+equivalent:
 
 ::
 
@@ -1560,10 +1562,10 @@ Dropping a Column from a Table has a six-fold effect:
    1; the ordinal position of each Column that followed this Column in the
    Table's definition is adjusted accordingly.
 
-2. The ``INSERT``, ``UPDATE``, ``SELECT`` and ``REFERENCES`` Privileges on 
-   the Column are revoked (by the SQL special grantor, "``_SYSTEM``") from 
-   the <AuthorizationID> that owns the Column's Table with a ``CASCADE`` 
-   drop behaviour, so that the same Privileges are also revoked from all 
+2. The ``INSERT``, ``UPDATE``, ``SELECT`` and ``REFERENCES`` Privileges on
+   the Column are revoked (by the SQL special grantor, "``_SYSTEM``") from
+   the <AuthorizationID> that owns the Column's Table with a ``CASCADE``
+   drop behaviour, so that the same Privileges are also revoked from all
    other <AuthorizationID>s.
 
 3. Any Trigger whose definition explicitly includes the Column is
@@ -1575,7 +1577,7 @@ Dropping a Column from a Table has a six-fold effect:
 
 5. If the Column is the system-generated Column of its Table, the
    Table's definition is changed so that it no longer shows the Table to be a
-   referenceable Base table and the Table is removed from every ``SCOPE`` 
+   referenceable Base table and the Table is removed from every ``SCOPE``
    clause that includes it.
 
 6. The data in the Column is destroyed.
@@ -1596,44 +1598,44 @@ is that one <Table Constraint> is added to the definition of the Table named
 *DROP CONSTRAINT Clause*
 ------------------------
 
-The effect of ``ALTER TABLE`` <Table name> ``DROP CONSTRAINT`` <Constraint 
+The effect of ``ALTER TABLE`` <Table name> ``DROP CONSTRAINT`` <Constraint
 name> ``RESTRICT``, e.g.:
 
 ::
 
    ALTER TABLE Table_1 DROP CONSTRAINT constraint_1 RESTRICT;
 
-is that the Constraint named is removed from the definition of the Table that 
-owns it, provided that the Constraint is not used by any SQL routine, and 
-provided that no other Constraint and no View are dependent on the Constraint. 
-(A ``FOREIGN KEY`` Constraint is dependent on the ``UNIQUE`` or ``PRIMARY KEY`` 
-Constraint that names its referenced Columns and a View is dependent on a 
-Constraint if *(a)* it's a grouped View that includes a Column which isn't also 
-referred to in a set function and *(b)* if the Constraint is needed to conclude 
-that there is a known functional dependency between the group and the Column 
-named.) That is, ``RESTRICT`` ensures that only a Constraint with no dependent 
-Objects can be dropped. If the Constraint is used by any other Object, ``ALTER 
-TABLE ... DROP CONSTRAINT`` will fail. 
+is that the Constraint named is removed from the definition of the Table that
+owns it, provided that the Constraint is not used by any SQL routine, and
+provided that no other Constraint and no View are dependent on the Constraint.
+(A ``FOREIGN KEY`` Constraint is dependent on the ``UNIQUE`` or ``PRIMARY KEY``
+Constraint that names its referenced Columns and a View is dependent on a
+Constraint if *(a)* it's a grouped View that includes a Column which isn't also
+referred to in a set function and *(b)* if the Constraint is needed to conclude
+that there is a known functional dependency between the group and the Column
+named.) That is, ``RESTRICT`` ensures that only a Constraint with no dependent
+Objects can be dropped. If the Constraint is used by any other Object, ``ALTER
+TABLE ... DROP CONSTRAINT`` will fail.
 
-The effect of ``ALTER TABLE`` <Table name> ``DROP CONSTRAINT`` <Constraint 
+The effect of ``ALTER TABLE`` <Table name> ``DROP CONSTRAINT`` <Constraint
 name> ``CASCADE``, e.g.:
 
 ::
 
    ALTER TABLE Table_1 DROP CONSTRAINT constraint_1 CASCADE;
 
-is that the Constraint named is removed from the definition of the Table that 
-owns it and that all dependent Constraints, Views and SQL routines are also 
-dropped with a ``CASCADE`` drop behaviour. (Note: If the dropped Constraint 
-caused one or more Columns to have the "known not nullable" nullability 
-characteristic, then the affected Columns' nullability characteristic becomes 
-"possibly nullable" unless some other Constraint also constrains them to non- 
-null values.) 
+is that the Constraint named is removed from the definition of the Table that
+owns it and that all dependent Constraints, Views and SQL routines are also
+dropped with a ``CASCADE`` drop behaviour. (Note: If the dropped Constraint
+caused one or more Columns to have the "known not nullable" nullability
+characteristic, then the affected Columns' nullability characteristic becomes
+"possibly nullable" unless some other Constraint also constrains them to non-
+null values.)
 
-If you want to restrict your code to Core SQL, don't use ``ALTER TABLE`` to 
-drop a Column from a Table, to change a <Column definition> using any of the 
-available options, to add a Constraint to a Table or to drop a Constraint from 
-a Table. 
+If you want to restrict your code to Core SQL, don't use ``ALTER TABLE`` to
+drop a Column from a Table, to change a <Column definition> using any of the
+available options, to add a Constraint to a Table or to drop a Constraint from
+a Table.
 
 DROP TABLE statement
 ====================
@@ -1645,13 +1647,13 @@ The ``DROP TABLE`` statement destroys a Base table. The required syntax for the
 
     DROP TABLE <Table name> {RESTRICT | CASCADE}
 
-``DROP TABLE`` destroys a Base table and its data. The <Table name> must 
-identify an existing Base table whose owner is either the current 
-<AuthorizationID> or a Role that the current <AuthorizationID> may use. That 
-is, only the <AuthorizationID> that owns the Table may drop it. ``DROP TABLE`` 
-can be used to drop a persistent Base table, a ``GLOBAL TEMPORARY`` Base table 
-or a created ``LOCAL TEMPORARY`` Base table, but you can't use it to drop a 
-declared ``LOCAL TEMPORARY`` Base table. 
+``DROP TABLE`` destroys a Base table and its data. The <Table name> must
+identify an existing Base table whose owner is either the current
+<AuthorizationID> or a Role that the current <AuthorizationID> may use. That
+is, only the <AuthorizationID> that owns the Table may drop it. ``DROP TABLE``
+can be used to drop a persistent Base table, a ``GLOBAL TEMPORARY`` Base table
+or a created ``LOCAL TEMPORARY`` Base table, but you can't use it to drop a
+declared ``LOCAL TEMPORARY`` Base table.
 
 The effect of ``DROP TABLE <Table name> RESTRICT``, e.g.:
 
@@ -1686,8 +1688,8 @@ Successfully destroying a Table has a five-fold effect:
    subtables.
 
 4. All Privileges held on the Table by the <AuthorizationID> that owns
-   it are revoked (by the SQL special grantor, "``_SYSTEM``") with a 
-   ``CASCADE`` revoke behaviour, so that all Privileges held on the Table by 
+   it are revoked (by the SQL special grantor, "``_SYSTEM``") with a
+   ``CASCADE`` revoke behaviour, so that all Privileges held on the Table by
    any other <AuthorizationID> are also revoked.
 
 5. All SQL routines, Views, Constraints, Assertions and Triggers that
@@ -1699,9 +1701,9 @@ behaviour for your ``DROP TABLE`` statements.
 CREATE VIEW Statement
 =====================
 
-The ``CREATE VIEW`` statement names a new View and defines the query which, 
-when evaluated, determines the rows of data that are shown in the View. The 
-required syntax for the ``CREATE VIEW`` statement is: 
+The ``CREATE VIEW`` statement names a new View and defines the query which,
+when evaluated, determines the rows of data that are shown in the View. The
+required syntax for the ``CREATE VIEW`` statement is:
 
 ::
 
@@ -1719,15 +1721,15 @@ Schema it belongs to.
   to. A <Table name> that includes an explicit <Schema name> qualifier belongs
   to the Schema named. A <Table name> that does not include an explicit <Schema
   name> qualifier belongs to the SQL-session default Schema. The <Table name>
-  must be unique (for all Base tables and Views) within the Schema that owns 
+  must be unique (for all Base tables and Views) within the Schema that owns
   it.
 
-If ``CREATE VIEW`` is part of a ``CREATE SCHEMA`` statement, the <Table name>, 
-if explicitly qualified, must include the <Schema name> of the Schema being 
-created; that is, it isn't possible to create a View belonging to a different 
-Schema from within ``CREATE SCHEMA``. For example, this SQL statement will not 
-return an error because the <Table name> will default to include the qualifying 
-<Schema name>: 
+If ``CREATE VIEW`` is part of a ``CREATE SCHEMA`` statement, the <Table name>,
+if explicitly qualified, must include the <Schema name> of the Schema being
+created; that is, it isn't possible to create a View belonging to a different
+Schema from within ``CREATE SCHEMA``. For example, this SQL statement will not
+return an error because the <Table name> will default to include the qualifying
+<Schema name>:
 
 ::
 
@@ -1750,8 +1752,8 @@ name of the Schema being created:
          SELECT column_1 FROM bob.Table_1;
       -- creates a View called BOB.VIEW_1 in Schema BOB
 
-But this SQL statement will return an error because the <Table name> 
-explicitly includes a qualifying <Schema name> that is different from the 
+But this SQL statement will return an error because the <Table name>
+explicitly includes a qualifying <Schema name> that is different from the
 name of the Schema being created:
 
 ::
@@ -1765,27 +1767,27 @@ name of the Schema being created:
 *Privileges*
 ------------
 
-If ``CREATE VIEW`` is executed as a stand-alone SQL statement, the current 
-<AuthorizationID> must either be the owner of the Schema that this new View 
-belongs to, or the Schema's owner must be a Role that the current 
-<AuthorizationID> may use. That is, only the owner of a Schema can create Views 
-for that Schema. The current <AuthorizationID> must also have the ``SELECT`` 
-Privilege on every Column used in the View's query definition. 
+If ``CREATE VIEW`` is executed as a stand-alone SQL statement, the current
+<AuthorizationID> must either be the owner of the Schema that this new View
+belongs to, or the Schema's owner must be a Role that the current
+<AuthorizationID> may use. That is, only the owner of a Schema can create Views
+for that Schema. The current <AuthorizationID> must also have the ``SELECT``
+Privilege on every Column used in the View's query definition.
 
-In addition to creating a View, ``CREATE VIEW`` also causes the SQL special 
-grantor, "``_SYSTEM``", to grant Privileges on the View to the Schema owner 
-<AuthorizationID> (that is, the <AuthorizationID creating the View). Your 
-Privileges on a View stem from your Privileges on the underlying Tables that 
-make up the View. That is, you get the same Privileges on a View that you hold 
-on the Tables/Columns used in the View's query definition -- with the proviso 
-that if you have the ``UPDATE``, ``INSERT`` and/or ``DELETE`` Privileges on a 
-Table and you're creating a non-updatable View, those Privileges will not 
-cascade. So: when you create a View, "``_SYSTEM``" will grant you Table 
-Privileges (any of ``INSERT``, ``SELECT``, ``UPDATE``, ``DELETE`` and 
-``REFERENCES`` that are applicable) on the new View, as well as Column 
-Privileges (any of ``SELECT``, ``INSERT``, ``UPDATE`` and ``REFERENCES`` that 
-are applicable) on every Column of the new View. If your Privileges on the 
-underlying Tables are grantable, your Privileges on the View will be too. 
+In addition to creating a View, ``CREATE VIEW`` also causes the SQL special
+grantor, "``_SYSTEM``", to grant Privileges on the View to the Schema owner
+<AuthorizationID> (that is, the <AuthorizationID creating the View). Your
+Privileges on a View stem from your Privileges on the underlying Tables that
+make up the View. That is, you get the same Privileges on a View that you hold
+on the Tables/Columns used in the View's query definition -- with the proviso
+that if you have the ``UPDATE``, ``INSERT`` and/or ``DELETE`` Privileges on a
+Table and you're creating a non-updatable View, those Privileges will not
+cascade. So: when you create a View, "``_SYSTEM``" will grant you Table
+Privileges (any of ``INSERT``, ``SELECT``, ``UPDATE``, ``DELETE`` and
+``REFERENCES`` that are applicable) on the new View, as well as Column
+Privileges (any of ``SELECT``, ``INSERT``, ``UPDATE`` and ``REFERENCES`` that
+are applicable) on every Column of the new View. If your Privileges on the
+underlying Tables are grantable, your Privileges on the View will be too.
 
 That is, Views are Tables, but when it comes to Privileges, there are some big
 differences between the things that happen for Base tables, and the things
@@ -1803,19 +1805,19 @@ possess the Privilege on the underlying Table), or you get them explicitly
   destroy it using the ``DROP VIEW`` statement.
 
 * If you have the ``SELECT`` Privilege on every Column that your View is
-  based on, you get the ``SELECT`` Privilege on the View, so you may 
-  ``SELECT`` from the View. If all of your underlying ``SELECT`` Privileges 
-  are grantable, so is your ``SELECT`` Privilege on the View. You inherit 
-  ``REFERENCES`` Privileges in the same way: if you have the ``REFERENCES`` 
-  Privilege on every Column that your View is based on, you get the 
-  ``REFERENCES`` Privilege on the View, so you may use the View in an 
+  based on, you get the ``SELECT`` Privilege on the View, so you may
+  ``SELECT`` from the View. If all of your underlying ``SELECT`` Privileges
+  are grantable, so is your ``SELECT`` Privilege on the View. You inherit
+  ``REFERENCES`` Privileges in the same way: if you have the ``REFERENCES``
+  Privilege on every Column that your View is based on, you get the
+  ``REFERENCES`` Privilege on the View, so you may use the View in an
   Assertion.
 
 * You inherit ``INSERT``, ``UPDATE`` and ``DELETE`` Privileges in the same way,
   with a major exception: these Privileges cannot exist if the View is not
-  updatable. That explains why, when you try to update a non-updatable View, 
-  the likely error is ``"Syntax error or access violation"`` -- the ultimate 
-  cause is the non-updatability, but the immediate cause at update time is 
+  updatable. That explains why, when you try to update a non-updatable View,
+  the likely error is ``"Syntax error or access violation"`` -- the ultimate
+  cause is the non-updatability, but the immediate cause at update time is
   that you lack the appropriate Privilege.
 
 * In addition to the inherited Privileges, you may hold Privileges
@@ -1830,11 +1832,11 @@ possess the Privilege on the underlying Table), or you get them explicitly
 *<Column name> Clause*
 ----------------------
 
-The optional parenthesized <Column name> clause of the ``CREATE VIEW`` 
-statement explicitly names the View's Columns. (As is usual with Tables, each 
-Column must have a name that is unique -- for all Columns -- within the View.) 
-If you omit this clause, the View's Columns will inherit the names of the 
-Columns they are based on. For example, consider these two SQL statements: 
+The optional parenthesized <Column name> clause of the ``CREATE VIEW``
+statement explicitly names the View's Columns. (As is usual with Tables, each
+Column must have a name that is unique -- for all Columns -- within the View.)
+If you omit this clause, the View's Columns will inherit the names of the
+Columns they are based on. For example, consider these two SQL statements:
 
 ::
 
@@ -1852,21 +1854,21 @@ Because the <Column name> clause is omitted, the View's Column will be named
    CREATE VIEW View_1 (view_column) AS
       SELECT column_1 FROM Table_1;
 
-Because the <Column name> clause is included, the View's Column will be named 
-``VIEW_COLUMN`` -- even though the Column it's based on has a different name. 
-Note that if you do use the <Column name> clause, you must provide a name for 
-every one of the View's Columns -- it isn't possible to name some, and allow 
-the others to default. 
+Because the <Column name> clause is included, the View's Column will be named
+``VIEW_COLUMN`` -- even though the Column it's based on has a different name.
+Note that if you do use the <Column name> clause, you must provide a name for
+every one of the View's Columns -- it isn't possible to name some, and allow
+the others to default.
 
-There are times when you may not omit the <Column name> clause. You must 
-explicitly name a View's Columns if *(a)* any of the Columns are derived 
-through the use of a set function, scalar function, <literal> or expression, 
-since none of these have a <Column name> which ``CREATE VIEW`` can inherit, 
-*(b)* the same name would be inherited for more than one of the View's Columns, 
-usually the case when the View is derived from a join of multiple Tables or 
-*(c)* when you're defining a ``RECURSIVE`` View (see below). Here's an example 
-that shows a View definition where the <Column name> clause is mandatory 
-because the second and third Columns have no name to inherit: 
+There are times when you may not omit the <Column name> clause. You must
+explicitly name a View's Columns if *(a)* any of the Columns are derived
+through the use of a set function, scalar function, <literal> or expression,
+since none of these have a <Column name> which ``CREATE VIEW`` can inherit,
+*(b)* the same name would be inherited for more than one of the View's Columns,
+usually the case when the View is derived from a join of multiple Tables or
+*(c)* when you're defining a ``RECURSIVE`` View (see below). Here's an example
+that shows a View definition where the <Column name> clause is mandatory
+because the second and third Columns have no name to inherit:
 
 ::
 
@@ -1874,7 +1876,7 @@ because the second and third Columns have no name to inherit:
       SELECT   column_1, column_1+25, 'explanation'
       FROM     Table_1;
 
-Note, however, that this ``CREATE VIEW`` statement would give you the same 
+Note, however, that this ``CREATE VIEW`` statement would give you the same
 result:
 
 ::
@@ -1891,33 +1893,33 @@ your View query to provide explicit names for the View's Columns.
 *AS Clause*
 -----------
 
-The ``AS`` clause of the ``CREATE VIEW`` statement defines the query that 
-determines the data you'll see each time you look at the View. At any point in 
-time, a View's data consists of the rows that result if its query definition 
-were evaluated. If the query is updatable, then your View is an updatable View. 
-Normally, a "query" is a form of ``SELECT`` statement (it may be also be 
-``VALUES`` or ``TABLE``; we'll define "query" more thoroughly in a later 
-chapter), so you can define a View using pretty well any combination of 
-predicates and search conditions. There are, however, some restrictions: 
+The ``AS`` clause of the ``CREATE VIEW`` statement defines the query that
+determines the data you'll see each time you look at the View. At any point in
+time, a View's data consists of the rows that result if its query definition
+were evaluated. If the query is updatable, then your View is an updatable View.
+Normally, a "query" is a form of ``SELECT`` statement (it may be also be
+``VALUES`` or ``TABLE``; we'll define "query" more thoroughly in a later
+chapter), so you can define a View using pretty well any combination of
+predicates and search conditions. There are, however, some restrictions:
 
 * The query may not contain a host variable or SQL parameter reference.
 
 * The query may not refer to any declared ``LOCAL TEMPORARY`` Tables.
 
-* The query may not use an expression which would result in a View Column 
+* The query may not use an expression which would result in a View Column
   with a ``NO COLLATION`` coercibility attribute.
 
-* The query may not include any references to the View you're defining 
+* The query may not include any references to the View you're defining
   unless you're explicitly defining a ``RECURSIVE`` View.
 
-A View's Columns inherit their <data type> and other attributes and 
+A View's Columns inherit their <data type> and other attributes and
 Constraints from the Columns they're based on.
 
-[Obscure Rule] If a View's query can't be represented in ``INFORMATION_SCHEMA`` 
-without truncation, your DBMS will return the ``SQLSTATE warning 0100A 
-"warning-query expression too long for information schema"``. If you define a 
-View with a query that includes a ``GROUP BY`` and/or a ``HAVING`` clause that 
-isn't in a subquery, the View is known as a *grouped View*. 
+[Obscure Rule] If a View's query can't be represented in ``INFORMATION_SCHEMA``
+without truncation, your DBMS will return the ``SQLSTATE warning 0100A
+"warning-query expression too long for information schema"``. If you define a
+View with a query that includes a ``GROUP BY`` and/or a ``HAVING`` clause that
+isn't in a subquery, the View is known as a *grouped View*.
 
 Macros and Materializers
 ........................
@@ -1928,10 +1930,10 @@ There are two ways to do this.
 
 **The Macro, or Inline, View**
 
-The DBMS sees from the View's query that View ``V`` is based on Base table 
-``T`` so it simply replaces all occurrences of ``V`` with ``T``, and all 
-occurrences of ``V``'s <Column name>s with ``T``'s <Column name>s. Thus, for 
-example: 
+The DBMS sees from the View's query that View ``V`` is based on Base table
+``T`` so it simply replaces all occurrences of ``V`` with ``T``, and all
+occurrences of ``V``'s <Column name>s with ``T``'s <Column name>s. Thus, for
+example:
 
 ::
 
@@ -1947,7 +1949,7 @@ This is conceptually the same as the way that an assembler handles a macro,
 hence the name. A good DBMS will do the entire transformation during the
 prepare stage, outside the runtime path, so it is very unlikely that a View
 query will be measurably slower than a query on the underlying Table if a
-macro transform is possible. However, here's an example where it's not 
+macro transform is possible. However, here's an example where it's not
 possible:
 
 ::
@@ -1957,7 +1959,7 @@ possible:
 
    SELECT AVG(g_count) FROM View_1 WHERE g_count = 5;
 
-This ``SELECT`` statement can't work because the macro transform would 
+This ``SELECT`` statement can't work because the macro transform would
 evaluate to:
 
 ::
@@ -1970,7 +1972,7 @@ and that's not legal SQL syntax.
 
 The DBMS makes a hidden "temporary Base table" with the same definition as the
 Columns in the View, and then populates the temporary Table using the View's
-query. Thus it would handle our difficult-to-do-with-a-macro View (above) 
+query. Thus it would handle our difficult-to-do-with-a-macro View (above)
 like this:
 
 ::
@@ -1993,39 +1995,39 @@ becomes:
 
    SELECT AVG(g_count) FROM Some_Table_Name;
 
-A materialized View is more flexible and is easier to implement than a macro 
-View because the method of creation is always the same, and because any query 
-expression is transformable. On the negative side of the ledger, it usually 
-takes extra time to populate the temporary Table: the DBMS is not just 
-"selecting from Table A", it's "selecting from Table A and putting the results 
-in Table B, then selecting from Table B". And, if we consider any operation 
-other than ``SELECT`` or ``REFERENCE``, we quickly see that the temporary Table 
-is useless -- for example, when we ``INSERT`` into a View we want the insertion 
-to happen on the actual Table, not on some ephemeral ad-hoc copy of the actual 
-Base table that disappears when we ``SELECT`` again. So, we expect that a good 
-DBMS will use macro Views for simple queries and switch to materialized Views 
-when the going gets rough. 
+A materialized View is more flexible and is easier to implement than a macro
+View because the method of creation is always the same, and because any query
+expression is transformable. On the negative side of the ledger, it usually
+takes extra time to populate the temporary Table: the DBMS is not just
+"selecting from Table A", it's "selecting from Table A and putting the results
+in Table B, then selecting from Table B". And, if we consider any operation
+other than ``SELECT`` or ``REFERENCE``, we quickly see that the temporary Table
+is useless -- for example, when we ``INSERT`` into a View we want the insertion
+to happen on the actual Table, not on some ephemeral ad-hoc copy of the actual
+Base table that disappears when we ``SELECT`` again. So, we expect that a good
+DBMS will use macro Views for simple queries and switch to materialized Views
+when the going gets rough.
 
 Updatable Views
 ...............
 
-We have seen that, when we ``SELECT`` from a View, the DBMS will transform our 
-request into some equivalent request which is a ``SELECT`` from the underlying 
-Base table(s). Now, ``UPDATE`` or ``INSERT`` or ``DELETE`` operations 
-("updates" for short) must also involve a change to the underlying Base tables, 
-otherwise they would be pointless. So, for updates on Views, your DBMS must 
-reverse the transformation. This is often difficult or impossible. The SQL-92 
-rules for updatability are: 
+We have seen that, when we ``SELECT`` from a View, the DBMS will transform our
+request into some equivalent request which is a ``SELECT`` from the underlying
+Base table(s). Now, ``UPDATE`` or ``INSERT`` or ``DELETE`` operations
+("updates" for short) must also involve a change to the underlying Base tables,
+otherwise they would be pointless. So, for updates on Views, your DBMS must
+reverse the transformation. This is often difficult or impossible. The SQL-92
+rules for updatability are:
 
 * The query must be a single ``SELECT ...`` on a single Table, so Views
-  are not updatable if the ``SELECT`` contains select functions (``UNION``, 
-  ``INTERSECT``, ``EXCEPT``, ``CORRESPONDING``) or join operators (``JOIN`` 
-  or joining commas as in ``FROM a,b,c``). The query may also be ``TABLE 
-  <Table name>`` because ``TABLE <Table name>`` is, at bottom, a ``SELECT``. 
-  Rule 1 is relaxed in SQL3, which has the big effect that you can update 
+  are not updatable if the ``SELECT`` contains select functions (``UNION``,
+  ``INTERSECT``, ``EXCEPT``, ``CORRESPONDING``) or join operators (``JOIN``
+  or joining commas as in ``FROM a,b,c``). The query may also be ``TABLE
+  <Table name>`` because ``TABLE <Table name>`` is, at bottom, a ``SELECT``.
+  Rule 1 is relaxed in SQL3, which has the big effect that you can update
   Views of joins.
 
-* The select list may contain only <Column name>s and [``AS`` name] clauses. 
+* The select list may contain only <Column name>s and [``AS`` name] clauses.
   Therefore, this SQL statement defines an updatable View:
 
 ::
@@ -2048,15 +2050,15 @@ many arithmetic and string operations are in fact reversible -- but the DBMS
 doesn't know it.
 
 * There must be no implicit or explicit grouping, so the <keyword>s
-  ``DISTINCT`` or ``GROUP BY`` or ``HAVING``, or any set function, may not 
-  appear in the main query (though they may appear in that query's 
-  subqueries), nor may any subqueries be correlated subqueries (that is, 
-  they may not themselves refer to the Table named in the outer query). Rule 
-  3 cannot be gotten around. For example you can't change the average 
-  salary: you have to change the individual salaries (Joke: unless you're 
-  the Canadian Anti-Poverty Commission which once announced that "most 
-  Canadians make less than the average wage"). However, the rule is 
-  syntax-based -- you might find that, in fact, ``DISTINCT`` is a no-op 
+  ``DISTINCT`` or ``GROUP BY`` or ``HAVING``, or any set function, may not
+  appear in the main query (though they may appear in that query's
+  subqueries), nor may any subqueries be correlated subqueries (that is,
+  they may not themselves refer to the Table named in the outer query). Rule
+  3 cannot be gotten around. For example you can't change the average
+  salary: you have to change the individual salaries (Joke: unless you're
+  the Canadian Anti-Poverty Commission which once announced that "most
+  Canadians make less than the average wage"). However, the rule is
+  syntax-based -- you might find that, in fact, ``DISTINCT`` is a no-op
   (that is, the decision "is it distinct?" is a matter of syntax, not of fact).
 
 * The query may not refer to the View being defined.
@@ -2085,10 +2087,10 @@ the operation transforms straightforwardly to:
 
    UPDATE Table SET column_1 = value;
 
-For ``INSERT`` operations, there is an additional problem if the View is based 
-on only a subset of the Columns of the underlying Base table. In that case, the 
-rest of the Base table's Columns all are set to their default value. For 
-example: 
+For ``INSERT`` operations, there is an additional problem if the View is based
+on only a subset of the Columns of the underlying Base table. In that case, the
+rest of the Base table's Columns all are set to their default value. For
+example:
 
 ::
 
@@ -2120,18 +2122,18 @@ Consider these two SQL statements:
 
    UPDATE View_1 SET view_col_1=4;
 
-The View definition restricts it to those rows of ``TABLE_1`` where 
-``COLUMN_1`` has a value of 5 -- but as soon as the ``UPDATE`` operation 
-succeeds, there will be no such rows. To the user, the apparent effect is that 
-all the rows of ``VIEW_1`` "disappear" -- as if they were deleted instead of 
-updated. That is okay and legal, but doesn't it contradict the View idea? That 
-is, if someone is restricted during ``SELECT`` to finding only those rows that 
-match the condition ``column_1=5``, why should he/she/it be allowed to 
-``UPDATE`` or ``INSERT`` rows that do not follow the same restriction? 
+The View definition restricts it to those rows of ``TABLE_1`` where
+``COLUMN_1`` has a value of 5 -- but as soon as the ``UPDATE`` operation
+succeeds, there will be no such rows. To the user, the apparent effect is that
+all the rows of ``VIEW_1`` "disappear" -- as if they were deleted instead of
+updated. That is okay and legal, but doesn't it contradict the View idea? That
+is, if someone is restricted during ``SELECT`` to finding only those rows that
+match the condition ``column_1=5``, why should he/she/it be allowed to
+``UPDATE`` or ``INSERT`` rows that do not follow the same restriction?
 
-The solution is to use the optional ``WITH CHECK OPTION`` clause in your 
-updatable View definitions (it is valid only if you are defining an updatable 
-View). Adjust the two SQL statements to: 
+The solution is to use the optional ``WITH CHECK OPTION`` clause in your
+updatable View definitions (it is valid only if you are defining an updatable
+View). Adjust the two SQL statements to:
 
 ::
 
@@ -2141,11 +2143,11 @@ View). Adjust the two SQL statements to:
 
    UPDATE View_1 SET view_col_1=4;
 
-and now the ``UPDATE`` statement will fail: your DBMS will return the 
-``SQLSTATE error 44000 "with check option violation"``. The effect of ``WITH 
-CHECK OPTION`` is to say: "the ``WHERE`` clause defines what is in the View and 
-you cannot go outside the bounds of that definition in any ``INSERT`` or 
-``UPDATE`` operation". 
+and now the ``UPDATE`` statement will fail: your DBMS will return the
+``SQLSTATE error 44000 "with check option violation"``. The effect of ``WITH
+CHECK OPTION`` is to say: "the ``WHERE`` clause defines what is in the View and
+you cannot go outside the bounds of that definition in any ``INSERT`` or
+``UPDATE`` operation".
 
 A View's ``CHECK OPTION`` is effectively a Constraint. That is, there is a
 similarity between the two definitions in this example:
@@ -2169,12 +2171,12 @@ similarity between the two definitions in this example:
       INSERT INTO View_1 VALUES(6000);
       -- results in error
 
-If ``WITH CHECK OPTION`` is included in a View definition, then all ``INSERT`` 
-and ``UPDATE`` operations on that View will be checked to ensure that every new 
-row satisfies the View's query conditions. Such "View Constraints" are popular, 
-probably because the ``CREATE VIEW`` statement has been around for a longer 
-time than the Base table ``CHECK`` Constraint. There are a few downsides you 
-should be aware of, though, if you use such View Constraints: 
+If ``WITH CHECK OPTION`` is included in a View definition, then all ``INSERT``
+and ``UPDATE`` operations on that View will be checked to ensure that every new
+row satisfies the View's query conditions. Such "View Constraints" are popular,
+probably because the ``CREATE VIEW`` statement has been around for a longer
+time than the Base table ``CHECK`` Constraint. There are a few downsides you
+should be aware of, though, if you use such View Constraints:
 
 * You do not have the option of deferring Constraint checking. All
   checks happen at the end of the ``INSERT`` or ``UPDATE`` operation.
@@ -2183,14 +2185,14 @@ should be aware of, though, if you use such View Constraints:
   Table Constraint.
 
 * The SQL Standard does not make it clear what the effect should be if
-  ``NULL``\s are used (and therefore make the result of the Constraint check 
+  ``NULL``\s are used (and therefore make the result of the Constraint check
   ``UNKNOWN`` rather than ``TRUE`` or ``FALSE``). For the Base table insertion:
 
 ::
 
    INSERT INTO Table_1 VALUES (NULL);
 
-the answer is clear: there is no error and so the ``INSERT`` is allowed. 
+the answer is clear: there is no error and so the ``INSERT`` is allowed.
 Presumably the same is true for the View insertion:
 
 ::
@@ -2203,8 +2205,8 @@ Regardless of the reasons you use ``WITH CHECK OPTION`` -- as a general
 constrainer or as an encapsulation enforcer -- the View must obey these rules:
 
 * The ``WHERE`` clause must be "deterministic" (this only means that you
-  can't use Columns which might change in value, such as ``CURRENT_TIME``. 
-  For a more complete explanation, see our chapter on Constraints and 
+  can't use Columns which might change in value, such as ``CURRENT_TIME``.
+  For a more complete explanation, see our chapter on Constraints and
   Assertions.
 
 * The View must be updatable.
@@ -2239,25 +2241,25 @@ Suppose you create Views within Views within Views, for example:
 
 .. NOTE::
 
-   A Table used in the definition of another Table is an "immediately 
-   underlying" Table; thus Table ``TABLE_1`` underlies View ``VIEW_1``. 
-   Because ``VIEW_1`` is then used in the definition of ``VIEW_2``, we say 
-   that ``VIEW_1`` immediately underlies ``VIEW_2`` and that ``TABLE_1`` 
-   indirectly underlies ``VIEW_2``. Taken together, both ``TABLE_1`` and 
-   ``VIEW_1`` "generally underlie" ``VIEW_2``: one indirectly and the other 
-   immediately. 
+   A Table used in the definition of another Table is an "immediately
+   underlying" Table; thus Table ``TABLE_1`` underlies View ``VIEW_1``.
+   Because ``VIEW_1`` is then used in the definition of ``VIEW_2``, we say
+   that ``VIEW_1`` immediately underlies ``VIEW_2`` and that ``TABLE_1``
+   indirectly underlies ``VIEW_2``. Taken together, both ``TABLE_1`` and
+   ``VIEW_1`` "generally underlie" ``VIEW_2``: one indirectly and the other
+   immediately.
 
-Our example contains a variety of ``WITH CHECK OPTION`` clauses. To see what 
-their effects are, we will try to do an ``INSERT`` for each of the Views. We 
-begin with ``VIEW_1``: 
+Our example contains a variety of ``WITH CHECK OPTION`` clauses. To see what
+their effects are, we will try to do an ``INSERT`` for each of the Views. We
+begin with ``VIEW_1``:
 
 ::
 
    INSERT INTO View_1 VALUES (0,0,0,0,0);
 
-This ``INSERT`` operation is legal: there is no check option in the View's 
-definition, so the row is inserted into ``TABLE_1`` despite the fact that we 
-won't be able to see that effect by looking at ``VIEW_1``. 
+This ``INSERT`` operation is legal: there is no check option in the View's
+definition, so the row is inserted into ``TABLE_1`` despite the fact that we
+won't be able to see that effect by looking at ``VIEW_1``.
 
 Here's an ``INSERT`` into ``VIEW_2``:
 
@@ -2273,11 +2275,11 @@ second column may not be 0. No surprise there, but this will fail too!:
 
    INSERT INTO View_2 VALUES (0,1,1,1,1);
 
-When you define a View with ``WITH CASCADED CHECK OPTION`` (or with ``WITH 
-CHECK OPTION``) they mean the same thing because ``CASCADED`` is the default), 
-then the check applies not only to the View you're updating, but to every View 
-that underlies it -- and ``VIEW_1`` contains a condition that disallows zeros 
-in ``COLUMN_1``. 
+When you define a View with ``WITH CASCADED CHECK OPTION`` (or with ``WITH
+CHECK OPTION``) they mean the same thing because ``CASCADED`` is the default),
+then the check applies not only to the View you're updating, but to every View
+that underlies it -- and ``VIEW_1`` contains a condition that disallows zeros
+in ``COLUMN_1``.
 
 Here are two ``INSERT``s into ``VIEW_3``:
 
@@ -2287,16 +2289,16 @@ Here are two ``INSERT``s into ``VIEW_3``:
 
    INSERT INTO View_3 VALUES (1,0,1,1,1);
 
-These ``INSERT`` operations will also fail: although ``VIEW_3`` has no check 
-option, its underlying Views do and so operations on ``VIEW_3`` may not violate 
-their conditions. But, since ``VIEW_3`` has no check option of its own, this 
-``INSERT`` is legal: 
+These ``INSERT`` operations will also fail: although ``VIEW_3`` has no check
+option, its underlying Views do and so operations on ``VIEW_3`` may not violate
+their conditions. But, since ``VIEW_3`` has no check option of its own, this
+``INSERT`` is legal:
 
 ::
 
    INSERT INTO View_3 VALUES (1,1,0,1,1);
 
-because there is no check on ``VIEW_3``, or on its underlying Views, that 
+because there is no check on ``VIEW_3``, or on its underlying Views, that
 disallows zeros in ``COLUMN_3``.
 
 Now, here's an ``INSERT`` into ``VIEW_4``:
@@ -2305,16 +2307,16 @@ Now, here's an ``INSERT`` into ``VIEW_4``:
 
    INSERT INTO View_4 VALUES (0,0,0,1,1);
 
-This ``INSERT`` operation is legal. For ``VIEW_4``, there is only one check 
-condition in effect -- that ``COLUMN_4`` may not be zero -- and this condition 
-is satisfied by the ``INSERT``. ``VIEW_3``'s condition -- that ``COLUMN_3`` may 
-not be zero -- doesn't have to be satisfied because ``VIEW_4`` was defined with 
-``WITH LOCAL CHECK OPTION``. This means that, while ``VIEW_4``'s condition will 
-be checked, the conditions of its immediately underlying View will only be 
-checked if that View was defined with a ``WITH CHECK OPTION`` clause (which is 
-not the case for ``VIEW_3``). It also means that the conditions of its 
-indirectly underlying Views (that is, of ``VIEW_1`` and ``VIEW_2``) won't be 
-checked at all, regardless of their ``WITH CHECK OPTION`` definitions. 
+This ``INSERT`` operation is legal. For ``VIEW_4``, there is only one check
+condition in effect -- that ``COLUMN_4`` may not be zero -- and this condition
+is satisfied by the ``INSERT``. ``VIEW_3``'s condition -- that ``COLUMN_3`` may
+not be zero -- doesn't have to be satisfied because ``VIEW_4`` was defined with
+``WITH LOCAL CHECK OPTION``. This means that, while ``VIEW_4``'s condition will
+be checked, the conditions of its immediately underlying View will only be
+checked if that View was defined with a ``WITH CHECK OPTION`` clause (which is
+not the case for ``VIEW_3``). It also means that the conditions of its
+indirectly underlying Views (that is, of ``VIEW_1`` and ``VIEW_2``) won't be
+checked at all, regardless of their ``WITH CHECK OPTION`` definitions.
 
 Finally, here's an ``INSERT`` into ``VIEW_5``:
 
@@ -2322,23 +2324,23 @@ Finally, here's an ``INSERT`` into ``VIEW_5``:
 
    INSERT INTO View_5 VALUES (0,0,0,1,0);
 
-Once again, this ``INSERT`` operation is legal: ``VIEW_5`` has no ``WITH CHECK 
-OPTION`` clause, and so its condition is not checked. However, the View it's 
-based on (``VIEW_4``) does have a ``WITH CHECK OPTION`` clause, and so this 
-``INSERT`` statement will fail: 
+Once again, this ``INSERT`` operation is legal: ``VIEW_5`` has no ``WITH CHECK
+OPTION`` clause, and so its condition is not checked. However, the View it's
+based on (``VIEW_4``) does have a ``WITH CHECK OPTION`` clause, and so this
+``INSERT`` statement will fail:
 
 ::
 
    INSERT INTO View_5 VALUES (1,1,1,0,1);
 
-because ``VIEW_4``'s condition is checked for any ``INSERT`` or ``UPDATE`` 
-operation on ``VIEW_5``. But, since ``VIEW_4`` was defined with ``WITH LOCAL 
-CHECK OPTION``, the View immediately underlying ``VIEW_4`` is the only other 
-View whose conditions will be checked -- and then only if that View was defined 
-with a ``WITH CHECK OPTION`` clause. Thus, for this example, operations on 
-``VIEW_5`` are affected only by the conditions set for ``VIEW_4`` -- 
-``COLUMN_1`` may be zero, ``COLUMN_2`` may be zero and ``COLUMN_3`` may be zero 
-because the conditions for ``VIEW_1``, ``VIEW_2`` and ``VIEW_3`` don't apply. 
+because ``VIEW_4``'s condition is checked for any ``INSERT`` or ``UPDATE``
+operation on ``VIEW_5``. But, since ``VIEW_4`` was defined with ``WITH LOCAL
+CHECK OPTION``, the View immediately underlying ``VIEW_4`` is the only other
+View whose conditions will be checked -- and then only if that View was defined
+with a ``WITH CHECK OPTION`` clause. Thus, for this example, operations on
+``VIEW_5`` are affected only by the conditions set for ``VIEW_4`` --
+``COLUMN_1`` may be zero, ``COLUMN_2`` may be zero and ``COLUMN_3`` may be zero
+because the conditions for ``VIEW_1``, ``VIEW_2`` and ``VIEW_3`` don't apply.
 
 Our example is fairly complex because we mixed all the possibilities together.
 In real life, one avoids the complexity by declaring a company policy: always
@@ -2358,17 +2360,17 @@ Here is a contrived, illegal example of two Views that reference each other:
       CREATE VIEW View_2 (view_2_col_1,view_2_col_2,view_2_col_3) AS
          SELECT view_1_col_1,column_1,'B' FROM Table_1,View_1;
 
-Although the definition of ``VIEW_1`` is legal, the definition of ``VIEW_2`` is 
-not because it defines a recursive View: a View whose query refers to the View 
-being defined -- that is, since ``VIEW_2`` is based on ``VIEW_1``, and since 
-``VIEW_1`` is based on ``VIEW_2``, ultimately, ``VIEW_2`` is based on itself. 
-We used the ``CREATE SCHEMA`` statement for this example because, within 
-``CREATE SCHEMA``, each Column in each View derives ultimately from either a 
-Base table Column or a <literal>, so recursive Views are possible in theory. In 
-reality, though, current DBMSs don't allow them and neither does the SQL-92 
-Standard. In SQL3, though, recursion is allowed provided it's explicit and 
-provided that ``CREATE VIEW`` includes a <Column name> clause but no ``WITH 
-CHECK OPTION`` clause. Thus, with SQL3 only, this SQL statement is possible: 
+Although the definition of ``VIEW_1`` is legal, the definition of ``VIEW_2`` is
+not because it defines a recursive View: a View whose query refers to the View
+being defined -- that is, since ``VIEW_2`` is based on ``VIEW_1``, and since
+``VIEW_1`` is based on ``VIEW_2``, ultimately, ``VIEW_2`` is based on itself.
+We used the ``CREATE SCHEMA`` statement for this example because, within
+``CREATE SCHEMA``, each Column in each View derives ultimately from either a
+Base table Column or a <literal>, so recursive Views are possible in theory. In
+reality, though, current DBMSs don't allow them and neither does the SQL-92
+Standard. In SQL3, though, recursion is allowed provided it's explicit and
+provided that ``CREATE VIEW`` includes a <Column name> clause but no ``WITH
+CHECK OPTION`` clause. Thus, with SQL3 only, this SQL statement is possible:
 
 ::
 
@@ -2379,21 +2381,21 @@ CHECK OPTION`` clause. Thus, with SQL3 only, this SQL statement is possible:
       CREATE RECURSIVE VIEW View_2 (view_2_col_1,view_2_col_2,view_2_col_3) AS
          SELECT view_1_col_1,column_1,'B' FROM Table_1,View_1;
 
-If you want to restrict your code to Core SQL, don't define any ``RECURSIVE`` 
-Views, don't use the ``EXCEPT``, ``INTERSECT`` or ``CORRESPONDING`` operators 
-in your View queries and don't use the optional ``CASCADED`` or ``LOCAL`` 
-levels specification in your check clauses -- always define Views only with 
-``WITH CHECK OPTION`` alone. 
+If you want to restrict your code to Core SQL, don't define any ``RECURSIVE``
+Views, don't use the ``EXCEPT``, ``INTERSECT`` or ``CORRESPONDING`` operators
+in your View queries and don't use the optional ``CASCADED`` or ``LOCAL``
+levels specification in your check clauses -- always define Views only with
+``WITH CHECK OPTION`` alone.
 
 Getting More Out Of Views
 =========================
 
-A View's virtue is that it isn't the whole picture. Something is hidden. Hidden 
-is good. In the following descriptions, which all show Views being put to some 
-useful purpose, the same refrain could be sung each time: "Views Hide -- Good". 
+A View's virtue is that it isn't the whole picture. Something is hidden. Hidden
+is good. In the following descriptions, which all show Views being put to some
+useful purpose, the same refrain could be sung each time: "Views Hide -- Good".
 
-One thing we'd like to hide, or abstract, is the retrieval method. For a 
-mailing list, the method might look like this: 
+One thing we'd like to hide, or abstract, is the retrieval method. For a
+mailing list, the method might look like this:
 
 ::
 
@@ -2431,13 +2433,13 @@ sales. For them we want to say:
       FROM Sales
       GROUP BY manager;
 
-... and they can select whatever they like from ``VIEW_1`` (which is an example 
-of a "grouped View"). 
+... and they can select whatever they like from ``VIEW_1`` (which is an example
+of a "grouped View").
 
-The next thing we want to hide is secrets. We could grant ``PUBLIC`` access to 
-some grouped Views, or we could grant ``PUBLIC`` access to only certain Columns 
-in certain Tables. In fact, granting on Column-subset Views is the normal way 
-to do a by-Column ``GRANT`` (see our chapter on AuthorizationIDs). 
+The next thing we want to hide is secrets. We could grant ``PUBLIC`` access to
+some grouped Views, or we could grant ``PUBLIC`` access to only certain Columns
+in certain Tables. In fact, granting on Column-subset Views is the normal way
+to do a by-Column ``GRANT`` (see our chapter on AuthorizationIDs).
 
 
 .. TIP::
@@ -2462,7 +2464,7 @@ to do a by-Column ``GRANT`` (see our chapter on AuthorizationIDs).
 DROP VIEW Statement
 ===================
 
-The ``DROP VIEW`` statement destroys a View. The required syntax for the 
+The ``DROP VIEW`` statement destroys a View. The required syntax for the
 ``DROP VIEW`` statement is:
 
 ::
@@ -2484,8 +2486,8 @@ The effect of ``DROP VIEW <Table name> RESTRICT``, e.g.:
 is that the View named is destroyed, provided that the View is not referred to
 in any other View definition and is not referred to in any Constraint
 definition, Assertion definition, Trigger definition or SQL routine. That is,
-``RESTRICT`` ensures that only a View with no dependent Objects can be 
-destroyed. If the View is used by any other Object, ``DROP VIEW ... 
+``RESTRICT`` ensures that only a View with no dependent Objects can be
+destroyed. If the View is used by any other Object, ``DROP VIEW ...
 RESTRICT`` will fail.
 
 The effect of ``DROP VIEW <Table name> CASCADE``, e.g.:
@@ -2500,15 +2502,15 @@ Successfully destroying a View has a three-fold effect:
 
 1. The View named is destroyed.
 
-2. All Privileges held on the View by the <AuthorizationID> that owns it are 
-   revoked (by the SQL special grantor, "``_SYSTEM``") with a ``CASCADE`` 
-   revoke behaviour, so that all Privileges held on the View by any other 
-   <AuthorizationID> are also revoked. 
+2. All Privileges held on the View by the <AuthorizationID> that owns it are
+   revoked (by the SQL special grantor, "``_SYSTEM``") with a ``CASCADE``
+   revoke behaviour, so that all Privileges held on the View by any other
+   <AuthorizationID> are also revoked.
 
-3. All SQL routines, Views, Constraints, Assertions and Triggers that depend 
+3. All SQL routines, Views, Constraints, Assertions and Triggers that depend
    on the View are dropped with a ``CASCADE`` drop behaviour.
 
-If you want to restrict your code to Core SQL, don't use the ``CASCADE`` 
+If you want to restrict your code to Core SQL, don't use the ``CASCADE``
 drop behaviour for your ``DROP VIEW`` statements.
 
 DECLARE TABLE Statement
@@ -2530,10 +2532,10 @@ and defines the Table's Columns and Constraints. The required syntax for the
              LIKE <Table name> |
              <Column name> WITH OPTIONS <column option list>
 
-``DECLARE LOCAL TEMPORARY TABLE`` defines a new declared local temporary Base 
-table. You can only use this SQL statement within a ``MODULE`` statement. 
-Declared temporary Tables aren't part of the Table metadata in 
-``INFORMATION_SCHEMA``. 
+``DECLARE LOCAL TEMPORARY TABLE`` defines a new declared local temporary Base
+table. You can only use this SQL statement within a ``MODULE`` statement.
+Declared temporary Tables aren't part of the Table metadata in
+``INFORMATION_SCHEMA``.
 
 In effect, a declared local temporary Table does not exist until it is invoked
 by an SQL-client Module during an SQL-session. Once invoked, it will only be
@@ -2544,13 +2546,13 @@ invoked during the SQL-session are dropped.
 * The <Table name> identifies the Table and the Module that it belongs
   to and must be unique (for all declared local temporary Base tables) within
   the Module that owns it. Because a declared local temporary Table is distinct
-  within an SQL-client Module within an SQL-session, the Schema it belongs 
-  to is a Schema determined by your DBMS, so don't add a qualifying <Schema 
-  name> when you declare a temporary Table. (In effect, your DBMS will fix a 
-  qualifying <Schema name> for a declared local temporary Table based on the 
-  DBMS's name for the SQL-session in which you invoke that Table, coupled 
-  with its name for the SQL-client Module that contains that Table's 
-  declaration.) Whenever you refer to a declared local temporary Table, you 
+  within an SQL-client Module within an SQL-session, the Schema it belongs
+  to is a Schema determined by your DBMS, so don't add a qualifying <Schema
+  name> when you declare a temporary Table. (In effect, your DBMS will fix a
+  qualifying <Schema name> for a declared local temporary Table based on the
+  DBMS's name for the SQL-session in which you invoke that Table, coupled
+  with its name for the SQL-client Module that contains that Table's
+  declaration.) Whenever you refer to a declared local temporary Table, you
   must preface the <Table name> with ``MODULE``.
 
 The <table element> clause defines the structure of the Table's contents: it
@@ -2558,7 +2560,7 @@ tells you what sort of data the Table contains. This clause is contains a list
 of table elements, such as Column and Table Constraint definitions, that are
 just like the elements we described for the ``CREATE TABLE`` statement -- see
 those descriptions for detailed information. Every temporary Table declaration
-has to contain at least one <Column definition>. Here are two equivalent 
+has to contain at least one <Column definition>. Here are two equivalent
 examples:
 
 ::
@@ -2577,11 +2579,11 @@ examples:
       CONSTRAINT constraint_1 UNIQUE(column_1)
       CONSTRAINT constraint_2 CHECK(column_3 IS NOT NULL));
 
-When you declare a local temporary Table, you may use the ``ON COMMIT`` clause 
-to specify whether you want the Table to be emptied whenever a ``COMMIT`` 
-statement is executed. If you omit the ``ON COMMIT`` clause from ``DECLARE 
-LOCAL TEMPORARY TABLE``, it defaults to ``ON COMMIT DELETE ROWS``. For example, 
-these two SQL statements are equivalent: 
+When you declare a local temporary Table, you may use the ``ON COMMIT`` clause
+to specify whether you want the Table to be emptied whenever a ``COMMIT``
+statement is executed. If you omit the ``ON COMMIT`` clause from ``DECLARE
+LOCAL TEMPORARY TABLE``, it defaults to ``ON COMMIT DELETE ROWS``. For example,
+these two SQL statements are equivalent:
 
 ::
 
@@ -2600,9 +2602,9 @@ Based on this Table declaration, the effect of these two SQL statements:
 
    COMMIT;
 
-is that ``TABLE_1`` is first materialized and has data inserted into it, and 
-then the rows are deleted. That is, at ``COMMIT`` time, your DBMS effectively 
-executes this SQL statement: 
+is that ``TABLE_1`` is first materialized and has data inserted into it, and
+then the rows are deleted. That is, at ``COMMIT`` time, your DBMS effectively
+executes this SQL statement:
 
 ::
 
@@ -2621,36 +2623,36 @@ since the declaration of ``TABLE_1`` states that the Table is to be emptied at
 
    COMMIT;
 
-is that ``TABLE_1`` is declared, materialized and has data inserted into it, 
-and then the rows are committed. That is, at ``COMMIT`` time, your DBMS does 
-not delete the rows, since ``TABLE_1``'s declaration explicitly says not to. 
-(The rows will, however, be deleted at the end of the SQL-session.) 
+is that ``TABLE_1`` is declared, materialized and has data inserted into it,
+and then the rows are committed. That is, at ``COMMIT`` time, your DBMS does
+not delete the rows, since ``TABLE_1``'s declaration explicitly says not to.
+(The rows will, however, be deleted at the end of the SQL-session.)
 
-In addition to declaring a Table, ``DECLARE LOCAL TEMPORARY TABLE`` also causes 
-the SQL special grantor, "``_SYSTEM``", to grant non-grantable ``INSERT``, 
-``SELECT``, ``UPDATE``, ``DELETE`` and ``REFERENCES`` Privileges on the 
-declared Table, as well as non-grantable ``SELECT``, ``INSERT``, ``UPDATE`` and 
-``REFERENCES`` Privileges on every Column in the declared Table, to the current 
-<AuthorizationID>. This ensures that the Table may be materialized, and 
-operated on, by any <AuthorizationID> that can run the Module that contains the 
-Table declaration. 
+In addition to declaring a Table, ``DECLARE LOCAL TEMPORARY TABLE`` also causes
+the SQL special grantor, "``_SYSTEM``", to grant non-grantable ``INSERT``,
+``SELECT``, ``UPDATE``, ``DELETE`` and ``REFERENCES`` Privileges on the
+declared Table, as well as non-grantable ``SELECT``, ``INSERT``, ``UPDATE`` and
+``REFERENCES`` Privileges on every Column in the declared Table, to the current
+<AuthorizationID>. This ensures that the Table may be materialized, and
+operated on, by any <AuthorizationID> that can run the Module that contains the
+Table declaration.
 
-If you want to restrict your code to Core SQL, don't use the ``DECLARE LOCAL 
-TEMPORARY TABLE`` statement. 
+If you want to restrict your code to Core SQL, don't use the ``DECLARE LOCAL
+TEMPORARY TABLE`` statement.
 
 Dialects
 ========
 
-Some vendors relax the rules on what may be an updatable View. For example, 
-IBM's DB2 will let you ``DELETE`` from Views whose queries contain arithmetic 
-expressions, and will even let you ``UPDATE`` such Views provided you don't try 
-to update the Column derived from the expression. 
+Some vendors relax the rules on what may be an updatable View. For example,
+IBM's DB2 will let you ``DELETE`` from Views whose queries contain arithmetic
+expressions, and will even let you ``UPDATE`` such Views provided you don't try
+to update the Column derived from the expression.
 
-Although the Full-SQL syntax for the check option clause is ``WITH [ 
-{CASCADED|LOCAL} ] CHECK OPTION``, the majority of vendors only allow the 
-optionless syntax ``WITH CHECK OPTION``, which is all that's required for Core 
-SQL. In general, the check option is always ``CASCADED`` (as required by the 
-Standard), but there was a time when the default was ``LOCAL`` so some caution 
-is necessary. Sometimes ``WITH CHECK OPTION`` may be illegal even though the 
-View is updatable; for example IBM's DB2 once insisted that there could be no 
+Although the Full-SQL syntax for the check option clause is ``WITH [
+{CASCADED|LOCAL} ] CHECK OPTION``, the majority of vendors only allow the
+optionless syntax ``WITH CHECK OPTION``, which is all that's required for Core
+SQL. In general, the check option is always ``CASCADED`` (as required by the
+Standard), but there was a time when the default was ``LOCAL`` so some caution
+is necessary. Sometimes ``WITH CHECK OPTION`` may be illegal even though the
+View is updatable; for example IBM's DB2 once insisted that there could be no
 subqueries in the View definition.

--- a/docs/chapters/19.rst
+++ b/docs/chapters/19.rst
@@ -4,7 +4,9 @@
 Chapter 19 -- SQL Domain
 ========================
 
-In this chapter, we'll describe SQL Domains in detail, and show you the 
+.. include:: ../_include/note.rst
+
+In this chapter, we'll describe SQL Domains in detail, and show you the
 syntax to use to create, alter and destroy them.
 
 .. rubric:: Table of Contents
@@ -15,48 +17,48 @@ syntax to use to create, alter and destroy them.
 Domain
 ======
 
-A Schema may contain zero or more Domains. An SQL Domain is a named, 
-user-defined set of valid values. Domains are dependent on some Schema -- the 
-<Domain name> must be unique within the Schema the Domain belongs to (it may 
-not be the same as any <UDT name> in its Schema either) -- and are created, 
-altered and dropped using standard SQL statements. The Objects that may belong 
-to a Domain are known as Domain Constraints; they depend on some Domain. 
+A Schema may contain zero or more Domains. An SQL Domain is a named,
+user-defined set of valid values. Domains are dependent on some Schema -- the
+<Domain name> must be unique within the Schema the Domain belongs to (it may
+not be the same as any <UDT name> in its Schema either) -- and are created,
+altered and dropped using standard SQL statements. The Objects that may belong
+to a Domain are known as Domain Constraints; they depend on some Domain.
 
 A Domain is defined by a descriptor that contains seven pieces of information:
 
-1. The <Domain name>, qualified by the <Schema name> of the Schema it belongs 
+1. The <Domain name>, qualified by the <Schema name> of the Schema it belongs
    to.
 
-2. The Domain's SQL <data type> specification, including its name, length, 
+2. The Domain's SQL <data type> specification, including its name, length,
    precision and scale, as applicable.
 
-3. The name of the Character set that the Domain's set of values must belong 
+3. The name of the Character set that the Domain's set of values must belong
    to (for character string types).
 
-4. The name of the Domain's default Collation. (This is the Collation that 
-   may be used to compare a character string Domain's values in the absence of 
+4. The name of the Domain's default Collation. (This is the Collation that
+   may be used to compare a character string Domain's values in the absence of
    an explicit ``COLLATE`` clause.)
 
-5. Whether reference values must be checked and whether <reference scope 
+5. Whether reference values must be checked and whether <reference scope
    check action> specifies ``RESTRICT`` or ``SET NULL`` (for ``REF`` types).
 
 6. The Domain's default value (if any).
 
 7. A descriptor for every Constraint that belongs to the Domain.
 
-To create a Domain, use the ``CREATE DOMAIN`` statement (either as a 
-stand-alone SQL statement or within a ``CREATE SCHEMA`` statement). ``CREATE 
-DOMAIN`` specifies the enclosing Schema, names the Domain and identifies the 
-Domain's set of valid values. To change an existing Domain, use the ``ALTER 
-DOMAIN`` statement. To destroy a Domain, use the ``DROP DOMAIN`` statement. 
+To create a Domain, use the ``CREATE DOMAIN`` statement (either as a
+stand-alone SQL statement or within a ``CREATE SCHEMA`` statement). ``CREATE
+DOMAIN`` specifies the enclosing Schema, names the Domain and identifies the
+Domain's set of valid values. To change an existing Domain, use the ``ALTER
+DOMAIN`` statement. To destroy a Domain, use the ``DROP DOMAIN`` statement.
 
-There is a one-to-many association between Domains and Columns: one Domain 
+There is a one-to-many association between Domains and Columns: one Domain
 can be used to identify the set of valid values for multiple Columns.
 
 *Domain names*
 --------------
 
-A <Domain name> identifies a Domain. The required syntax for a <Domain name> 
+A <Domain name> identifies a Domain. The required syntax for a <Domain name>
 is:
 
 ::
@@ -67,15 +69,15 @@ is:
 A <Domain name> is a <regular identifier> or a <delimited identifier> that is
 unique (for all Domains and UDTs) within the Schema it belongs to. The <Schema
 name> which qualifies a <Domain name> names the Schema that the Domain belongs
-to and can either be explicitly stated, or a default will be supplied by 
+to and can either be explicitly stated, or a default will be supplied by
 your DBMS as follows:
 
-* If a <Domain name> in a ``CREATE SCHEMA`` statement isn't qualified, the 
+* If a <Domain name> in a ``CREATE SCHEMA`` statement isn't qualified, the
   default qualifier is the name of the Schema you're creating.
 
-* If the unqualified <Domain name> is found in any other SQL statement in a 
-  Module, the default qualifier is the name of the Schema identified in the 
-  ``SCHEMA`` clause or ``AUTHORIZATION`` clause of the ``MODULE`` statement 
+* If the unqualified <Domain name> is found in any other SQL statement in a
+  Module, the default qualifier is the name of the Schema identified in the
+  ``SCHEMA`` clause or ``AUTHORIZATION`` clause of the ``MODULE`` statement
   that defines that Module.
 
 Here are some examples of <Domain name>s:
@@ -94,8 +96,8 @@ Here are some examples of <Domain name>s:
 CREATE DOMAIN Statement
 =======================
 
-The ``CREATE DOMAIN`` statement names a new Domain and defines the Domain's 
-set of valid values. The required syntax for the ``CREATE DOMAIN`` statement 
+The ``CREATE DOMAIN`` statement names a new Domain and defines the Domain's
+set of valid values. The required syntax for the ``CREATE DOMAIN`` statement
 is:
 
 ::
@@ -113,24 +115,24 @@ is:
           Constraint_type
           [ <constraint attributes> ]
 
-``CREATE DOMAIN`` defines a new Domain: a named set of valid data values that 
-can be used -- somewhat like a macro -- to replace the <data type> 
-specification in subsequent <Column definition>s. A Domain is owned by the 
-Schema it belongs to. 
+``CREATE DOMAIN`` defines a new Domain: a named set of valid data values that
+can be used -- somewhat like a macro -- to replace the <data type>
+specification in subsequent <Column definition>s. A Domain is owned by the
+Schema it belongs to.
 
 * The <Domain name> identifies the Domain and the Schema that it
   belongs to. A <Domain name> that includes an explicit <Schema name> qualifier
-  belongs to the Schema named. A <Domain name> that does not include an 
-  explicit <Schema name> qualifier belongs to the SQL-session default Schema. 
-  The <Domain name> must be unique (for all Domains and UDTs) within the 
+  belongs to the Schema named. A <Domain name> that does not include an
+  explicit <Schema name> qualifier belongs to the SQL-session default Schema.
+  The <Domain name> must be unique (for all Domains and UDTs) within the
   Schema that owns it.
 
-If ``CREATE DOMAIN`` is part of a ``CREATE SCHEMA`` statement, the <Domain 
-name>, if explicitly qualified, must include the <Schema name> of the Schema 
-being created; that is, it isn't possible to create a Domain belonging to a 
-different Schema from within ``CREATE SCHEMA``. For example, this SQL statement 
-will not return an error because the <Domain name> will default to include the 
-qualifying <Schema name>: 
+If ``CREATE DOMAIN`` is part of a ``CREATE SCHEMA`` statement, the <Domain
+name>, if explicitly qualified, must include the <Schema name> of the Schema
+being created; that is, it isn't possible to create a Domain belonging to a
+different Schema from within ``CREATE SCHEMA``. For example, this SQL statement
+will not return an error because the <Domain name> will default to include the
+qualifying <Schema name>:
 
 ::
 
@@ -161,33 +163,33 @@ of the Schema being created:
 *Privileges*
 ------------
 
-If ``CREATE DOMAIN`` is executed as a stand-alone SQL statement, the current 
-<AuthorizationID> must either be the owner of the Schema that this new Domain 
-belongs to, or the Schema's owner must be a Role that the current 
-<AuthorizationID> may use. That is, only the owner of a Schema can create 
-Domains for that Schema. In addition to creating a Domain, ``CREATE DOMAIN`` 
-also causes the SQL special grantor, "``_SYSTEM``", to grant the ``USAGE`` 
-Privilege on the new Domain to the Schema owner <AuthorizationID> (that is, the 
-<AuthorizationID creating the Domain). This ``USAGE`` Privilege will be 
-grantable if *(a)* the grantee also has a grantable ``REFERENCES`` Privilege 
-for each Column named in the Domain definition and *(b)* the grantee also has a 
-grantable ``USAGE`` Privilege for each Domain, Collation, Character set and 
-Translation named in a <Domain Constraint> in the Domain definition. 
+If ``CREATE DOMAIN`` is executed as a stand-alone SQL statement, the current
+<AuthorizationID> must either be the owner of the Schema that this new Domain
+belongs to, or the Schema's owner must be a Role that the current
+<AuthorizationID> may use. That is, only the owner of a Schema can create
+Domains for that Schema. In addition to creating a Domain, ``CREATE DOMAIN``
+also causes the SQL special grantor, "``_SYSTEM``", to grant the ``USAGE``
+Privilege on the new Domain to the Schema owner <AuthorizationID> (that is, the
+<AuthorizationID creating the Domain). This ``USAGE`` Privilege will be
+grantable if *(a)* the grantee also has a grantable ``REFERENCES`` Privilege
+for each Column named in the Domain definition and *(b)* the grantee also has a
+grantable ``USAGE`` Privilege for each Domain, Collation, Character set and
+Translation named in a <Domain Constraint> in the Domain definition.
 
 *<data type>*
 -------------
 
-A Domain must be defined to accept a certain type of data. The Domain's <data 
-type> specification constrains the values that can be accepted by the Domain. 
-The <data type> specification includes length, precision and scale as 
-applicable. Valid <data type>s are: ``INT``, ``SMALLINT``, ``NUMERIC(p,s)``, 
-``DECIMAL(p,s)``, ``FLOAT(p)``, ``REAL``, ``DOUBLE PRECISION``, ``BIT(l)``, 
-``BIT VARYING(l)``, ``BLOB(l)``, ``CHAR(l)``, ``NCHAR(l)``, ``VARCHAR(l)``, 
-``NCHAR VARYING(l)``, ``CLOB(l)``, ``NCLOB(l)``, ``DATE``, ``TIME(p)``, 
-``TIME(p) WITH TIME ZONE``, ``TIMESTAMP(p)``, ``TIMESTAMP(p) WITH TIME ZONE``, 
-``INTERVAL`` <interval qualifier>, ``BOOLEAN``, ``ARRAY``, ``ROW`` and ``REF``. 
+A Domain must be defined to accept a certain type of data. The Domain's <data
+type> specification constrains the values that can be accepted by the Domain.
+The <data type> specification includes length, precision and scale as
+applicable. Valid <data type>s are: ``INT``, ``SMALLINT``, ``NUMERIC(p,s)``,
+``DECIMAL(p,s)``, ``FLOAT(p)``, ``REAL``, ``DOUBLE PRECISION``, ``BIT(l)``,
+``BIT VARYING(l)``, ``BLOB(l)``, ``CHAR(l)``, ``NCHAR(l)``, ``VARCHAR(l)``,
+``NCHAR VARYING(l)``, ``CLOB(l)``, ``NCLOB(l)``, ``DATE``, ``TIME(p)``,
+``TIME(p) WITH TIME ZONE``, ``TIMESTAMP(p)``, ``TIMESTAMP(p) WITH TIME ZONE``,
+``INTERVAL`` <interval qualifier>, ``BOOLEAN``, ``ARRAY``, ``ROW`` and ``REF``.
 
-The <keyword> ``AS`` in the <data type> clause is noise and can be omitted. 
+The <keyword> ``AS`` in the <data type> clause is noise and can be omitted.
 For example, these two SQL statements are equivalent:
 
 ::
@@ -196,17 +198,17 @@ For example, these two SQL statements are equivalent:
 
    CREATE DOMAIN domain_1 CHAR(10);
 
-[Obscure Rule] If the <data type> of a Domain is ``CHAR``, ``VARCHAR`` or 
-``CLOB``, the Character set that the Domain's values must belong to is 
-determined as follows: 
+[Obscure Rule] If the <data type> of a Domain is ``CHAR``, ``VARCHAR`` or
+``CLOB``, the Character set that the Domain's values must belong to is
+determined as follows:
 
 * If your ``CREATE DOMAIN`` statement includes a ``CHARACTER SET`` clause, the
   Domain's Character set is the Character set named. Your current
   <AuthorizationID> must have the ``USAGE`` Privilege on that Character set.
 
 * If your ``CREATE DOMAIN`` statement does not include a ``CHARACTER SET``
-  clause, the Domain's Character set is the Character set named in the 
-  ``DEFAULT CHARACTER SET`` clause of the ``CREATE SCHEMA`` statement that 
+  clause, the Domain's Character set is the Character set named in the
+  ``DEFAULT CHARACTER SET`` clause of the ``CREATE SCHEMA`` statement that
   defines the Schema that the Domain belongs to.
 
 For example, the effect of these two SQL statements:
@@ -220,7 +222,7 @@ For example, the effect of these two SQL statements:
 
 is to create a Domain in Schema ``BOB``. The Domain's set of valid values are
 fixed length character strings, exactly 10 characters long, all of whose
-characters must be found in the ``INFORMATION_SCHEMA.LATIN1`` Character set 
+characters must be found in the ``INFORMATION_SCHEMA.LATIN1`` Character set
 -- the Schema's default Character set. The effect of these two SQL statements:
 
 ::
@@ -231,74 +233,74 @@ characters must be found in the ``INFORMATION_SCHEMA.LATIN1`` Character set
    CREATE DOMAIN domain_1 AS CHAR(10)
       CHARACTER SET INFORMATION_SCHEMA.SQL_CHARACTER);
 
-is to create the same Domain with one difference: this time, its values must 
-consist only of characters found in the ``INFORMATION_SCHEMA.SQL_CHARACTER`` 
-Character set -- the explicit Character set specification in ``CREATE DOMAIN`` 
-constrains the Domain's set of values. The Schema's default Character set does 
-not. 
+is to create the same Domain with one difference: this time, its values must
+consist only of characters found in the ``INFORMATION_SCHEMA.SQL_CHARACTER``
+Character set -- the explicit Character set specification in ``CREATE DOMAIN``
+constrains the Domain's set of values. The Schema's default Character set does
+not.
 
-[Obscure Rule] If the <data type> of a Domain is ``CHAR``, ``VARCHAR``, 
-``CLOB``, ``NCHAR``, ``NCHAR VARYING`` or ``NCLOB``, and your ``CREATE DOMAIN`` 
-statement does not include a ``COLLATE`` clause, the Domain has a coercibility 
-attribute of ``COERCIBLE`` -- but if your ``CREATE DOMAIN`` statement includes 
-a ``COLLATE`` clause, the Domain has a coercibility attribute of ``IMPLICIT``. 
-In either case, the Domain's default Collation is determined as follows: 
+[Obscure Rule] If the <data type> of a Domain is ``CHAR``, ``VARCHAR``,
+``CLOB``, ``NCHAR``, ``NCHAR VARYING`` or ``NCLOB``, and your ``CREATE DOMAIN``
+statement does not include a ``COLLATE`` clause, the Domain has a coercibility
+attribute of ``COERCIBLE`` -- but if your ``CREATE DOMAIN`` statement includes
+a ``COLLATE`` clause, the Domain has a coercibility attribute of ``IMPLICIT``.
+In either case, the Domain's default Collation is determined as follows:
 
 * If your ``CREATE DOMAIN`` statement includes a ``COLLATE`` clause, the
   Domain's default Collation is the Collation named. Your current
   <AuthorizationID> must have the ``USAGE`` Privilege on that Collation.
 
 * If your ``CREATE DOMAIN`` statement does not include a ``COLLATE`` clause,
-  the Domain's default Collation is the default Collation of the Domain's 
+  the Domain's default Collation is the default Collation of the Domain's
   Character set.
 
-[Obscure Rule] If the <data type> of a Domain is ``REF``\(UDT), your current 
-<AuthorizationID> must have the ``USAGE`` Privilege on that UDT. If the <data 
-type> of a Domain includes ``REF`` with a <scope clause>, your ``CREATE 
-DOMAIN`` statement must also include a <reference scope check> clause, to 
-indicate whether references are to be checked or not (don't add a <reference 
-scope check> clause under any other circumstances). In this case, you may also 
-add the optional <reference scope check action> clause, to indicate the action 
-to be taken whenever a Column based on this Domain is the subject of a 
-``DELETE`` statement. If you omit the <reference scope check action> clause, it 
-defaults to ``ON DELETE RESTRICT``. 
+[Obscure Rule] If the <data type> of a Domain is ``REF``\(UDT), your current
+<AuthorizationID> must have the ``USAGE`` Privilege on that UDT. If the <data
+type> of a Domain includes ``REF`` with a <scope clause>, your ``CREATE
+DOMAIN`` statement must also include a <reference scope check> clause, to
+indicate whether references are to be checked or not (don't add a <reference
+scope check> clause under any other circumstances). In this case, you may also
+add the optional <reference scope check action> clause, to indicate the action
+to be taken whenever a Column based on this Domain is the subject of a
+``DELETE`` statement. If you omit the <reference scope check action> clause, it
+defaults to ``ON DELETE RESTRICT``.
 
 * If a Domain is defined with ``REFERENCES ARE CHECKED`` and a <scope
-  clause> naming one or more Tables is included in the ``CREATE DOMAIN`` 
-  statement, then there is an implied ``DEFERRABLE INITIALLY IMMEDIATE`` 
-  Constraint on the new Domain which checks that the values of every Column 
-  based on the Domain are also found in the system generated Column of each 
-  Table named in the <scope clause>. In this case, if the <reference scope 
-  check action> is ``SET NULL`` then, prior to deleting any rows from the 
-  Tables that own a Column based on this Domain, your DBMS will *(a)* 
-  execute a ``SET CONSTRAINT`` statement that sets the implied Constraint's 
-  constraint check time to ``DEFERRED``, *(b)* ``DELETE`` the rows as 
-  required, *(c)* set the value of the system generated Column in each Table 
-  named in the <scope clause> to ``NULL``, for each row that matched the 
-  deleted rows and *(d)* execute a ``SET CONSTRAINT`` statement that sets 
+  clause> naming one or more Tables is included in the ``CREATE DOMAIN``
+  statement, then there is an implied ``DEFERRABLE INITIALLY IMMEDIATE``
+  Constraint on the new Domain which checks that the values of every Column
+  based on the Domain are also found in the system generated Column of each
+  Table named in the <scope clause>. In this case, if the <reference scope
+  check action> is ``SET NULL`` then, prior to deleting any rows from the
+  Tables that own a Column based on this Domain, your DBMS will *(a)*
+  execute a ``SET CONSTRAINT`` statement that sets the implied Constraint's
+  constraint check time to ``DEFERRED``, *(b)* ``DELETE`` the rows as
+  required, *(c)* set the value of the system generated Column in each Table
+  named in the <scope clause> to ``NULL``, for each row that matched the
+  deleted rows and *(d)* execute a ``SET CONSTRAINT`` statement that sets
   the implied Constraint's constraint check time to ``IMMEDIATE``.
 
 *DEFAULT Clause*
 ----------------
 
-The optional ``DEFAULT`` clause defines the Domain's default value: the value 
-to insert whenever a Column based on this Domain is the target of an ``INSERT`` 
-statement that doesn't include an explicit value for that Column. The 
-``DEFAULT`` options are: ``DEFAULT`` <literal>, ``DEFAULT CURRENT_DATE``, 
-``DEFAULT CURRENT_TIME(p)``, ``DEFAULT CURRENT_TIMESTAMP(p)``, ``DEFAULT 
-LOCALTIME(p)``, ``DEFAULT LOCALTIMESTAMP(p)``, ``DEFAULT USER``, ``DEFAULT 
-CURRENT_USER``, ``DEFAULT SESSION_USER``, ``DEFAULT SYSTEM_USER``, ``DEFAULT 
-CURRENT_PATH``, ``DEFAULT ARRAY[]``, ``DEFAULT ARRAY??(??)`` and ``DEFAULT 
-NULL`` -- see "<default clause>" in our chapter on Tables. For example, this 
-SQL statement creates a Domain whose default value is the <character string 
-literal> ``'bobby'``: 
+The optional ``DEFAULT`` clause defines the Domain's default value: the value
+to insert whenever a Column based on this Domain is the target of an ``INSERT``
+statement that doesn't include an explicit value for that Column. The
+``DEFAULT`` options are: ``DEFAULT`` <literal>, ``DEFAULT CURRENT_DATE``,
+``DEFAULT CURRENT_TIME(p)``, ``DEFAULT CURRENT_TIMESTAMP(p)``, ``DEFAULT
+LOCALTIME(p)``, ``DEFAULT LOCALTIMESTAMP(p)``, ``DEFAULT USER``, ``DEFAULT
+CURRENT_USER``, ``DEFAULT SESSION_USER``, ``DEFAULT SYSTEM_USER``, ``DEFAULT
+CURRENT_PATH``, ``DEFAULT ARRAY[]``, ``DEFAULT ARRAY??(??)`` and ``DEFAULT
+NULL`` -- see "<default clause>" in our chapter on Tables. For example, this
+SQL statement creates a Domain whose default value is the <character string
+literal> ``'bobby'``:
 
 ::
 
    CREATE DOMAIN domain_1 AS VARCHAR(15)
       DEFAULT 'bobby';
 
-And this SQL statement creates a Domain whose default value is the value 
+And this SQL statement creates a Domain whose default value is the value
 returned by the ``CURRENT_DATE`` function:
 
 ::
@@ -309,12 +311,12 @@ returned by the ``CURRENT_DATE`` function:
 *<Domain Constraint>s*
 ----------------------
 
-The optional <Domain Constraint> list clause of ``CREATE DOMAIN`` is used to 
-define zero or more <Constraint>s on the Domain: the Constraint rules will 
-restrict the Domain's set of valid values -- see our chapter on Constraints and 
-Assertions. The syntax ``CREATE DOMAIN <Domain name> AS <data type> DEFAULT 
-default value <Domain Constraint> <Domain Constraint>`` defines a 
-Domain whose definition includes two <Domain Constraint>s. Here is an example: 
+The optional <Domain Constraint> list clause of ``CREATE DOMAIN`` is used to
+define zero or more <Constraint>s on the Domain: the Constraint rules will
+restrict the Domain's set of valid values -- see our chapter on Constraints and
+Assertions. The syntax ``CREATE DOMAIN <Domain name> AS <data type> DEFAULT
+default value <Domain Constraint> <Domain Constraint>`` defines a
+Domain whose definition includes two <Domain Constraint>s. Here is an example:
 
 ::
 
@@ -325,13 +327,13 @@ Domain whose definition includes two <Domain Constraint>s. Here is an example:
       CONSTRAINT constraint_2
          CHECK (VALUE BETWEEN -1000 AND 9999) DEFERRABLE INITIALLY IMMEDIATE;
 
-In this example, ``DOMAIN_1`` has a default value of 150 and is constrained to 
-accept only integers that fall into ``SMALLINT``'s range. The Domain is further 
-constrained (by ``CONSTRAINT_1``) not to accept null values and (by 
-``CONSTRAINT_2``) to accept only values between -1000 and +9999. Since a 
-<Domain Constraint>'s search condition may not be recursive, this SQL statement 
-will return an error because the <Domain Constraint> refers to the Domain it 
-belongs to: 
+In this example, ``DOMAIN_1`` has a default value of 150 and is constrained to
+accept only integers that fall into ``SMALLINT``'s range. The Domain is further
+constrained (by ``CONSTRAINT_1``) not to accept null values and (by
+``CONSTRAINT_2``) to accept only values between -1000 and +9999. Since a
+<Domain Constraint>'s search condition may not be recursive, this SQL statement
+will return an error because the <Domain Constraint> refers to the Domain it
+belongs to:
 
 ::
 
@@ -344,7 +346,7 @@ If you want to restrict your code to Core SQL, don't use the ``CREATE DOMAIN`` s
 ALTER DOMAIN Statement
 ======================
 
-The ``ALTER DOMAIN`` statement changes a Domain's definition. The required 
+The ``ALTER DOMAIN`` statement changes a Domain's definition. The required
 syntax for the ``ALTER DOMAIN`` statement is:
 
 ::
@@ -365,22 +367,22 @@ Every Column that is based on the Domain will be affected by the change.
 *SET DEFAULT Clause*
 --------------------
 
-The effect of ``ALTER DOMAIN`` <Domain name> ``SET DEFAULT`` default value, 
+The effect of ``ALTER DOMAIN`` <Domain name> ``SET DEFAULT`` default value,
 e.g.:
 
 ::
 
    ALTER DOMAIN domain_1 SET DEFAULT 200;
 
-is that the default value of the Domain named will be changed. (You can use 
-this version of ``ALTER DOMAIN`` either to add a default value to a Domain or 
-to change a Domain's existing default value.) The ``ALTER DOMAIN ... SET 
-DEFAULT`` options are: ``DEFAULT`` <literal>, ``DEFAULT CURRENT_DATE``, 
-``DEFAULT CURRENT_TIME(p)``, ``DEFAULT CURRENT_TIMESTAMP(p)``, ``DEFAULT 
-LOCALTIME(p)``, ``DEFAULT LOCALTIMESTAMP(p)``, ``DEFAULT USER``, ``DEFAULT 
-CURRENT_USER``, ``DEFAULT SESSION_USER``, ``DEFAULT SYSTEM_USER``, ``DEFAULT 
-CURRENT_PATH``, ``DEFAULT ARRAY[]``, ``DEFAULT ARRAY??(??)`` and ``DEFAULT 
-NULL`` -- see "<default clause>", in our chapter on Tables. 
+is that the default value of the Domain named will be changed. (You can use
+this version of ``ALTER DOMAIN`` either to add a default value to a Domain or
+to change a Domain's existing default value.) The ``ALTER DOMAIN ... SET
+DEFAULT`` options are: ``DEFAULT`` <literal>, ``DEFAULT CURRENT_DATE``,
+``DEFAULT CURRENT_TIME(p)``, ``DEFAULT CURRENT_TIMESTAMP(p)``, ``DEFAULT
+LOCALTIME(p)``, ``DEFAULT LOCALTIMESTAMP(p)``, ``DEFAULT USER``, ``DEFAULT
+CURRENT_USER``, ``DEFAULT SESSION_USER``, ``DEFAULT SYSTEM_USER``, ``DEFAULT
+CURRENT_PATH``, ``DEFAULT ARRAY[]``, ``DEFAULT ARRAY??(??)`` and ``DEFAULT
+NULL`` -- see "<default clause>", in our chapter on Tables.
 
 *DROP DEFAULT Clause*
 ---------------------
@@ -391,24 +393,24 @@ The effect of ``ALTER DOMAIN`` <Domain name> ``DROP DEFAULT``, e.g.:
 
    ALTER DOMAIN domain_1 DROP DEFAULT;
 
-is that the default value of the Domain named will be removed from the Domain's 
-definition>. (You'll get a syntax error if the Domain's definition doesn't 
-include a default value.) Before removing the default value from the Domain's 
-definition, your DBMS will first check the definitions of every Column based on 
-the Domain for a default value. If a dependent <Column definition> has no 
-default value, your DBMS will add the Domain's default value to the <Column 
-definition>. For example, the effect of this SQL statement: 
+is that the default value of the Domain named will be removed from the Domain's
+definition>. (You'll get a syntax error if the Domain's definition doesn't
+include a default value.) Before removing the default value from the Domain's
+definition, your DBMS will first check the definitions of every Column based on
+the Domain for a default value. If a dependent <Column definition> has no
+default value, your DBMS will add the Domain's default value to the <Column
+definition>. For example, the effect of this SQL statement:
 
 ::
 
    ALTER domain_1 DROP DEFAULT;
 
-is twofold. First, the definition of every Column dependent on ``DOMAIN_1`` 
-will be checked for a Column default value. If none is found, the default value 
-from the Domain definition is added to the <Column definition> to ensure that 
-the Column is not left without a default value for future insertions. The 
-second effect is that the Domain's default value is removed from the definition 
-of ``DOMAIN_1``. 
+is twofold. First, the definition of every Column dependent on ``DOMAIN_1``
+will be checked for a Column default value. If none is found, the default value
+from the Domain definition is added to the <Column definition> to ensure that
+the Column is not left without a default value for future insertions. The
+second effect is that the Domain's default value is removed from the definition
+of ``DOMAIN_1``.
 
 *ADD <Domain Constraint> Clause*
 --------------------------------
@@ -426,7 +428,7 @@ is that one <Domain Constraint> is added to the definition of the Domain named
 *DROP CONSTRAINT Clause*
 ------------------------
 
-The effect of ``ALTER DOMAIN`` <Domain name> ``DROP CONSTRAINT`` <Constraint 
+The effect of ``ALTER DOMAIN`` <Domain name> ``DROP CONSTRAINT`` <Constraint
 name>, e.g.:
 
 ::
@@ -439,13 +441,13 @@ the "known not nullable" nullability characteristic, then the affected
 Columns' nullability characteristic becomes "possibly nullable" unless some
 other Constraint also constrains them to non-null values.)
 
-If you want to restrict your code to Core SQL, don't use the ``ALTER 
+If you want to restrict your code to Core SQL, don't use the ``ALTER
 DOMAIN`` statement.
 
 DROP DOMAIN Statement
 =====================
 
-The ``DROP DOMAIN`` statement destroys a Domain. The required syntax for the 
+The ``DROP DOMAIN`` statement destroys a Domain. The required syntax for the
 ``DROP DOMAIN`` statement is:
 
 ::
@@ -462,12 +464,12 @@ The effect of ``DROP DOMAIN`` <Domain name> ``RESTRICT``, e.g.:
 
    DROP DOMAIN domain_1 RESTRICT;
 
-is that the Domain named is destroyed, provided that *(a)* no Columns are based 
-on the Domain and *(b)* that the Domain isn't referred to in any View 
-definition, Constraint or Assertion definition, or SQL routine. That is, 
-``RESTRICT`` ensures that only a Domain with no dependent Objects can be 
-destroyed. If the Domain is used by any other Object, ``DROP DOMAIN ... 
-RESTRICT`` will fail. 
+is that the Domain named is destroyed, provided that *(a)* no Columns are based
+on the Domain and *(b)* that the Domain isn't referred to in any View
+definition, Constraint or Assertion definition, or SQL routine. That is,
+``RESTRICT`` ensures that only a Domain with no dependent Objects can be
+destroyed. If the Domain is used by any other Object, ``DROP DOMAIN ...
+RESTRICT`` will fail.
 
 The effect of ``DROP DOMAIN`` <Domain name> ``CASCADE``, e.g.:
 
@@ -482,37 +484,37 @@ Successfully dropping a Domain has a five-fold effect:
 1. The Domain named is destroyed.
 
 2. All Privileges held on the Domain by the <AuthorizationID> that owns
-   it are revoked (by the SQL special grantor, "``_SYSTEM``") with a 
-   ``CASCADE`` revoke behaviour, so that all Privileges held on the Domain 
+   it are revoked (by the SQL special grantor, "``_SYSTEM``") with a
+   ``CASCADE`` revoke behaviour, so that all Privileges held on the Domain
    by any other <AuthorizationID> are also revoked.
 
 3. The definition of every Column based on the Domain is changed: the
-   <Domain name> is removed and the Domain's <data type> specification is 
-   added. If the <Column definition> has no default value, the Domain's 
-   default value is added. If the <Column definition> has no ``COLLATE`` 
-   clause, the Domain's ``COLLATE`` clause is added, provided that the 
+   <Domain name> is removed and the Domain's <data type> specification is
+   added. If the <Column definition> has no default value, the Domain's
+   default value is added. If the <Column definition> has no ``COLLATE``
+   clause, the Domain's ``COLLATE`` clause is added, provided that the
    <AuthorizationID> has the ``USAGE`` Privilege on the Collation named.
 
-4. The definition of every Table that owns a Column based on the Domain is 
-   changed: a <Table Constraint> that is equivalent to every applicable 
-   <Domain Constraint> is added, provided that the <AuthorizationID> has all 
+4. The definition of every Table that owns a Column based on the Domain is
+   changed: a <Table Constraint> that is equivalent to every applicable
+   <Domain Constraint> is added, provided that the <AuthorizationID> has all
    the Privileges needed to add such <Table Constraint>s.
 
-5. All SQL routines, Views and Constraints that depend on the Domain are 
+5. All SQL routines, Views and Constraints that depend on the Domain are
    dropped with a ``CASCADE`` drop behaviour.
 
-If you want to restrict your code to Core SQL, don't use the ``DROP DOMAIN`` 
+If you want to restrict your code to Core SQL, don't use the ``DROP DOMAIN``
 statement.
 
 Frequently-used numeric Domains
 ===============================
 
-Any business needs to store "money" -- usually a signed decimal with two fixed 
-digits after the decimal point; and "interest" -- usually an unsigned decimal 
-with 3 digits after the decimal point. Some SQL DBMSs have special data types 
-for business needs, but Standard SQL doesn't, so this is a good place to use a 
-Domain. For example, these four SQL statements define and utilize two numeric 
-Domains: 
+Any business needs to store "money" -- usually a signed decimal with two fixed
+digits after the decimal point; and "interest" -- usually an unsigned decimal
+with 3 digits after the decimal point. Some SQL DBMSs have special data types
+for business needs, but Standard SQL doesn't, so this is a good place to use a
+Domain. For example, these four SQL statements define and utilize two numeric
+Domains:
 
 ::
 
@@ -529,28 +531,28 @@ Domains:
       money_column_2 MONEY_,
       interest_column_2 INTEREST_);
 
-In this example, the first two SQL statements create two Domains named 
-``MONEY_`` and ``INTEREST_``. The third SQL statement adds a Constraint to 
-``INTEREST_`` Domain: it must always have a value greater than or equal to 
-zero. Lastly, the Domains are used in a ``CREATE TABLE`` statement -- this 
-saves a bit of typing, but more importantly, using the Domains makes it clear 
-that money and interest fields are being defined -- rather than merely vague, 
-generic decimal fields. 
+In this example, the first two SQL statements create two Domains named
+``MONEY_`` and ``INTEREST_``. The third SQL statement adds a Constraint to
+``INTEREST_`` Domain: it must always have a value greater than or equal to
+zero. Lastly, the Domains are used in a ``CREATE TABLE`` statement -- this
+saves a bit of typing, but more importantly, using the Domains makes it clear
+that money and interest fields are being defined -- rather than merely vague,
+generic decimal fields.
 
-SQL provides a predefined unsigned-integer Domain, called ``CARDINAL_NUMBER``, 
-that you could use on the theory that anything predefined is better than a 
-roll-your-own. Since all predefined Objects are belong to 
-``INFORMATION_SCHEMA``, use a <Schema name> qualifier when making Columns with 
-``CARDINAL_NUMBER`` -- for example: 
+SQL provides a predefined unsigned-integer Domain, called ``CARDINAL_NUMBER``,
+that you could use on the theory that anything predefined is better than a
+roll-your-own. Since all predefined Objects are belong to
+``INFORMATION_SCHEMA``, use a <Schema name> qualifier when making Columns with
+``CARDINAL_NUMBER`` -- for example:
 
 ::
 
    ALTER TABLE Exact_Examples ADD COLUMN
       occurrence_cardinal INFORMATION_SCHEMA.CARDINAL_NUMBER;
 
-This definition will cause this SQL statement to fail because 
-``CARDINAL_NUMBER`` allows only unsigned numbers (that is, only numbers that 
-are greater than or equal to zero): 
+This definition will cause this SQL statement to fail because
+``CARDINAL_NUMBER`` allows only unsigned numbers (that is, only numbers that
+are greater than or equal to zero):
 
 ::
 
@@ -565,5 +567,5 @@ But this SQL statement will work:
       occurrence_cardinal = +1;
 
 .. NOTE::
-   Numbers in a ``CARDINAL_NUMBER`` Domain don't have the same range as 
+   Numbers in a ``CARDINAL_NUMBER`` Domain don't have the same range as
    C/Delphi "unsigned".

--- a/docs/chapters/20.rst
+++ b/docs/chapters/20.rst
@@ -4,6 +4,8 @@
 Chapter 20 -- SQL Constraint and Assertion
 ==========================================
 
+.. include:: ../_include/note.rst
+
 In this chapter, we'll describe SQL Constraints and SQL Assertions in detail,
 and show you the syntax to use to create, alter and destroy them.
 
@@ -15,17 +17,17 @@ and show you the syntax to use to create, alter and destroy them.
 Constraint
 ==========
 
-A Schema may contain zero or more integrity Constraints (an Assertion is just a 
-special type of integrity Constraint: it is not necessarily dependent on a 
-single Base table as simple Constraints are.) An SQL Constraint is a named rule 
-which helps define valid sets of values by putting limits on the results of 
-``INSERT``, ``UPDATE`` or ``DELETE`` operations performed on a Base table, an 
-Assertion, by contrast, may define valid sets of values for individual rows of 
-a Base table or for an entire Base table or it may define the set of valid 
-values required to exist among a number of Base tables. Constraints are 
-dependent on some Schema -- the <Constraint name> must be unique within the 
-Schema the Constraint belongs to -- and are created and dropped using standard 
-SQL statements. 
+A Schema may contain zero or more integrity Constraints (an Assertion is just a
+special type of integrity Constraint: it is not necessarily dependent on a
+single Base table as simple Constraints are.) An SQL Constraint is a named rule
+which helps define valid sets of values by putting limits on the results of
+``INSERT``, ``UPDATE`` or ``DELETE`` operations performed on a Base table, an
+Assertion, by contrast, may define valid sets of values for individual rows of
+a Base table or for an entire Base table or it may define the set of valid
+values required to exist among a number of Base tables. Constraints are
+dependent on some Schema -- the <Constraint name> must be unique within the
+Schema the Constraint belongs to -- and are created and dropped using standard
+SQL statements.
 
 There are four Constraint variations -- ``UNIQUE`` Constraints, ``PRIMARY KEY``
 Constraints, ``FOREIGN KEY`` Constraints and ``CHECK`` Constraints.
@@ -34,44 +36,44 @@ Constraints, ``FOREIGN KEY`` Constraints and ``CHECK`` Constraints.
    Columns: it is satisfied if no two rows in the Table have the same non-null
    values in the unique Columns.
 
-2. A ``PRIMARY KEY`` Constraint is a ``UNIQUE`` Constraint that specifies 
-   ``PRIMARY KEY``: it is satisfied if *(a)* no two rows in the Table have 
-   the same non-null values in the unique Columns and *(b)* none of the 
-   primary key Columns are ``NULL``. ``UNIQUE`` Constraints and ``PRIMARY 
+2. A ``PRIMARY KEY`` Constraint is a ``UNIQUE`` Constraint that specifies
+   ``PRIMARY KEY``: it is satisfied if *(a)* no two rows in the Table have
+   the same non-null values in the unique Columns and *(b)* none of the
+   primary key Columns are ``NULL``. ``UNIQUE`` Constraints and ``PRIMARY
    KEY`` Constraints describe a Base table's candidate keys.
 
 3. A ``FOREIGN KEY`` Constraint defines one or more Columns of a Table as
    referencing Columns whose values must match the values of some corresponding
-   referenced Columns in a referenced Base table (the referenced Columns 
-   must be ``UNIQUE`` Columns for the referenced Table). It is satisfied if, 
-   for every row in the referencing Table, the values of the referencing 
-   Columns are equal to those of the corresponding referenced Columns in 
-   some row of the referenced Table. (If either Table contains ``NULL``\s, 
-   satisfaction of the ``FOREIGN KEY`` Constraint depends on the 
-   Constraint's match type.) ``FOREIGN KEY`` Constraints describe linkages 
+   referenced Columns in a referenced Base table (the referenced Columns
+   must be ``UNIQUE`` Columns for the referenced Table). It is satisfied if,
+   for every row in the referencing Table, the values of the referencing
+   Columns are equal to those of the corresponding referenced Columns in
+   some row of the referenced Table. (If either Table contains ``NULL``\s,
+   satisfaction of the ``FOREIGN KEY`` Constraint depends on the
+   Constraint's match type.) ``FOREIGN KEY`` Constraints describe linkages
    between Base tables.
 
 4. A ``CHECK`` Constraint defines a search condition: it is violated if the
-   result of the condition is ``FALSE`` for any row of the Table. An 
+   result of the condition is ``FALSE`` for any row of the Table. An
    Assertion is a ``CHECK`` Constraint that may operate on multiple Tables.
 
 *Non-deterministic Constraints*
 -------------------------------
 
-A ``CHECK`` Constraint may not define a non-deterministic search condition -- 
-that is, any condition whose result may vary from time to time. Here is an 
-example of an invalid ``CHECK`` Constraint: 
+A ``CHECK`` Constraint may not define a non-deterministic search condition --
+that is, any condition whose result may vary from time to time. Here is an
+example of an invalid ``CHECK`` Constraint:
 
 ::
 
    CREATE TABLE Table_1 (
       column_1 DATE CHECK (column_1 = CURRENT_DATE);
 
-This SQL statement would return an error because the ``CHECK`` Constraint's 
-search condition is non-deterministic -- since the value of ``CURRENT_DATE`` 
-changes each time the function is called, your DBMS is not able to determine 
-whether the Constraint has been violated or not. For another example, run this 
-query twice, on the same database: 
+This SQL statement would return an error because the ``CHECK`` Constraint's
+search condition is non-deterministic -- since the value of ``CURRENT_DATE``
+changes each time the function is called, your DBMS is not able to determine
+whether the Constraint has been violated or not. For another example, run this
+query twice, on the same database:
 
 ::
 
@@ -88,9 +90,9 @@ query twice:
    FROM   Table_1
    WHERE  column_time = CURRENT_TIME;
 
-You can't be sure that the results will be the same both times because the 
-current time is a value from outside your SQL environment, beyond the control 
-of your DBMS. Now run this query twice: 
+You can't be sure that the results will be the same both times because the
+current time is a value from outside your SQL environment, beyond the control
+of your DBMS. Now run this query twice:
 
 ::
 
@@ -100,63 +102,63 @@ of your DBMS. Now run this query twice:
    SELECT 'A'
    FROM   Table_1;
 
-Once again, you can't be sure that the results will be the same both times. 
-With most Collations (``NO PAD`` and "case insensitive"), the <literal>s 
-``'a'`` and ``'A'`` are equivalent -- that is, they're equal to each other. But 
-they're still not the same <literal>. 
+Once again, you can't be sure that the results will be the same both times.
+With most Collations (``NO PAD`` and "case insensitive"), the <literal>s
+``'a'`` and ``'A'`` are equivalent -- that is, they're equal to each other. But
+they're still not the same <literal>.
 
-The point is that the only predictable queries are those which depend on SQL- 
-data and defined rules. As soon as you start to use values which are outside 
-SQL, or which result from implementation-dependent answers to areas which the 
-SQL Standards leaves undefined, you have a query which requires a nine-syllable 
-term to describe: "possibly non-deterministic". Specifically, queries are 
-possibly non-deterministic (and therefore not allowed in Constraints) if they 
-depend on: 
+The point is that the only predictable queries are those which depend on SQL-
+data and defined rules. As soon as you start to use values which are outside
+SQL, or which result from implementation-dependent answers to areas which the
+SQL Standards leaves undefined, you have a query which requires a nine-syllable
+term to describe: "possibly non-deterministic". Specifically, queries are
+possibly non-deterministic (and therefore not allowed in Constraints) if they
+depend on:
 
-* A niladic function (``CURRENT_DATE``, ``CURRENT_TIME``, 
-  ``CURRENT_TIMESTAMP``, ``LOCALTIME``, ``LOCALTIMESTAMP``, ``USER``, 
-  ``CURRENT_USER``, ``SESSION_USER``, ``SYSTEM_USER``, ``CURRENT_PATH``, 
+* A niladic function (``CURRENT_DATE``, ``CURRENT_TIME``,
+  ``CURRENT_TIMESTAMP``, ``LOCALTIME``, ``LOCALTIMESTAMP``, ``USER``,
+  ``CURRENT_USER``, ``SESSION_USER``, ``SYSTEM_USER``, ``CURRENT_PATH``,
   ``CURRENT_ROLE``).
 
 * An operation which picks from multiple values that may be
-  equivalent-but-not-the-same. Picky operations include: ``MIN``, ``MAX``, 
-  ``UNION`` (though ``UNION ALL`` is okay), ``INTERSECT``, ``EXCEPT``, 
-  ``DISTINCT`` and grouping columns. Equivalent-but-not-the-same can be true 
-  for: character strings and times and timestamps (in the latter cases the 
+  equivalent-but-not-the-same. Picky operations include: ``MIN``, ``MAX``,
+  ``UNION`` (though ``UNION ALL`` is okay), ``INTERSECT``, ``EXCEPT``,
+  ``DISTINCT`` and grouping columns. Equivalent-but-not-the-same can be true
+  for: character strings and times and timestamps (in the latter cases the
   external factor that causes non-determinism is the time zone).
 
 * A routine invocation which is based on a procedure in a host language
   or on parameters that are set by a host program.
 
-No matter what type of Constraint you're defining, the main ideas are always 
+No matter what type of Constraint you're defining, the main ideas are always
 the same.
 
 1. You're describing a state which must not be ``FALSE``. This means it
-   can be either ``TRUE`` or ``UNKNOWN``. (It can also be "temporarily 
-   ``FALSE``" -- your DBMS is supposed to allow bad data until constraint 
-   check time. Then, if it descries a ``FALSE`` condition, it must wipe the 
-   bad data out again, so it's equally correct to say "Constraint violation" 
-   and "attempted Constraint violation".) Evaluation of a Constraint is one 
+   can be either ``TRUE`` or ``UNKNOWN``. (It can also be "temporarily
+   ``FALSE``" -- your DBMS is supposed to allow bad data until constraint
+   check time. Then, if it descries a ``FALSE`` condition, it must wipe the
+   bad data out again, so it's equally correct to say "Constraint violation"
+   and "attempted Constraint violation".) Evaluation of a Constraint is one
    of the areas where ``NULL``\s and three-valued logic play an important role.
 
-2. A Constraint is an Object in a Schema -- it is not a procedure. It is, 
-   rather, a revelation to the DBMS about what you want and what you don't 
+2. A Constraint is an Object in a Schema -- it is not a procedure. It is,
+   rather, a revelation to the DBMS about what you want and what you don't
    want to see in your database.
 
 *Constraint Deferrability*
 --------------------------
 
-All Constraints are defined with a deferral mode of either ``DEFERRABLE`` or 
-``NOT DEFERRABLE``. A deferral mode of ``DEFERRABLE`` allows you to specify 
-when you want your DBMS to check the Constraint for violation (the choices are 
-at statement end or at transaction end). A deferral mode of ``NOT DEFERRABLE`` 
-doesn't give you this option: your DBMS will check the Constraint for violation 
-as soon as it finishes executing an SQL statement. Of course, not every SQL 
-statement will cause your DBMS to check Constraints -- the main statements that 
-cause Constraint checking are ``INSERT``, ``UPDATE`` and ``DELETE`` (there is 
-no Constraint checking for ``DROP`` statements). ``DELETE`` is slightly less 
-important because whenever you get rid of a row, there is no longer any need to 
-check whether that row violates a Constraint. Consider these SQL statements: 
+All Constraints are defined with a deferral mode of either ``DEFERRABLE`` or
+``NOT DEFERRABLE``. A deferral mode of ``DEFERRABLE`` allows you to specify
+when you want your DBMS to check the Constraint for violation (the choices are
+at statement end or at transaction end). A deferral mode of ``NOT DEFERRABLE``
+doesn't give you this option: your DBMS will check the Constraint for violation
+as soon as it finishes executing an SQL statement. Of course, not every SQL
+statement will cause your DBMS to check Constraints -- the main statements that
+cause Constraint checking are ``INSERT``, ``UPDATE`` and ``DELETE`` (there is
+no Constraint checking for ``DROP`` statements). ``DELETE`` is slightly less
+important because whenever you get rid of a row, there is no longer any need to
+check whether that row violates a Constraint. Consider these SQL statements:
 
 ::
 
@@ -175,48 +177,48 @@ check whether that row violates a Constraint. Consider these SQL statements:
    UPDATE Table_1 SET
       column_1 = column_1 + 1;
 
-Believe it or not, there are DBMSs alive today which will fail when they 
-encounter this example's ``UPDATE`` statement. The reason is that they 
-``UPDATE`` one row at a time and perform the Constraint check immediately after 
-doing each row (this is normally the case whenever a DBMS implements ``UNIQUE`` 
-Constraints using a "unique index"). Therefore, as soon as ``1+1=2`` is done 
-for the first row, there's a duplication -- even though, if the DBMS would only 
-proceed to do the next row, the duplication would disappear (it would end up 
-with a ``2`` in the first row and a ``3`` in the second row). The fact is, 
-there never is a need for the Constraint to be checked until the end of the 
-``UPDATE`` statement -- nor does the SQL Standard allow for Constraint checking 
-until that time. 
+Believe it or not, there are DBMSs alive today which will fail when they
+encounter this example's ``UPDATE`` statement. The reason is that they
+``UPDATE`` one row at a time and perform the Constraint check immediately after
+doing each row (this is normally the case whenever a DBMS implements ``UNIQUE``
+Constraints using a "unique index"). Therefore, as soon as ``1+1=2`` is done
+for the first row, there's a duplication -- even though, if the DBMS would only
+proceed to do the next row, the duplication would disappear (it would end up
+with a ``2`` in the first row and a ``3`` in the second row). The fact is,
+there never is a need for the Constraint to be checked until the end of the
+``UPDATE`` statement -- nor does the SQL Standard allow for Constraint checking
+until that time.
 
-Every Constraint is also defined with a persistent initial constraint check 
-time that depends on its deferral mode: it is either ``INITIALLY IMMEDIATE`` or 
-``INITIALLY DEFERRED``. A Constraint that is ``NOT DEFERRABLE`` always has an 
-initial constraint check time of ``INITIALLY IMMEDIATE``. A Constraint that is 
-``DEFERRABLE`` may have an initial constraint check time of either ``INITIALLY 
-IMMEDIATE`` or ``INITIALLY DEFERRED``. During a transaction, each Constraint 
-also has a current constraint check time: its defined initial constraint check 
-time is always the current constraint check time at the beginning of a 
-transaction but you may change the check time for the period of the transaction 
-(from ``IMMEDIATE`` to ``DEFERRED`` or vice versa) if the Constraint is 
-``DEFERRABLE``. 
+Every Constraint is also defined with a persistent initial constraint check
+time that depends on its deferral mode: it is either ``INITIALLY IMMEDIATE`` or
+``INITIALLY DEFERRED``. A Constraint that is ``NOT DEFERRABLE`` always has an
+initial constraint check time of ``INITIALLY IMMEDIATE``. A Constraint that is
+``DEFERRABLE`` may have an initial constraint check time of either ``INITIALLY
+IMMEDIATE`` or ``INITIALLY DEFERRED``. During a transaction, each Constraint
+also has a current constraint check time: its defined initial constraint check
+time is always the current constraint check time at the beginning of a
+transaction but you may change the check time for the period of the transaction
+(from ``IMMEDIATE`` to ``DEFERRED`` or vice versa) if the Constraint is
+``DEFERRABLE``.
 
-* During a transaction, your DBMS will check every Constraint with a current 
-  constraint check time of ``IMMEDIATE`` for violation right after it 
-  executes an SQL statement -- thus each such Constraint may be checked 
+* During a transaction, your DBMS will check every Constraint with a current
+  constraint check time of ``IMMEDIATE`` for violation right after it
+  executes an SQL statement -- thus each such Constraint may be checked
   multiple times during a transaction.
 
-* During a transaction, your DBMS will wait to check every Constraint with a 
+* During a transaction, your DBMS will wait to check every Constraint with a
   current constraint check time of ``DEFERRED`` until the transaction ends --
   thus each such Constraint will be checked only once per transaction.
-  
-For each SQL-session, the current constraint check time of all Constraints is 
+
+For each SQL-session, the current constraint check time of all Constraints is
 a property of that SQL-session.
 
-To create a Constraint, use a <Table Constraint> definition or a <Column 
-Constraint> definition in a ``CREATE TABLE`` or an ``ALTER TABLE`` statement or 
-use a <Domain Constraint> definition in a ``CREATE DOMAIN`` or an ``ALTER 
-DOMAIN`` statement or use the ``CREATE ASSERTION`` statement. To destroy a 
-Constraint, use the ``ALTER TABLE``, ``ALTER DOMAIN`` or ``DROP ASSERTION`` 
-statements. To change an existing Constraint, drop and then redefine it. 
+To create a Constraint, use a <Table Constraint> definition or a <Column
+Constraint> definition in a ``CREATE TABLE`` or an ``ALTER TABLE`` statement or
+use a <Domain Constraint> definition in a ``CREATE DOMAIN`` or an ``ALTER
+DOMAIN`` statement or use the ``CREATE ASSERTION`` statement. To destroy a
+Constraint, use the ``ALTER TABLE``, ``ALTER DOMAIN`` or ``DROP ASSERTION``
+statements. To change an existing Constraint, drop and then redefine it.
 
 There is a one-to-many association between Base tables and <Table
 Constraint>s or <Column Constraint>s: one Base table may be constrained by the
@@ -252,7 +254,7 @@ a default will be supplied by your DBMS as follows:
 
 * If the unqualified <Constraint name> is found in any other SQL
   statement in a Module, the default qualifier is the name of the Schema
-  identified in the ``SCHEMA`` clause or ``AUTHORIZATION`` clause of the 
+  identified in the ``SCHEMA`` clause or ``AUTHORIZATION`` clause of the
   ``MODULE`` statement which defines that Module.
 
 Here are some examples of <Constraint name>s:
@@ -271,43 +273,43 @@ Here are some examples of <Constraint name>s:
 *<Table Constraint> and <Column Constraint>*
 --------------------------------------------
 
-A Base table may be constrained by zero or more <Table Constraint>s: 
-Constraints defined on one or more of its Columns in a ``CREATE TABLE`` or an 
-``ALTER TABLE`` statement. <Table Constraint>s are dependent on some Base 
-table, and therefore on some Schema -- the <Constraint name> must be unique 
-within the Schema the Constraint belongs to. There are five kinds of <Table 
-Constraint>s: ``UNIQUE`` Constraints, ``PRIMARY KEY`` Constraints, ``FOREIGN 
-KEY`` Constraints, ``CHECK`` Constraints and ``NOT NULL`` Constraints (which 
-are really just a type of ``CHECK`` Constraint). 
+A Base table may be constrained by zero or more <Table Constraint>s:
+Constraints defined on one or more of its Columns in a ``CREATE TABLE`` or an
+``ALTER TABLE`` statement. <Table Constraint>s are dependent on some Base
+table, and therefore on some Schema -- the <Constraint name> must be unique
+within the Schema the Constraint belongs to. There are five kinds of <Table
+Constraint>s: ``UNIQUE`` Constraints, ``PRIMARY KEY`` Constraints, ``FOREIGN
+KEY`` Constraints, ``CHECK`` Constraints and ``NOT NULL`` Constraints (which
+are really just a type of ``CHECK`` Constraint).
 
-A <Column definition> (and therefore a Base table) may be constrained by zero 
-or more <Column Constraint>s: Constraints defined on a single Column in a 
-``CREATE TABLE`` or an ``ALTER TABLE`` statement. A <Column Constraint> 
-logically becomes a <Table Constraint> as soon as it is created. <Column 
-Constraint>s are dependent on some Base table, and therefore on some Schema -- 
-the <Constraint name> must be unique within the Schema the Constraint belongs 
-to. A <Column Constraint> may be any Constraint that can be a <Table 
-Constraint>. 
+A <Column definition> (and therefore a Base table) may be constrained by zero
+or more <Column Constraint>s: Constraints defined on a single Column in a
+``CREATE TABLE`` or an ``ALTER TABLE`` statement. A <Column Constraint>
+logically becomes a <Table Constraint> as soon as it is created. <Column
+Constraint>s are dependent on some Base table, and therefore on some Schema --
+the <Constraint name> must be unique within the Schema the Constraint belongs
+to. A <Column Constraint> may be any Constraint that can be a <Table
+Constraint>.
 
 *<Domain Constraint>*
 ---------------------
 
-A Domain may be constrained by zero or more <Domain Constraint>s: Constraints 
-defined in a ``CREATE DOMAIN`` or an ``ALTER DOMAIN`` statement. <Domain 
-Constraint>s are dependent on some Domain, and therefore on some Schema -- the 
-<Constraint name> must be unique within the Schema the Constraint belongs to. 
-All <Domain Constraint>s are ``CHECK`` Constraints whose search conditions are 
-applied to all Columns based on the Domain and to all values cast to the 
-Domain. The search condition may not be a recursive search condition (that is, 
-it may not refer, either directly or indirectly, to the Domain that the <Domain 
-Constraint> belongs to) and it must begin with the <value specification> 
-``VALUE``; that is, the only proper form for a <Domain Constraint>'s rule is: 
+A Domain may be constrained by zero or more <Domain Constraint>s: Constraints
+defined in a ``CREATE DOMAIN`` or an ``ALTER DOMAIN`` statement. <Domain
+Constraint>s are dependent on some Domain, and therefore on some Schema -- the
+<Constraint name> must be unique within the Schema the Constraint belongs to.
+All <Domain Constraint>s are ``CHECK`` Constraints whose search conditions are
+applied to all Columns based on the Domain and to all values cast to the
+Domain. The search condition may not be a recursive search condition (that is,
+it may not refer, either directly or indirectly, to the Domain that the <Domain
+Constraint> belongs to) and it must begin with the <value specification>
+``VALUE``; that is, the only proper form for a <Domain Constraint>'s rule is:
 
 ::
 
    CHECK (VALUE ...)
 
-(This is the only time SQL allows you to use the <value specification> 
+(This is the only time SQL allows you to use the <value specification>
 ``VALUE``.)
 
 Three things wrong with the World Wide Web are:
@@ -319,24 +321,24 @@ Three things wrong with the World Wide Web are:
 
 3. Links can be broken (the notorious "URL not found" error).
 
-If we could control the World Wide Web, we'd do what we could to stomp out each 
-of those practices, in turn. Specifically, we'd add three basic kinds of 
-Constraints. Well, we don't control the Web. But we do control databases, so we 
-can use Constraints to stop bad data from getting into our Base tables. (There 
-are other lines of defense against bad data -- for example, the requirement 
-that values correspond to a defined <data type>, the ``WITH CHECK OPTION`` 
-requirement on a View, the SQL3 ``TRIGGER`` feature, and the procedures in your 
-host language programs. We describe these defenses in other chapters.) 
+If we could control the World Wide Web, we'd do what we could to stomp out each
+of those practices, in turn. Specifically, we'd add three basic kinds of
+Constraints. Well, we don't control the Web. But we do control databases, so we
+can use Constraints to stop bad data from getting into our Base tables. (There
+are other lines of defense against bad data -- for example, the requirement
+that values correspond to a defined <data type>, the ``WITH CHECK OPTION``
+requirement on a View, the SQL3 ``TRIGGER`` feature, and the procedures in your
+host language programs. We describe these defenses in other chapters.)
 
-If it's possible, you should create your Constraints and associate them only 
-with Base tables -- that way, the process is clear to all users. You'll know 
-where to look for information about the Constraints -- they'll be associated 
-with the Tables themselves in the ``INFORMATION_SCHEMA``. And, after reading 
-this chapter, you'll know what the specific, rather rigid, rules are -- which 
-reduces uncertainty, since specific and rigid rules are clear and 
-well-understood rules. In any case, it is logically proper to associate a 
-Constraint with a Table, because a Table is a set of row values and a 
-Constraint is a restriction (or description) of that set of values. 
+If it's possible, you should create your Constraints and associate them only
+with Base tables -- that way, the process is clear to all users. You'll know
+where to look for information about the Constraints -- they'll be associated
+with the Tables themselves in the ``INFORMATION_SCHEMA``. And, after reading
+this chapter, you'll know what the specific, rather rigid, rules are -- which
+reduces uncertainty, since specific and rigid rules are clear and
+well-understood rules. In any case, it is logically proper to associate a
+Constraint with a Table, because a Table is a set of row values and a
+Constraint is a restriction (or description) of that set of values.
 
 Constraint Descriptors
 ======================
@@ -358,7 +360,7 @@ information:
 5. The names and positions of the Columns that are required to contain
    only unique values.
 
-A ``PRIMARY KEY`` Constraint is defined by a descriptor that contains five 
+A ``PRIMARY KEY`` Constraint is defined by a descriptor that contains five
 pieces of information:
 
 1. The <Constraint name>, qualified by the <Schema name> of the Schema
@@ -377,7 +379,7 @@ pieces of information:
    key and thus are required to contain only unique, non-null values. (A Table
    that has a primary key cannot have a proper supertable.)
 
-A ``FOREIGN KEY`` Constraint is defined by a descriptor that contains nine 
+A ``FOREIGN KEY`` Constraint is defined by a descriptor that contains nine
 pieces of information:
 
 1. The <Constraint name>, qualified by the <Schema name> of the Schema
@@ -404,7 +406,7 @@ pieces of information:
 
 9. The Constraint's referential triggered actions (if any).
 
-A ``NOT NULL`` Constraint is defined by a descriptor that contains four 
+A ``NOT NULL`` Constraint is defined by a descriptor that contains four
 pieces of information:
 
 1. The <Constraint name>, qualified by the <Schema name> of the Schema
@@ -429,8 +431,8 @@ information:
    DEFERRED`` or ``INITIALLY IMMEDIATE``.
 
 4. The Constraint's rule: the <keyword> ``CHECK`` followed by the
-   parenthesized search condition that forces the Table's set of valid 
-   values for one or more Columns to be ``TRUE`` or ``UNKNOWN`` for the 
+   parenthesized search condition that forces the Table's set of valid
+   values for one or more Columns to be ``TRUE`` or ``UNKNOWN`` for the
    condition.
 
 An Assertion is defined by a descriptor that contains five pieces of
@@ -445,17 +447,17 @@ information:
    DEFERRED`` or ``INITIALLY IMMEDIATE``.
 
 4. The Constraint's rule: the <keyword> ``CHECK`` followed by the
-   parenthesized search condition that forces the set of valid values for 
+   parenthesized search condition that forces the set of valid values for
    one or more Base Tables to be ``TRUE`` or ``UNKNOWN`` for the condition.
 
 Constraint Definition
 =====================
 
-A Constraint definition creates a <Table Constraint>, a <Column Constraint> or 
-a <Domain Constraint>. Used in a ``CREATE TABLE``, ``ALTER TABLE``, ``CREATE 
-DOMAIN`` or ``ALTER DOMAIN`` statement, it names a Constraint and defines the 
-Constraint's type, deferral mode and constraint check time. The required syntax 
-for a Constraint definition is: 
+A Constraint definition creates a <Table Constraint>, a <Column Constraint> or
+a <Domain Constraint>. Used in a ``CREATE TABLE``, ``ALTER TABLE``, ``CREATE
+DOMAIN`` or ``ALTER DOMAIN`` statement, it names a Constraint and defines the
+Constraint's type, deferral mode and constraint check time. The required syntax
+for a Constraint definition is:
 
 ::
 
@@ -492,20 +494,20 @@ for a Constraint definition is:
           <constraint check time> ::=
           INITIALLY DEFERRED | INITIALLY IMMEDIATE
 
-A Constraint definition defines a new rule that will constrain a Base table's 
-set of valid values. A <Table Constraint> and a <Column Constraint> are owned 
-by the Table they belong to. A <Domain Constraint> is owned by the Domain it 
-belongs to. 
+A Constraint definition defines a new rule that will constrain a Base table's
+set of valid values. A <Table Constraint> and a <Column Constraint> are owned
+by the Table they belong to. A <Domain Constraint> is owned by the Domain it
+belongs to.
 
 *<Constraint Name>*
 -------------------
 
-All Constraints have names. The optional ``CONSTRAINT`` clause of a Constraint 
-definition is used to provide an explicit name for a Constraint. If you omit 
-the ``CONSTRAINT`` clause from a Constraint definition, your DBMS will provide 
-a default <Constraint name> to identify the Constraint. For example, this SQL 
-statement includes a Constraint definition that includes a ``CONSTRAINT`` 
-clause: 
+All Constraints have names. The optional ``CONSTRAINT`` clause of a Constraint
+definition is used to provide an explicit name for a Constraint. If you omit
+the ``CONSTRAINT`` clause from a Constraint definition, your DBMS will provide
+a default <Constraint name> to identify the Constraint. For example, this SQL
+statement includes a Constraint definition that includes a ``CONSTRAINT``
+clause:
 
 ::
 
@@ -523,18 +525,18 @@ Constraint definition that omits the ``CONSTRAINT`` clause:
 (The name of the Constraint is defined by your DBMS and is therefore non-
 standard, so we recommend that you explicitly name all of your Constraints.)
 
-The <Constraint name> identifies the Constraint and the Schema that it belongs 
-to. A <Constraint name> that includes an explicit <Schema name> qualifier 
-belongs to the Schema named. A <Constraint name> that does not include an 
-explicit <Schema name> qualifier belongs to the SQL-session default Schema. (In 
-both cases, that Schema must, of course, own the Table or Domain for which the 
-Constraint is defined.) The <Constraint name> must be unique (for all 
-Constraints and Assertions) within the Schema that owns it. If ``CREATE 
-TABLE``, ``ALTER TABLE``, ``CREATE DOMAIN`` or ``ALTER DOMAIN`` are part of a 
-``CREATE SCHEMA`` statement, the <Constraint name>, if explicitly qualified, 
-must include the <Schema name> of the Schema being created; that is, it isn't 
-possible to create a Constraint belonging to a different Schema from within 
-``CREATE SCHEMA``. 
+The <Constraint name> identifies the Constraint and the Schema that it belongs
+to. A <Constraint name> that includes an explicit <Schema name> qualifier
+belongs to the Schema named. A <Constraint name> that does not include an
+explicit <Schema name> qualifier belongs to the SQL-session default Schema. (In
+both cases, that Schema must, of course, own the Table or Domain for which the
+Constraint is defined.) The <Constraint name> must be unique (for all
+Constraints and Assertions) within the Schema that owns it. If ``CREATE
+TABLE``, ``ALTER TABLE``, ``CREATE DOMAIN`` or ``ALTER DOMAIN`` are part of a
+``CREATE SCHEMA`` statement, the <Constraint name>, if explicitly qualified,
+must include the <Schema name> of the Schema being created; that is, it isn't
+possible to create a Constraint belonging to a different Schema from within
+``CREATE SCHEMA``.
 
 *Types of Constraints*
 ----------------------
@@ -548,25 +550,25 @@ Column of a Base Table. You may define a <Column Constraint> only within a
 <Table Constraint> for the Table that owns the Column that the Constraint is
 defined for.
 
-A <Domain Constraint> defines a rule that limits the set of values for every 
-Column that is based on the Domain that the Constraint is defined for. One or 
-more Columns from one or more Base tables may thus be affected by a <Domain 
-Constraint>. A <Domain Constraint> is a ``CHECK`` Constraint that uses the 
-<value specification> ``VALUE``. 
+A <Domain Constraint> defines a rule that limits the set of values for every
+Column that is based on the Domain that the Constraint is defined for. One or
+more Columns from one or more Base tables may thus be affected by a <Domain
+Constraint>. A <Domain Constraint> is a ``CHECK`` Constraint that uses the
+<value specification> ``VALUE``.
 
 *Deferral Mode*
 ---------------
 
-A Constraint definition may include a specification of the Constraint's 
-deferral mode: either ``DEFERRABLE`` or ``NOT DEFERRABLE``. A deferral mode of 
-``NOT DEFERRABLE`` means that your DBMS will check the Constraint for violation 
-immediately after executing every SQL statement in a transaction. A deferral 
-mode of ``DEFERRABLE`` means that your DBMS may defer checking the Constraint 
-for violation until the end of the transaction. If you omit the deferral mode 
-specification from a Constraint definition, the Constraint's deferral mode 
-depends on its initial constraint check time: the deferral mode for an 
-``INITIALLY DEFERRED`` Constraint defaults to ``DEFERRABLE`` and the deferral 
-mode for an ``INITIALLY IMMEDIATE`` Constraint defaults to ``NOT DEFERRABLE``. 
+A Constraint definition may include a specification of the Constraint's
+deferral mode: either ``DEFERRABLE`` or ``NOT DEFERRABLE``. A deferral mode of
+``NOT DEFERRABLE`` means that your DBMS will check the Constraint for violation
+immediately after executing every SQL statement in a transaction. A deferral
+mode of ``DEFERRABLE`` means that your DBMS may defer checking the Constraint
+for violation until the end of the transaction. If you omit the deferral mode
+specification from a Constraint definition, the Constraint's deferral mode
+depends on its initial constraint check time: the deferral mode for an
+``INITIALLY DEFERRED`` Constraint defaults to ``DEFERRABLE`` and the deferral
+mode for an ``INITIALLY IMMEDIATE`` Constraint defaults to ``NOT DEFERRABLE``.
 
 *Constraint Check Time*
 -----------------------
@@ -577,56 +579,56 @@ IMMEDIATE``. If you omit the constraint check time specification from a
 Constraint definition, the Constraint will have a constraint check time of
 ``INITIALLY IMMEDIATE``.
 
-If its initial constraint check time is ``INITIALLY DEFERRED``, a Constraint's 
-deferral mode must be ``DEFERRABLE`` and its constraint check time will be 
-``DEFERRED`` at the beginning of every transaction. You may use the ``SET 
-CONSTRAINTS`` statement to change a ``DEFERRABLE INITIALLY DEFERRED`` 
-Constraint's constraint check time for a transaction (this is the current 
-constraint check time) to ``IMMEDIATE``. 
+If its initial constraint check time is ``INITIALLY DEFERRED``, a Constraint's
+deferral mode must be ``DEFERRABLE`` and its constraint check time will be
+``DEFERRED`` at the beginning of every transaction. You may use the ``SET
+CONSTRAINTS`` statement to change a ``DEFERRABLE INITIALLY DEFERRED``
+Constraint's constraint check time for a transaction (this is the current
+constraint check time) to ``IMMEDIATE``.
 
-If its initial constraint check time is ``INITIALLY IMMEDIATE``, a Constraint's 
-deferral mode may be either ``DEFERRABLE`` or ``NOT DEFERRABLE`` and its 
-constraint check time will be ``IMMEDIATE`` at the beginning of every 
-transaction. You may use the ``SET CONSTRAINTS`` statement to change a 
-``DEFERRABLE INITIALLY IMMEDIATE`` Constraint's constraint check time for a 
-transaction to ``DEFERRED`` but you may not use ``SET CONSTRAINTS`` on a ``NOT 
-DEFERRABLE INITIALLY IMMEDIATE`` Constraint because such Constraints can't have 
-their constraint check times changed. 
+If its initial constraint check time is ``INITIALLY IMMEDIATE``, a Constraint's
+deferral mode may be either ``DEFERRABLE`` or ``NOT DEFERRABLE`` and its
+constraint check time will be ``IMMEDIATE`` at the beginning of every
+transaction. You may use the ``SET CONSTRAINTS`` statement to change a
+``DEFERRABLE INITIALLY IMMEDIATE`` Constraint's constraint check time for a
+transaction to ``DEFERRED`` but you may not use ``SET CONSTRAINTS`` on a ``NOT
+DEFERRABLE INITIALLY IMMEDIATE`` Constraint because such Constraints can't have
+their constraint check times changed.
 
-Immediately after executing any SQL statement, your DBMS checks every 
-Constraint with a current constraint check time of ``IMMEDIATE`` for violation, 
-but does not check the Constraints with a current constraint check time of 
-``DEFERRED``. At the end of a transaction, any Constraints with a current 
-constraint check time of ``DEFERRED`` have it changed to ``IMMEDIATE`` -- thus, 
-your DBMS checks every Constraint for violation at the end of a transaction. 
-When checked, if any Constraint is violated, the SQL statement that caused it 
-to be checked will fail: your DBMS will return the ``SQLSTATE error 23000 
-"integrity constraint violation"`` unless the SQL statement that fails is a 
-``COMMIT`` statement. If ``COMMIT`` fails, your DBMS will return the ``SQLSTATE 
-error 40002 "transaction rollback-integrity constraint violation"``. In either 
-case, the status of all SQL-data remains as it was prior to the execution of 
-the failed SQL statement. 
+Immediately after executing any SQL statement, your DBMS checks every
+Constraint with a current constraint check time of ``IMMEDIATE`` for violation,
+but does not check the Constraints with a current constraint check time of
+``DEFERRED``. At the end of a transaction, any Constraints with a current
+constraint check time of ``DEFERRED`` have it changed to ``IMMEDIATE`` -- thus,
+your DBMS checks every Constraint for violation at the end of a transaction.
+When checked, if any Constraint is violated, the SQL statement that caused it
+to be checked will fail: your DBMS will return the ``SQLSTATE error 23000
+"integrity constraint violation"`` unless the SQL statement that fails is a
+``COMMIT`` statement. If ``COMMIT`` fails, your DBMS will return the ``SQLSTATE
+error 40002 "transaction rollback-integrity constraint violation"``. In either
+case, the status of all SQL-data remains as it was prior to the execution of
+the failed SQL statement.
 
 .. CAUTION::
 
-   You're taking a huge risk when you use deferred Constraints, since you're 
-   not warned of any problems until ``COMMIT`` time. Remember that, at this 
+   You're taking a huge risk when you use deferred Constraints, since you're
+   not warned of any problems until ``COMMIT`` time. Remember that, at this
    point, instead of returning a message like "sorry the Constraint's been
    violated" and giving you a chance to fix the problem, your DBMS will say
-   "sorry the Constraint's been violated" and ``ROLLBACK``\s the entire 
-   transaction! In other words, although you've asked for ``COMMIT``, what 
-   you get is ``ROLLBACK``. This is perhaps the only command in any 
-   programming language where, if you ask for *x*, you not only don't get 
-   *x*, you actually get the precise reverse of *x*! If you must use 
-   deferred Constraints, add this SQL statement to your transaction before 
+   "sorry the Constraint's been violated" and ``ROLLBACK``\s the entire
+   transaction! In other words, although you've asked for ``COMMIT``, what
+   you get is ``ROLLBACK``. This is perhaps the only command in any
+   programming language where, if you ask for *x*, you not only don't get
+   *x*, you actually get the precise reverse of *x*! If you must use
+   deferred Constraints, add this SQL statement to your transaction before
    you ``COMMIT``:
 
    ::
 
       SET CONSTRAINTS ALL IMMEDIATE;
 
-   The advantage of ``SET CONSTRAINTS ALL IMMEDIATE`` is that it won't 
-   ``ROLLBACK``, so if you execute it before you ``COMMIT``, you improve 
+   The advantage of ``SET CONSTRAINTS ALL IMMEDIATE`` is that it won't
+   ``ROLLBACK``, so if you execute it before you ``COMMIT``, you improve
    your chances of having something to commit.
 
 Although it's usually best to check all Constraints for violation right after
@@ -637,19 +639,19 @@ reasons why you might want to defer Constraint checking:
   transaction that temporarily throws everything out of balance), but you know
   that the situation will resolve itself by transaction end.
 
-* Because you want to subvert or ignore Constraints until there is some 
-  reason to worry about them. For example, there might be some calculations 
+* Because you want to subvert or ignore Constraints until there is some
+  reason to worry about them. For example, there might be some calculations
   that you want to perform on a "what if" basis, and the only way to get them
-  straight is by temporarily turning off the Constraint checking mechanism. 
+  straight is by temporarily turning off the Constraint checking mechanism.
   Such "what if" calculations are normally ended with a ``ROLLBACK`` statement.
 
 .. CAUTION::
 
-   There are some systems -- the notorious example is the requirement for 
-   ODBC -- which "auto-commit". This means that as soon as a SQL statement 
-   is finished, your helpful DBMS will automatically execute a ``COMMIT`` 
-   statement for you! As well as being a violation of the SQL Standard and 
-   making the ``ROLLBACK`` statement useless, this action destroys the basis 
+   There are some systems -- the notorious example is the requirement for
+   ODBC -- which "auto-commit". This means that as soon as a SQL statement
+   is finished, your helpful DBMS will automatically execute a ``COMMIT``
+   statement for you! As well as being a violation of the SQL Standard and
+   making the ``ROLLBACK`` statement useless, this action destroys the basis
    on which we lay our deferred-Constraint plans.
 
 Here is an example of a SQL statement that adds a ``NOT DEFERRABLE INITIALLY
@@ -668,7 +670,7 @@ Table:
    ALTER TABLE Table_1 ADD CONSTRAINT constraint_1
       CHECK (column_1 > 500) DEFERRABLE INITIALLY IMMEDIATE;
 
-This SQL statement adds a ``DEFERRABLE INITIALLY DEFERRED`` Constraint to a 
+This SQL statement adds a ``DEFERRABLE INITIALLY DEFERRED`` Constraint to a
 Table:
 
 ::
@@ -700,23 +702,23 @@ The required syntax for a ``UNIQUE`` Constraint is:
     <Column name> UNIQUE
     [ <constraint attributes> ]
 
-A Base table may be constrained by zero or more ``UNIQUE`` Constraints, each 
-specifying a rule that a group of one or more Columns (the unique key) may 
-contain only unique values. You can't define a unique key with Columns that 
-have a <data type> of ``BLOB``, ``CLOB``, ``NCLOB`` or ``ARRAY``. A unique key 
-is also known as a candidate key of the Table. The main reasons you need 
-candidate keys are *(a)* to get row-level addressing, *(b)* so that foreign 
-keys can reference the candidate key and *(c)* to prevent duplication (keyboard 
-errors, etc). 
+A Base table may be constrained by zero or more ``UNIQUE`` Constraints, each
+specifying a rule that a group of one or more Columns (the unique key) may
+contain only unique values. You can't define a unique key with Columns that
+have a <data type> of ``BLOB``, ``CLOB``, ``NCLOB`` or ``ARRAY``. A unique key
+is also known as a candidate key of the Table. The main reasons you need
+candidate keys are *(a)* to get row-level addressing, *(b)* so that foreign
+keys can reference the candidate key and *(c)* to prevent duplication (keyboard
+errors, etc).
 
-Each ``UNIQUE`` Constraint must name a set of Columns that is different from 
-the set of Columns named by any other ``UNIQUE`` or ``PRIMARY KEY`` Constraint 
-defined for the Table. If you use ``UNIQUE (VALUE)`` to define a ``UNIQUE`` 
-Constraint, you're constraining the Table that owns the Constraint to have just 
-that one ``UNIQUE`` Constraint and -- since a ``PRIMARY KEY`` Constraint is a 
-type of ``UNIQUE`` Constraint -- you're also constraining that Table not to 
-have any ``PRIMARY KEY`` Constraint. ``UNIQUE (VALUE)`` constrains the entire 
-row of the Table to be unique from any other row. 
+Each ``UNIQUE`` Constraint must name a set of Columns that is different from
+the set of Columns named by any other ``UNIQUE`` or ``PRIMARY KEY`` Constraint
+defined for the Table. If you use ``UNIQUE (VALUE)`` to define a ``UNIQUE``
+Constraint, you're constraining the Table that owns the Constraint to have just
+that one ``UNIQUE`` Constraint and -- since a ``PRIMARY KEY`` Constraint is a
+type of ``UNIQUE`` Constraint -- you're also constraining that Table not to
+have any ``PRIMARY KEY`` Constraint. ``UNIQUE (VALUE)`` constrains the entire
+row of the Table to be unique from any other row.
 
 Here are some examples of ``UNIQUE`` Constraint definitions:
 
@@ -737,7 +739,7 @@ Here are some examples of ``UNIQUE`` Constraint definitions:
       UNIQUE(column_1,column_2) DEFERRED INITIALLY DEFERRED;
    -- defines a UNIQUE <Table Constraint> in ALTER TABLE
 
-Once created, a ``UNIQUE`` <Column Constraint> logically becomes a 
+Once created, a ``UNIQUE`` <Column Constraint> logically becomes a
 ``UNIQUE`` <TableConstraint>. The <Column Constraint> in this SQL statement:
 
 ::
@@ -753,12 +755,12 @@ is therefore equivalent to the <Table Constraint> in this SQL statement:
       column_1 SMALLINT,
       UNIQUE(column_1));
 
-A ``UNIQUE`` Constraint makes it impossible to ``COMMIT`` any operation that 
-would cause the unique key to contain any non-null duplicate values. (Multiple 
-null values are allowed, since the null value is never equal to anything, even 
-another null value.) A ``UNIQUE`` Constraint is violated if its condition is 
-``FALSE`` for any row of the Table it belongs to. Consider these SQL 
-statements: 
+A ``UNIQUE`` Constraint makes it impossible to ``COMMIT`` any operation that
+would cause the unique key to contain any non-null duplicate values. (Multiple
+null values are allowed, since the null value is never equal to anything, even
+another null value.) A ``UNIQUE`` Constraint is violated if its condition is
+``FALSE`` for any row of the Table it belongs to. Consider these SQL
+statements:
 
 ::
 
@@ -774,18 +776,18 @@ statements:
 For this example, ``CONSTRAINT_1`` would be violated only if you tried to
 ``INSERT`` another {``1``, ``'hello'``} row into ``TABLE_1``: a {``1``,
 ``'bye'``} row, a {``2``, ``'hello'``} row, a {null, ``'hello'``} row, a
-{``1``, null} row and a {null, null} row would all satisfy the Constraint. 
+{``1``, null} row and a {null, null} row would all satisfy the Constraint.
 
-If you want to restrict your code to Core SQL, don't use the ``UNIQUE(VALUE)`` 
-form to define a ``UNIQUE`` Constraint and don't add a ``NOT NULL`` Constraint 
-to any Column that is part of a unique key for a ``UNIQUE`` Constraint. 
+If you want to restrict your code to Core SQL, don't use the ``UNIQUE(VALUE)``
+form to define a ``UNIQUE`` Constraint and don't add a ``NOT NULL`` Constraint
+to any Column that is part of a unique key for a ``UNIQUE`` Constraint.
 
 Constraint_type -- PRIMARY KEY Constraint
 =========================================
 
-A ``PRIMARY KEY`` Constraint is either a <Table Constraint> or a <Column 
-Constraint> and defines a rule that constrains a unique key to non-duplicate, 
-non-null values only. The required syntax for a ``PRIMARY KEY`` Constraint is: 
+A ``PRIMARY KEY`` Constraint is either a <Table Constraint> or a <Column
+Constraint> and defines a rule that constrains a unique key to non-duplicate,
+non-null values only. The required syntax for a ``PRIMARY KEY`` Constraint is:
 
 ::
 
@@ -799,17 +801,17 @@ non-null values only. The required syntax for a ``PRIMARY KEY`` Constraint is:
     <Column name> PRIMARY KEY
     [ <constraint attributes> ]
 
-A Base table may be constrained by no more than one ``PRIMARY KEY`` Constraint, 
-which specifies a rule that a group of one or more Columns is the Table's 
-primary key. A primary key is the set of Columns in a Base table that (because 
-they will be used as the main unique identifier for a row) must contain only 
-unique and not null values. You can't define a primary key with Columns that 
-have a <data type> of ``BLOB``, ``CLOB``, ``NCLOB`` or ``ARRAY``. 
+A Base table may be constrained by no more than one ``PRIMARY KEY`` Constraint,
+which specifies a rule that a group of one or more Columns is the Table's
+primary key. A primary key is the set of Columns in a Base table that (because
+they will be used as the main unique identifier for a row) must contain only
+unique and not null values. You can't define a primary key with Columns that
+have a <data type> of ``BLOB``, ``CLOB``, ``NCLOB`` or ``ARRAY``.
 
-A Table's ``PRIMARY KEY`` Constraint must name a set of Columns that is 
-different from the set of Columns named by any other ``UNIQUE`` Constraint 
-defined for the Table. Which unique key should be the primary key for a Table? 
-The criteria are: 
+A Table's ``PRIMARY KEY`` Constraint must name a set of Columns that is
+different from the set of Columns named by any other ``UNIQUE`` Constraint
+defined for the Table. Which unique key should be the primary key for a Table?
+The criteria are:
 
 * Simplicity, i.e.: the key with the fewest Columns and smallest size.
 
@@ -837,9 +839,9 @@ Here are some examples of ``PRIMARY KEY`` Constraint definitions:
       PRIMARY KEY(column_1,column_2) NOT DEFERRABLE INITIALLY IMMEDIATE;
    -- defines a PRIMARY KEY <Table Constraint> in ALTER TABLE
 
-Once created, a ``PRIMARY KEY`` <Column Constraint> logically becomes a 
-``PRIMARY KEY`` <Table Constraint>. The <Column Constraint> in this SQL 
-statement: 
+Once created, a ``PRIMARY KEY`` <Column Constraint> logically becomes a
+``PRIMARY KEY`` <Table Constraint>. The <Column Constraint> in this SQL
+statement:
 
 ::
 
@@ -854,11 +856,11 @@ is therefore equivalent to the <Table Constraint> in this SQL statement:
       column_1 SMALLINT,
       PRIMARY KEY(column_1));
 
-A ``PRIMARY KEY`` Constraint makes it impossible to ``COMMIT`` any 
-operation that would cause the unique key to contain any ``NULL``\s or 
-any duplicate values. A ``PRIMARY KEY`` Constraint is violated if its 
-condition is ``FALSE`` for any row of the Table it belongs to. Consider 
-these SQL statements: 
+A ``PRIMARY KEY`` Constraint makes it impossible to ``COMMIT`` any
+operation that would cause the unique key to contain any ``NULL``\s or
+any duplicate values. A ``PRIMARY KEY`` Constraint is violated if its
+condition is ``FALSE`` for any row of the Table it belongs to. Consider
+these SQL statements:
 
 ::
 
@@ -870,23 +872,23 @@ these SQL statements:
    INSERT INTO Table_1 (column_1, column_2)
    VALUES (1, 'hello');
 
-For this example, ``CONSTRAINT_1`` would be violated if you tried to ``INSERT`` 
-another {``1, 'hello'``} row into ``TABLE_1`` or if you tried to insert a 
-{null, ``'hello'``} row, a {``1``, null} row or a {null, null} into 
-``TABLE_1``. 
+For this example, ``CONSTRAINT_1`` would be violated if you tried to ``INSERT``
+another {``1, 'hello'``} row into ``TABLE_1`` or if you tried to insert a
+{null, ``'hello'``} row, a {``1``, null} row or a {null, null} into
+``TABLE_1``.
 
-The uniqueness of a primary key helps guarantee the integrity of your data. 
-Once you've defined a primary key for a Table, you're protected from simple 
-errors like putting in the same person twice. More importantly, or at least 
-equally importantly, you have the reflection of the "real world" fact that two 
-things aren't alike in every respect -- if they were, they'd form the same 
-record. When you declare a primary key, you are hinting to your DBMS that the 
-data in the key is relatively static. Many attributes of a Table are transient: 
-an employee's salary, age, weight, title, evaluation, etc. But a primary key 
-Column's values tend to be stable -- we don't change people's names or our part 
-numbers very often. A primary key identifier also comes in handy when you're 
-splitting your data into two Tables. For example, consider an "Internet 
-address". You might start off with this Table definition: 
+The uniqueness of a primary key helps guarantee the integrity of your data.
+Once you've defined a primary key for a Table, you're protected from simple
+errors like putting in the same person twice. More importantly, or at least
+equally importantly, you have the reflection of the "real world" fact that two
+things aren't alike in every respect -- if they were, they'd form the same
+record. When you declare a primary key, you are hinting to your DBMS that the
+data in the key is relatively static. Many attributes of a Table are transient:
+an employee's salary, age, weight, title, evaluation, etc. But a primary key
+Column's values tend to be stable -- we don't change people's names or our part
+numbers very often. A primary key identifier also comes in handy when you're
+splitting your data into two Tables. For example, consider an "Internet
+address". You might start off with this Table definition:
 
 ::
 
@@ -894,13 +896,13 @@ address". You might start off with this Table definition:
       table_id VARCHAR(40),
       int_address VARCHAR(50));
 
-This is fine as long as whomever is represented in the ``TABLE_ID`` Column only 
-has one Internet address. But that person now gives you the Internet address 
-used at work -- and perhaps at several other locations. Should you have a 
-repeating Column (``ARRAY``) for this data? Well maybe, but the use of 
-non-atomic values is still frowned on and deservedly has a bad rep -- see our 
-chapter on <collection type>s for a discussion of the problem. The classic 
-relational solution is to split your data into two Tables. For example: 
+This is fine as long as whomever is represented in the ``TABLE_ID`` Column only
+has one Internet address. But that person now gives you the Internet address
+used at work -- and perhaps at several other locations. Should you have a
+repeating Column (``ARRAY``) for this data? Well maybe, but the use of
+non-atomic values is still frowned on and deservedly has a bad rep -- see our
+chapter on <collection type>s for a discussion of the problem. The classic
+relational solution is to split your data into two Tables. For example:
 
 ::
 
@@ -955,12 +957,12 @@ syntax for a ``FOREIGN KEY`` Constraint is:
        [ <referential triggered action> ]
     [ <constraint attributes> ]
 
-A Base table may be constrained by zero or more ``FOREIGN KEY`` Constraints, 
-which specify a rule that a group of one or more Columns of the Table may 
-contain only those values found in a similar set of unique Columns belonging to 
-(usually) another Table. You can't define a foreign key with Columns that have 
-a <data type> of ``BLOB``, ``CLOB``, ``NCLOB`` or ``ARRAY``. Here are some 
-examples of ``FOREIGN KEY`` Constraint definitions: 
+A Base table may be constrained by zero or more ``FOREIGN KEY`` Constraints,
+which specify a rule that a group of one or more Columns of the Table may
+contain only those values found in a similar set of unique Columns belonging to
+(usually) another Table. You can't define a foreign key with Columns that have
+a <data type> of ``BLOB``, ``CLOB``, ``NCLOB`` or ``ARRAY``. Here are some
+examples of ``FOREIGN KEY`` Constraint definitions:
 
 ::
 
@@ -981,9 +983,9 @@ examples of ``FOREIGN KEY`` Constraint definitions:
          DEFERRABLE INITIALLY IMMEDIATE;
    -- defines a FOREIGN KEY <Table Constraint> in ALTER TABLE
 
-Once created, a ``FOREIGN KEY`` <Column Constraint> logically becomes a 
-``FOREIGN KEY`` <Table Constraint>. The <Column Constraint> in this SQL 
-statement: 
+Once created, a ``FOREIGN KEY`` <Column Constraint> logically becomes a
+``FOREIGN KEY`` <Table Constraint>. The <Column Constraint> in this SQL
+statement:
 
 ::
 
@@ -998,67 +1000,67 @@ is therefore equivalent to the <Table Constraint> in this SQL statement:
       column_1 SMALLINT,
       FOREIGN KEY(column_1) REFERENCES Table_1);
 
-The rationale for a foreign key is: you can't have an employee in department D 
-if there is no department D, you can't have a branch that produces Widgets if 
-you don't have a product called a Widget, you can't locate an office in state = 
-'TY' if there is no state named 'Tynnessee'. A ``FOREIGN KEY`` Constraint 
-forges a link between the referencing Table and the referenced Table: it makes 
-it impossible to ``COMMIT`` any operation that would cause the foreign key to 
-contain any values that are not found in the referenced unique key. (The 
-referencing Table is the Table that the ``FOREIGN KEY`` Constraint belongs to; 
-the foreign key itself is made up of one or more Columns of that Table: these 
-are called the *referencing Columns*. The referenced Table is the Table that 
-contains the unique key that the foreign key must match: the Columns that make 
-up that unique key are called the referenced Columns. SQL allows the 
-referencing Table and the referenced Table to be the same.) In the usual 
-situation, illustrated in the examples above (other actions can be specified), 
-the Constraint makes it impossible to drop ``TABLE_1`` (because ``TABLE_2`` 
-references it), or to delete or change a row in ``TABLE_1`` so that ``TABLE_2`` 
-is left with unmatched referencing values, or to insert a row into ``TABLE_2`` 
-unless its referencing values are matched somewhere in ``TABLE_1``. A ``FOREIGN 
-KEY`` Constraint is violated if its condition is ``FALSE`` for any row of the 
-Table it belongs to. The result of the evaluation of the ``FOREIGN KEY`` 
-Constraint condition depends on the presence of null values and the degree of 
-matching specified for the Constraint; see the comments on the ``MATCH`` 
-clause, later in this section. 
+The rationale for a foreign key is: you can't have an employee in department D
+if there is no department D, you can't have a branch that produces Widgets if
+you don't have a product called a Widget, you can't locate an office in state =
+'TY' if there is no state named 'Tynnessee'. A ``FOREIGN KEY`` Constraint
+forges a link between the referencing Table and the referenced Table: it makes
+it impossible to ``COMMIT`` any operation that would cause the foreign key to
+contain any values that are not found in the referenced unique key. (The
+referencing Table is the Table that the ``FOREIGN KEY`` Constraint belongs to;
+the foreign key itself is made up of one or more Columns of that Table: these
+are called the *referencing Columns*. The referenced Table is the Table that
+contains the unique key that the foreign key must match: the Columns that make
+up that unique key are called the referenced Columns. SQL allows the
+referencing Table and the referenced Table to be the same.) In the usual
+situation, illustrated in the examples above (other actions can be specified),
+the Constraint makes it impossible to drop ``TABLE_1`` (because ``TABLE_2``
+references it), or to delete or change a row in ``TABLE_1`` so that ``TABLE_2``
+is left with unmatched referencing values, or to insert a row into ``TABLE_2``
+unless its referencing values are matched somewhere in ``TABLE_1``. A ``FOREIGN
+KEY`` Constraint is violated if its condition is ``FALSE`` for any row of the
+Table it belongs to. The result of the evaluation of the ``FOREIGN KEY``
+Constraint condition depends on the presence of null values and the degree of
+matching specified for the Constraint; see the comments on the ``MATCH``
+clause, later in this section.
 
 *Referencing Columns*
 ---------------------
 
-The ``FOREIGN KEY`` clause of a ``FOREIGN KEY`` <Table Constraint> definition 
-names the referencing Columns: the group of one or more Columns that make up 
-the foreign key (a Column may appear in the list only once). You may specify 
-only unqualified <Column name>s in this clause. 
+The ``FOREIGN KEY`` clause of a ``FOREIGN KEY`` <Table Constraint> definition
+names the referencing Columns: the group of one or more Columns that make up
+the foreign key (a Column may appear in the list only once). You may specify
+only unqualified <Column name>s in this clause.
 
 *Referenced Table and Columns*
 ------------------------------
 
-The ``REFERENCES`` clause of a ``FOREIGN KEY`` Constraint definition names the 
-referenced Base table: the Base table that contains the referenced unique key. 
-The Table types must match: if the Table that owns the ``FOREIGN KEY`` 
-Constraint is a persistent Base table, the referenced Table must also be a 
-persistent Base Table; if the referencing Table is a ``GLOBAL TEMPORARY`` Base 
-table, the referenced Table must also be a ``GLOBAL TEMPORARY`` Base Table; if 
-the referencing Table is a created ``LOCAL TEMPORARY`` Base table, the 
-referenced Table must be either a ``GLOBAL TEMPORARY`` Base Table or a created 
-``LOCAL TEMPORARY`` Base table; if the referencing Table is a declared ``LOCAL 
-TEMPORARY`` Base table, the referenced Table must be either a ``GLOBAL 
-TEMPORARY`` Base Table, a created ``LOCAL TEMPORARY`` Base table or a declared 
-``LOCAL TEMPORARY`` Base table; and if the referencing Table is any temporary 
-Base table defined with an ``ON COMMIT DELETE ROWS`` clause, the referenced 
-Table must also be a temporary Base Table defined with that clause. 
+The ``REFERENCES`` clause of a ``FOREIGN KEY`` Constraint definition names the
+referenced Base table: the Base table that contains the referenced unique key.
+The Table types must match: if the Table that owns the ``FOREIGN KEY``
+Constraint is a persistent Base table, the referenced Table must also be a
+persistent Base Table; if the referencing Table is a ``GLOBAL TEMPORARY`` Base
+table, the referenced Table must also be a ``GLOBAL TEMPORARY`` Base Table; if
+the referencing Table is a created ``LOCAL TEMPORARY`` Base table, the
+referenced Table must be either a ``GLOBAL TEMPORARY`` Base Table or a created
+``LOCAL TEMPORARY`` Base table; if the referencing Table is a declared ``LOCAL
+TEMPORARY`` Base table, the referenced Table must be either a ``GLOBAL
+TEMPORARY`` Base Table, a created ``LOCAL TEMPORARY`` Base table or a declared
+``LOCAL TEMPORARY`` Base table; and if the referencing Table is any temporary
+Base table defined with an ``ON COMMIT DELETE ROWS`` clause, the referenced
+Table must also be a temporary Base Table defined with that clause.
 
-The referenced Columns, optionally named in the ``REFERENCES`` clause of a 
-``FOREIGN KEY`` Constraint definition, are the group of one or more Columns 
-that make up the referenced unique key (that is, the referenced Columns must be 
-named in a ``NOT DEFERRABLE UNIQUE`` or ``NOT DEFERRABLE PRIMARY KEY`` 
-Constraint that belongs to the referenced Table and may therefore appear in the 
-list only once). You may specify only unqualified <Column name>s in this 
-clause. The Columns in the foreign key must match the number of, and have a 
-comparable <data type> with, the corresponding Columns in the referenced unique 
-key. If you omit the referenced Columns list from a ``FOREIGN KEY`` Constraint 
-definition, the referenced Table must be constrained by a ``NOT DEFERRABLE 
-PRIMARY KEY`` Constraint; the primary key is also the referenced unique key. 
+The referenced Columns, optionally named in the ``REFERENCES`` clause of a
+``FOREIGN KEY`` Constraint definition, are the group of one or more Columns
+that make up the referenced unique key (that is, the referenced Columns must be
+named in a ``NOT DEFERRABLE UNIQUE`` or ``NOT DEFERRABLE PRIMARY KEY``
+Constraint that belongs to the referenced Table and may therefore appear in the
+list only once). You may specify only unqualified <Column name>s in this
+clause. The Columns in the foreign key must match the number of, and have a
+comparable <data type> with, the corresponding Columns in the referenced unique
+key. If you omit the referenced Columns list from a ``FOREIGN KEY`` Constraint
+definition, the referenced Table must be constrained by a ``NOT DEFERRABLE
+PRIMARY KEY`` Constraint; the primary key is also the referenced unique key.
 
 Here are some more examples of ``FOREIGN KEY`` Constraint definitions:
 
@@ -1114,19 +1116,19 @@ Here are some more examples of ``FOREIGN KEY`` Constraint definitions:
 *Privileges*
 ------------
 
-In order to create a ``FOREIGN KEY`` Constraint, the <AuthorizationID> that 
-owns the referencing Table must be the current <AuthorizationID> and must have 
-the ``REFERENCES`` Privilege on every referenced Column named. 
+In order to create a ``FOREIGN KEY`` Constraint, the <AuthorizationID> that
+owns the referencing Table must be the current <AuthorizationID> and must have
+the ``REFERENCES`` Privilege on every referenced Column named.
 
 *MATCH Clause*
 --------------
 
-The optional ``MATCH`` clause of a ``FOREIGN KEY`` Constraint definition 
-specifies the degree of the required match between the values of the foreign 
-key and the referenced unique key. There are three match options: ``MATCH 
-SIMPLE``, ``MATCH FULL`` and ``MATCH PARTIAL``. If you omit the ``MATCH`` 
-clause, it defaults to ``MATCH SIMPLE``. For example, these two SQL statements 
-are equivalent: 
+The optional ``MATCH`` clause of a ``FOREIGN KEY`` Constraint definition
+specifies the degree of the required match between the values of the foreign
+key and the referenced unique key. There are three match options: ``MATCH
+SIMPLE``, ``MATCH FULL`` and ``MATCH PARTIAL``. If you omit the ``MATCH``
+clause, it defaults to ``MATCH SIMPLE``. For example, these two SQL statements
+are equivalent:
 
 ::
 
@@ -1138,15 +1140,15 @@ are equivalent:
       column_1 SMALLINT,
       CONSTRAINT constraint_1 REFERENCES Table_1 MATCH SIMPLE);
 
-The ``MATCH`` option specified for a ``FOREIGN KEY`` Constraint has an effect 
-only when your foreign key contains null values. 
+The ``MATCH`` option specified for a ``FOREIGN KEY`` Constraint has an effect
+only when your foreign key contains null values.
 
-For ``MATCH SIMPLE``, a ``FOREIGN KEY`` Constraint is satisfied if, for each 
-row of the referencing Table, either *(a)* at least one of the foreign key 
-Columns is ``NULL`` or *(b)* none of the foreign key Columns is ``NULL`` and 
-the value of the entire foreign key equals the value of the entire unique key 
-in at least one row of the referenced Table. For example, given a referenced 
-Table with these two unique key rows: 
+For ``MATCH SIMPLE``, a ``FOREIGN KEY`` Constraint is satisfied if, for each
+row of the referencing Table, either *(a)* at least one of the foreign key
+Columns is ``NULL`` or *(b)* none of the foreign key Columns is ``NULL`` and
+the value of the entire foreign key equals the value of the entire unique key
+in at least one row of the referenced Table. For example, given a referenced
+Table with these two unique key rows:
 
 ::
 
@@ -1167,16 +1169,16 @@ and this foreign key row is invalid:
 
    {10,'huge'} -- because no matching unique key row exists
 
-For ``MATCH FULL``, a ``FOREIGN KEY`` Constraint is satisfied if, for each row 
-of the referencing Table, either *(a)* every foreign key Column is ``NULL`` or 
-*(b)* none of the foreign key Columns is ``NULL`` and the value of the entire 
-foreign key equals the value of the entire unique key in at least one row of 
-the referenced Table. (If you define a ``FOREIGN KEY`` Constraint with ``MATCH 
-FULL`` and there is either *(a)* only one Column in the foreign key or *(b)* 
-one or more Columns defined as ``NOT NULL`` in the foreign key, then the 
-Constraint will have the same effect as if you had defined the Constraint with 
-``MATCH SIMPLE``.) For example, given a referenced Table with these two unique 
-key rows: 
+For ``MATCH FULL``, a ``FOREIGN KEY`` Constraint is satisfied if, for each row
+of the referencing Table, either *(a)* every foreign key Column is ``NULL`` or
+*(b)* none of the foreign key Columns is ``NULL`` and the value of the entire
+foreign key equals the value of the entire unique key in at least one row of
+the referenced Table. (If you define a ``FOREIGN KEY`` Constraint with ``MATCH
+FULL`` and there is either *(a)* only one Column in the foreign key or *(b)*
+one or more Columns defined as ``NOT NULL`` in the foreign key, then the
+Constraint will have the same effect as if you had defined the Constraint with
+``MATCH SIMPLE``.) For example, given a referenced Table with these two unique
+key rows:
 
 ::
 
@@ -1197,15 +1199,15 @@ and these foreign key rows are invalid:
    {NULL,'tiny'} {10,NULL} -- because, in each case, only some of the foreign
    key is NULL
 
-For ``MATCH PARTIAL``, a ``FOREIGN KEY`` Constraint is satisfied if, for each 
-row of the referencing Table, at least one foreign key Column is ``NULL`` and 
-the values of the rest of the foreign key Columns equal the values of the 
-corresponding unique key Columns in at least one row of the referenced Table. 
-(If you define a ``FOREIGN KEY`` Constraint with ``MATCH PARTIAL`` and there is 
-either *(a)* only one Column in the foreign key or *(b)* one or more Columns 
-defined as ``NOT NULL`` in the foreign key, then the Constraint will have the 
-same effect as if you had defined the Constraint with ``MATCH SIMPLE``.) For 
-example, given a referenced Table with these two unique key rows: 
+For ``MATCH PARTIAL``, a ``FOREIGN KEY`` Constraint is satisfied if, for each
+row of the referencing Table, at least one foreign key Column is ``NULL`` and
+the values of the rest of the foreign key Columns equal the values of the
+corresponding unique key Columns in at least one row of the referenced Table.
+(If you define a ``FOREIGN KEY`` Constraint with ``MATCH PARTIAL`` and there is
+either *(a)* only one Column in the foreign key or *(b)* one or more Columns
+defined as ``NOT NULL`` in the foreign key, then the Constraint will have the
+same effect as if you had defined the Constraint with ``MATCH SIMPLE``.) For
+example, given a referenced Table with these two unique key rows:
 
 ::
 
@@ -1238,20 +1240,20 @@ and these foreign key rows are invalid:
 *Referential Action*
 --------------------
 
-What happens if you ``UPDATE`` a primary key? What happens if you ``DELETE`` a 
-primary key? Neither should happen often, but if you must, remember that the 
-rule for primary/foreign key relationships is in terms of database states: "no 
-foreign key shall dangle". There are two ways to get rid of a dangling key: 
-prevent it from happening in the first place, or compensate if it does happen. 
-You can do this by defining your ``FOREIGN KEY`` Constraints with one ``ON 
-UPDATE`` clause and/or one ``ON DELETE`` clause, in any order. The optional 
-``ON UPDATE`` clause specifies the action you want your DBMS to take when an 
-``UPDATE`` operation on the referenced Table causes the ``FOREIGN KEY`` 
-Constraint to be violated. The optional ``ON DELETE`` clause specifies the 
-action you want your DBMS to take when a ``DELETE`` operation on the referenced 
-Table causes the ``FOREIGN KEY`` Constraint to be violated. If you omit either 
-clause, both default to ``ON UPDATE NO ACTION`` and ``ON DELETE NO ACTION``. 
-For example, these two SQL statements are equivalent: 
+What happens if you ``UPDATE`` a primary key? What happens if you ``DELETE`` a
+primary key? Neither should happen often, but if you must, remember that the
+rule for primary/foreign key relationships is in terms of database states: "no
+foreign key shall dangle". There are two ways to get rid of a dangling key:
+prevent it from happening in the first place, or compensate if it does happen.
+You can do this by defining your ``FOREIGN KEY`` Constraints with one ``ON
+UPDATE`` clause and/or one ``ON DELETE`` clause, in any order. The optional
+``ON UPDATE`` clause specifies the action you want your DBMS to take when an
+``UPDATE`` operation on the referenced Table causes the ``FOREIGN KEY``
+Constraint to be violated. The optional ``ON DELETE`` clause specifies the
+action you want your DBMS to take when a ``DELETE`` operation on the referenced
+Table causes the ``FOREIGN KEY`` Constraint to be violated. If you omit either
+clause, both default to ``ON UPDATE NO ACTION`` and ``ON DELETE NO ACTION``.
+For example, these two SQL statements are equivalent:
 
 ::
 
@@ -1264,115 +1266,115 @@ For example, these two SQL statements are equivalent:
       CONSTRAINT constraint_1 REFERENCES Table_1
          ON UPDATE NO ACTION ON DELETE NO ACTION);
 
-Besides ``NO ACTION``, you may also specify these actions in the ``ON UPDATE`` 
-and ``ON DELETE`` clauses: ``RESTRICT``, ``CASCADE``, ``SET NULL`` and ``SET 
-DEFAULT``. To decide which to use, consider first what you would like to 
-happen. Should you be prevented from leaving a dangling reference -- or should 
-you change the dangling reference too? (A *dangling reference* is a foreign key 
-that doesn't point to a unique key any more, and it isn't allowed in SQL.) If 
-you do change the dangling reference, should you be changing to *(a)* the same 
-value as the new unique key, *(b)* ``NULL`` or *(c)* some other value? Or 
-should the change be a deletion? All these options are available. The action 
-taken by your DBMS in all cases depends on the definition of "matching rows" 
-for the ``FOREIGN KEY`` Constraint: this, in turn, depends on the ``FOREIGN 
-KEY`` Constraint's ``MATCH`` option. 
+Besides ``NO ACTION``, you may also specify these actions in the ``ON UPDATE``
+and ``ON DELETE`` clauses: ``RESTRICT``, ``CASCADE``, ``SET NULL`` and ``SET
+DEFAULT``. To decide which to use, consider first what you would like to
+happen. Should you be prevented from leaving a dangling reference -- or should
+you change the dangling reference too? (A *dangling reference* is a foreign key
+that doesn't point to a unique key any more, and it isn't allowed in SQL.) If
+you do change the dangling reference, should you be changing to *(a)* the same
+value as the new unique key, *(b)* ``NULL`` or *(c)* some other value? Or
+should the change be a deletion? All these options are available. The action
+taken by your DBMS in all cases depends on the definition of "matching rows"
+for the ``FOREIGN KEY`` Constraint: this, in turn, depends on the ``FOREIGN
+KEY`` Constraint's ``MATCH`` option.
 
-For ``MATCH SIMPLE`` and ``MATCH FULL``, given a row in the referenced Table, 
-every row in your referencing Table that contains a foreign key whose value 
-equals the value of that unique key, is a matching row. For ``MATCH PARTIAL``, 
-given a row in the referenced Table, every row in your referencing Table that 
-contains a foreign key with at least one non-null Column whose value equals the 
-value of that unique key, is a matching row -- and a matching row that matches 
-only one row of the referenced Table is a unique matching row. 
+For ``MATCH SIMPLE`` and ``MATCH FULL``, given a row in the referenced Table,
+every row in your referencing Table that contains a foreign key whose value
+equals the value of that unique key, is a matching row. For ``MATCH PARTIAL``,
+given a row in the referenced Table, every row in your referencing Table that
+contains a foreign key with at least one non-null Column whose value equals the
+value of that unique key, is a matching row -- and a matching row that matches
+only one row of the referenced Table is a unique matching row.
 
 * If you define a ``FOREIGN KEY`` Constraint with ``MATCH SIMPLE ON DELETE
-  CASCADE`` or with ``MATCH FULL ON DELETE CASCADE``, every time you 
-  ``DELETE`` rows from the referenced Table, your DBMS will also ``DELETE`` 
-  all matching rows from the referencing Table. If you define a ``FOREIGN 
-  KEY`` Constraint with ``MATCH PARTIAL ON DELETE CASCADE``, every time you 
-  ``DELETE`` rows from the referenced Table, your DBMS will also ``DELETE`` 
+  CASCADE`` or with ``MATCH FULL ON DELETE CASCADE``, every time you
+  ``DELETE`` rows from the referenced Table, your DBMS will also ``DELETE``
+  all matching rows from the referencing Table. If you define a ``FOREIGN
+  KEY`` Constraint with ``MATCH PARTIAL ON DELETE CASCADE``, every time you
+  ``DELETE`` rows from the referenced Table, your DBMS will also ``DELETE``
   all unique matching rows from the referencing Table.
 
-* If you define a ``FOREIGN KEY`` Constraint with ``MATCH SIMPLE ON DELETE 
-  SET NULL`` or with ``MATCH FULL ON DELETE SET NULL``, every time you 
-  ``DELETE`` rows from the referenced Table, your DBMS will also set the 
-  entire foreign key in every matching row of the referencing Table to 
-  ``NULL``. If you define a ``FOREIGN KEY`` Constraint with ``MATCH PARTIAL 
-  ON DELETE SET NULL``, every time you ``DELETE`` rows from the referenced 
-  Table, your DBMS will also set the entire foreign key in every unique 
+* If you define a ``FOREIGN KEY`` Constraint with ``MATCH SIMPLE ON DELETE
+  SET NULL`` or with ``MATCH FULL ON DELETE SET NULL``, every time you
+  ``DELETE`` rows from the referenced Table, your DBMS will also set the
+  entire foreign key in every matching row of the referencing Table to
+  ``NULL``. If you define a ``FOREIGN KEY`` Constraint with ``MATCH PARTIAL
+  ON DELETE SET NULL``, every time you ``DELETE`` rows from the referenced
+  Table, your DBMS will also set the entire foreign key in every unique
   matching row of the referencing Table to ``NULL``.
 
-* If you define a ``FOREIGN KEY`` Constraint with ``MATCH SIMPLE ON DELETE 
-  SET DEFAULT`` or with ``MATCH FULL ON DELETE SET DEFAULT``, every time you 
-  ``DELETE`` rows from the referenced Table, your DBMS will also set each 
-  Column of the foreign key in every matching row of the referencing Table 
-  to its default value. If you define a ``FOREIGN KEY`` Constraint with 
-  ``MATCH PARTIAL ON DELETE SET DEFAULT``, every time you ``DELETE`` rows 
-  from the referenced Table, your DBMS will also set each Column of the 
-  foreign key in every unique matching row of the referencing Table to its 
+* If you define a ``FOREIGN KEY`` Constraint with ``MATCH SIMPLE ON DELETE
+  SET DEFAULT`` or with ``MATCH FULL ON DELETE SET DEFAULT``, every time you
+  ``DELETE`` rows from the referenced Table, your DBMS will also set each
+  Column of the foreign key in every matching row of the referencing Table
+  to its default value. If you define a ``FOREIGN KEY`` Constraint with
+  ``MATCH PARTIAL ON DELETE SET DEFAULT``, every time you ``DELETE`` rows
+  from the referenced Table, your DBMS will also set each Column of the
+  foreign key in every unique matching row of the referencing Table to its
   default value.
 
 * If you define a ``FOREIGN KEY`` Constraint with ``MATCH SIMPLE ON DELETE
-  RESTRICT`` or with ``MATCH FULL ON DELETE RESTRICT``, every time you 
-  attempt to ``DELETE`` rows from the referenced Table, your DBMS will check 
-  for matching rows in the referencing Table. If you define a ``FOREIGN 
-  KEY`` Constraint with ``MATCH PARTIAL ON DELETE RESTRICT``, every time you 
-  attempt to ``DELETE`` rows from the referenced Table, your DBMS will check 
-  for unique matching rows in the referencing Table. In either case, if any 
-  matching (or unique matching, as appropriate) rows exist, the operation 
-  will fail: your DBMS will return the ``SQLSTATE error 23001 "integrity 
-  constraint violation-restrict violation"``. A ``FOREIGN KEY`` Constraint 
-  defined with ``ON DELETE NO ACTION`` acts essentially the same as one 
+  RESTRICT`` or with ``MATCH FULL ON DELETE RESTRICT``, every time you
+  attempt to ``DELETE`` rows from the referenced Table, your DBMS will check
+  for matching rows in the referencing Table. If you define a ``FOREIGN
+  KEY`` Constraint with ``MATCH PARTIAL ON DELETE RESTRICT``, every time you
+  attempt to ``DELETE`` rows from the referenced Table, your DBMS will check
+  for unique matching rows in the referencing Table. In either case, if any
+  matching (or unique matching, as appropriate) rows exist, the operation
+  will fail: your DBMS will return the ``SQLSTATE error 23001 "integrity
+  constraint violation-restrict violation"``. A ``FOREIGN KEY`` Constraint
+  defined with ``ON DELETE NO ACTION`` acts essentially the same as one
   defined with ``ON DELETE RESTRICT``.
 
-* If you define a ``FOREIGN KEY`` Constraint with ``MATCH SIMPLE ON UPDATE 
-  CASCADE`` or with ``MATCH FULL ON UPDATE CASCADE``, every time you ``UPDATE`` 
-  a referenced Column, your DBMS will also ``UPDATE`` the corresponding foreign 
-  key Column in all matching rows of the referencing Table to the same value. 
-  If you define a ``FOREIGN KEY`` Constraint with ``MATCH PARTIAL ON UPDATE 
-  CASCADE``, every time you ``UPDATE`` a referenced Column, your DBMS will also 
-  ``UPDATE`` any corresponding non-null foreign key Column in every unique 
-  matching row of the referencing Table to the same value -- provided that, for 
-  each referencing row changed, all rows of the referenced Table that 
-  considered that referencing row to be a matching row also have the same 
-  change made. If this isn't the case, the operation will fail: your DBMS will 
-  return the ``SQLSTATE error 27000 "triggered data change violation"``. 
+* If you define a ``FOREIGN KEY`` Constraint with ``MATCH SIMPLE ON UPDATE
+  CASCADE`` or with ``MATCH FULL ON UPDATE CASCADE``, every time you ``UPDATE``
+  a referenced Column, your DBMS will also ``UPDATE`` the corresponding foreign
+  key Column in all matching rows of the referencing Table to the same value.
+  If you define a ``FOREIGN KEY`` Constraint with ``MATCH PARTIAL ON UPDATE
+  CASCADE``, every time you ``UPDATE`` a referenced Column, your DBMS will also
+  ``UPDATE`` any corresponding non-null foreign key Column in every unique
+  matching row of the referencing Table to the same value -- provided that, for
+  each referencing row changed, all rows of the referenced Table that
+  considered that referencing row to be a matching row also have the same
+  change made. If this isn't the case, the operation will fail: your DBMS will
+  return the ``SQLSTATE error 27000 "triggered data change violation"``.
 
-* If you define a ``FOREIGN KEY`` Constraint with ``MATCH SIMPLE ON UPDATE SET 
-  NULL``, every time you ``UPDATE`` a referenced Column, your DBMS will also 
-  set the corresponding foreign key Column in all matching rows of the 
-  referencing Table to ``NULL``. If you define a ``FOREIGN KEY`` Constraint 
-  with ``MATCH FULL ON UPDATE SET NULL``, every time you ``UPDATE`` a 
-  referenced Column, your DBMS will also set the entire foreign key in every 
-  matching row of the referencing Table to ``NULL``. If you define a ``FOREIGN 
-  KEY`` Constraint with ``MATCH PARTIAL ON UPDATE SET NULL``, every time you 
-  ``UPDATE`` a referenced Column, your DBMS will also set any corresponding 
-  non-null foreign key Column in every unique matching row of the referencing 
-  Table to ``NULL``. 
+* If you define a ``FOREIGN KEY`` Constraint with ``MATCH SIMPLE ON UPDATE SET
+  NULL``, every time you ``UPDATE`` a referenced Column, your DBMS will also
+  set the corresponding foreign key Column in all matching rows of the
+  referencing Table to ``NULL``. If you define a ``FOREIGN KEY`` Constraint
+  with ``MATCH FULL ON UPDATE SET NULL``, every time you ``UPDATE`` a
+  referenced Column, your DBMS will also set the entire foreign key in every
+  matching row of the referencing Table to ``NULL``. If you define a ``FOREIGN
+  KEY`` Constraint with ``MATCH PARTIAL ON UPDATE SET NULL``, every time you
+  ``UPDATE`` a referenced Column, your DBMS will also set any corresponding
+  non-null foreign key Column in every unique matching row of the referencing
+  Table to ``NULL``.
 
-* If you define a ``FOREIGN KEY`` Constraint with ``MATCH SIMPLE ON UPDATE SET 
-  DEFAULT`` or with ``MATCH FULL ON UPDATE SET DEFAULT``, every time you 
-  ``UPDATE`` a referenced Column, your DBMS will also set the corresponding 
-  foreign key Column in all matching rows of the referencing Table to its 
-  default value. If you define a ``FOREIGN KEY`` Constraint with ``MATCH 
-  PARTIAL ON UPDATE SET DEFAULT``, every time you ``UPDATE`` a referenced 
-  Column, your DBMS will also set any corresponding non-null foreign key Column 
-  in every unique matching row of the referencing Table to its default value. 
+* If you define a ``FOREIGN KEY`` Constraint with ``MATCH SIMPLE ON UPDATE SET
+  DEFAULT`` or with ``MATCH FULL ON UPDATE SET DEFAULT``, every time you
+  ``UPDATE`` a referenced Column, your DBMS will also set the corresponding
+  foreign key Column in all matching rows of the referencing Table to its
+  default value. If you define a ``FOREIGN KEY`` Constraint with ``MATCH
+  PARTIAL ON UPDATE SET DEFAULT``, every time you ``UPDATE`` a referenced
+  Column, your DBMS will also set any corresponding non-null foreign key Column
+  in every unique matching row of the referencing Table to its default value.
 
-* If you define a ``FOREIGN KEY`` Constraint with ``MATCH SIMPLE ON UPDATE 
-  RESTRICT`` or with ``MATCH FULL ON UPDATE RESTRICT``, every time you attempt 
-  to ``UPDATE`` a referenced Column, your DBMS will check for matching rows in 
-  the referencing Table. If you define a ``FOREIGN KEY`` Constraint with 
-  ``MATCH PARTIAL ON UPDATE RESTRICT``, every time you attempt to ``UPDATE`` a 
-  referenced Column, your DBMS will check for unique matching rows in the 
-  referencing Table. In either case, if any matching (or unique matching, as 
-  appropriate) rows exist, the operation will fail: your DBMS will return the 
-  ``SQLSTATE error 23001 "integrity constraint violation-restrict violation"``. 
-  A ``FOREIGN KEY`` Constraint defined with ``ON UPDATE NO ACTION`` acts 
-  essentially the same as one defined with ``ON UPDATE RESTRICT``. 
+* If you define a ``FOREIGN KEY`` Constraint with ``MATCH SIMPLE ON UPDATE
+  RESTRICT`` or with ``MATCH FULL ON UPDATE RESTRICT``, every time you attempt
+  to ``UPDATE`` a referenced Column, your DBMS will check for matching rows in
+  the referencing Table. If you define a ``FOREIGN KEY`` Constraint with
+  ``MATCH PARTIAL ON UPDATE RESTRICT``, every time you attempt to ``UPDATE`` a
+  referenced Column, your DBMS will check for unique matching rows in the
+  referencing Table. In either case, if any matching (or unique matching, as
+  appropriate) rows exist, the operation will fail: your DBMS will return the
+  ``SQLSTATE error 23001 "integrity constraint violation-restrict violation"``.
+  A ``FOREIGN KEY`` Constraint defined with ``ON UPDATE NO ACTION`` acts
+  essentially the same as one defined with ``ON UPDATE RESTRICT``.
 
-For an example of the ``NO ACTION`` / ``RESTRICT`` option, consider the 
-following SQL statements: 
+For an example of the ``NO ACTION`` / ``RESTRICT`` option, consider the
+following SQL statements:
 
 ::
 
@@ -1408,12 +1410,12 @@ is an error return, because the result in each case would be a value in
 
 .. NOTE::
 
-   The action specified for the ``ON UPDATE`` clause has no effect on 
-   ``UPDATE`` operations or ``INSERT`` operations performed on the referencing 
-   Table. Thus, an ``INSERT`` operation that attempts to put a row into 
-   ``TABLE_2``, or an ``UPDATE`` operation that attempts to change a row of 
-   ``TABLE_2``, will always fail if the resulting value in ``TABLE_2.COLUMN_1`` 
-   does not match some value of ``TABLE_1.COLUMN_1``.) 
+   The action specified for the ``ON UPDATE`` clause has no effect on
+   ``UPDATE`` operations or ``INSERT`` operations performed on the referencing
+   Table. Thus, an ``INSERT`` operation that attempts to put a row into
+   ``TABLE_2``, or an ``UPDATE`` operation that attempts to change a row of
+   ``TABLE_2``, will always fail if the resulting value in ``TABLE_2.COLUMN_1``
+   does not match some value of ``TABLE_1.COLUMN_1``.)
 
 The effect of this SQL statement:
 
@@ -1421,25 +1423,25 @@ The effect of this SQL statement:
 
    DELETE FROM Table_1 WHERE column_1=10;
 
-is also an error return, because deleting the applicable row from 
-``TABLE_1`` would leave ``TABLE_2`` with a row containing a ``COLUMN_1`` 
+is also an error return, because deleting the applicable row from
+``TABLE_1`` would leave ``TABLE_2`` with a row containing a ``COLUMN_1``
 value that does not match any ``TABLE_1.COLUMN_1`` value.
 
 To summarize:
 
-* When an ``UPDATE`` operation attempts to update a non-null value in a 
-  Column that is referenced in a ``FOREIGN KEY`` Constraint defined with ``ON 
-  UPDATE NO ACTION`` or ``ON UPDATE RESTRICT``, the ``UPDATE`` fails, 
-  regardless of the ``MATCH`` option, if there are matching rows in the 
-  referencing Table. 
+* When an ``UPDATE`` operation attempts to update a non-null value in a
+  Column that is referenced in a ``FOREIGN KEY`` Constraint defined with ``ON
+  UPDATE NO ACTION`` or ``ON UPDATE RESTRICT``, the ``UPDATE`` fails,
+  regardless of the ``MATCH`` option, if there are matching rows in the
+  referencing Table.
 
-* When a ``DELETE`` operation attempts to delete a row from a Table that is 
-  referenced in a ``FOREIGN KEY`` Constraint defined with ``ON DELETE NO 
-  ACTION`` or ``ON DELETE RESTRICT``, the ``DELETE`` operation fails, 
-  regardless of the ``MATCH`` option, if there are matching rows in the 
-  referencing Table. 
+* When a ``DELETE`` operation attempts to delete a row from a Table that is
+  referenced in a ``FOREIGN KEY`` Constraint defined with ``ON DELETE NO
+  ACTION`` or ``ON DELETE RESTRICT``, the ``DELETE`` operation fails,
+  regardless of the ``MATCH`` option, if there are matching rows in the
+  referencing Table.
 
-For an example of the ``CASCADE`` option, consider the following SQL 
+For an example of the ``CASCADE`` option, consider the following SQL
 statements:
 
 ::
@@ -1467,10 +1469,10 @@ For ``TABLE_1`` and ``TABLE_2``, the effect of this SQL statement:
 
    UPDATE Table_1 SET column_1=11 where column_1=10;
 
-is that all values of ``TABLE_1.COLUMN_1`` that are equal to ``10`` are set to 
-``11``, with the same effect cascading down; that is, all values in 
-``TABLE_2.COLUMN_1`` that are equal to ``10`` are also set to ``11``. And the 
-effect of this SQL statement: 
+is that all values of ``TABLE_1.COLUMN_1`` that are equal to ``10`` are set to
+``11``, with the same effect cascading down; that is, all values in
+``TABLE_2.COLUMN_1`` that are equal to ``10`` are also set to ``11``. And the
+effect of this SQL statement:
 
 ::
 
@@ -1481,28 +1483,28 @@ cascading down; that is, all matching rows of ``TABLE_2`` are also deleted.
 
 To summarize:
 
-* When an ``UPDATE`` operation attempts to update a non-null value in a 
-  Column that is referenced in a ``FOREIGN KEY`` Constraint defined with 
-  ``MATCH SIMPLE`` or ``MATCH FULL`` and ``ON UPDATE CASCADE``, the referenced 
-  Column, and the corresponding referencing Column in all matching rows, are 
-  set to the new value. When an ``UPDATE`` operation attempts to update a 
-  non-null value in a Column that is referenced in a ``FOREIGN KEY`` Constraint 
-  defined with ``MATCH FULL`` and ``ON UPDATE CASCADE``, the referenced Column, 
-  and the corresponding referencing Column in all unique matching rows where 
-  the referencing Column contains a non-null value, are set to the new value. 
-  Unique matching rows with a referencing Column that contains the null value 
-  are not updated. 
+* When an ``UPDATE`` operation attempts to update a non-null value in a
+  Column that is referenced in a ``FOREIGN KEY`` Constraint defined with
+  ``MATCH SIMPLE`` or ``MATCH FULL`` and ``ON UPDATE CASCADE``, the referenced
+  Column, and the corresponding referencing Column in all matching rows, are
+  set to the new value. When an ``UPDATE`` operation attempts to update a
+  non-null value in a Column that is referenced in a ``FOREIGN KEY`` Constraint
+  defined with ``MATCH FULL`` and ``ON UPDATE CASCADE``, the referenced Column,
+  and the corresponding referencing Column in all unique matching rows where
+  the referencing Column contains a non-null value, are set to the new value.
+  Unique matching rows with a referencing Column that contains the null value
+  are not updated.
 
-* When a ``DELETE`` operation attempts to delete a row from a Table that is 
-  referenced in a ``FOREIGN KEY`` Constraint defined with ``MATCH SIMPLE`` or 
-  ``MATCH FULL`` and ``ON DELETE CASCADE``, the applicable row, and all 
-  matching rows, are deleted. When a ``DELETE`` operation attempts to delete a 
-  row from a Table that is referenced in a ``FOREIGN KEY`` Constraint defined 
-  with ``MATCH PARTIAL`` and ``ON DELETE CASCADE``, the applicable row, and all 
-  unique matching rows, are deleted. 
+* When a ``DELETE`` operation attempts to delete a row from a Table that is
+  referenced in a ``FOREIGN KEY`` Constraint defined with ``MATCH SIMPLE`` or
+  ``MATCH FULL`` and ``ON DELETE CASCADE``, the applicable row, and all
+  matching rows, are deleted. When a ``DELETE`` operation attempts to delete a
+  row from a Table that is referenced in a ``FOREIGN KEY`` Constraint defined
+  with ``MATCH PARTIAL`` and ``ON DELETE CASCADE``, the applicable row, and all
+  unique matching rows, are deleted.
 
-For an example of the ``SET NULL`` option, consider the following SQL 
-statements: 
+For an example of the ``SET NULL`` option, consider the following SQL
+statements:
 
 ::
 
@@ -1529,45 +1531,45 @@ For ``TABLE_1`` and ``TABLE_2``, the effect of this SQL statement:
 
    UPDATE Table_1 SET column_1=11 where column_1=10;
 
-is that all values of ``TABLE_1.COLUMN_1`` that are equal to ``10`` are set to 
-``11``, and that all values in ``TABLE_2.COLUMN_1`` that are equal to ``10`` 
-are set to the null value. (If ``TABLE_2.COLUMN_1`` did not allow null values, 
-the ``UPDATE`` statement would fail.) And the effect of this SQL statement: 
+is that all values of ``TABLE_1.COLUMN_1`` that are equal to ``10`` are set to
+``11``, and that all values in ``TABLE_2.COLUMN_1`` that are equal to ``10``
+are set to the null value. (If ``TABLE_2.COLUMN_1`` did not allow null values,
+the ``UPDATE`` statement would fail.) And the effect of this SQL statement:
 
 ::
 
    DELETE FROM Table_1 WHERE column_1=10;
 
-is that all applicable rows are deleted from ``TABLE_1``, and that all values 
-in ``TABLE_2.COLUMN_1`` that are equal to ``10`` are set to the null value. (If 
-``TABLE_2.COLUMN_1`` did not allow null values, the ``DELETE`` statement would 
-fail.) 
+is that all applicable rows are deleted from ``TABLE_1``, and that all values
+in ``TABLE_2.COLUMN_1`` that are equal to ``10`` are set to the null value. (If
+``TABLE_2.COLUMN_1`` did not allow null values, the ``DELETE`` statement would
+fail.)
 
 To summarize:
 
-* When an ``UPDATE`` operation attempts to update a non-null value in a 
-  Column that is referenced in a ``FOREIGN KEY`` Constraint defined with 
-  ``MATCH SIMPLE`` and ``ON UPDATE SET NULL``, the referenced Column is set to 
-  the new value and the corresponding referencing Column in all matching rows 
-  is set to the null value. When an ``UPDATE`` operation attempts to update a 
-  non-null value in a Column that is referenced in a ``FOREIGN KEY`` Constraint 
-  defined with ``MATCH FULL`` and ``ON UPDATE SET NULL``, the referenced Column 
-  is set to the new value and every referencing Column (not just the 
-  corresponding Column) in all matching rows is set to the null value. When an 
-  ``UPDATE`` operation attempts to update a non-null value in a Column that is 
-  referenced in a ``FOREIGN KEY`` Constraint defined with ``MATCH PARTIAL`` and 
-  ``ON UPDATE SET NULL``, the referenced Column is set to the new value and the 
-  corresponding referencing Column in all unique matching rows is set to the 
-  null value. 
+* When an ``UPDATE`` operation attempts to update a non-null value in a
+  Column that is referenced in a ``FOREIGN KEY`` Constraint defined with
+  ``MATCH SIMPLE`` and ``ON UPDATE SET NULL``, the referenced Column is set to
+  the new value and the corresponding referencing Column in all matching rows
+  is set to the null value. When an ``UPDATE`` operation attempts to update a
+  non-null value in a Column that is referenced in a ``FOREIGN KEY`` Constraint
+  defined with ``MATCH FULL`` and ``ON UPDATE SET NULL``, the referenced Column
+  is set to the new value and every referencing Column (not just the
+  corresponding Column) in all matching rows is set to the null value. When an
+  ``UPDATE`` operation attempts to update a non-null value in a Column that is
+  referenced in a ``FOREIGN KEY`` Constraint defined with ``MATCH PARTIAL`` and
+  ``ON UPDATE SET NULL``, the referenced Column is set to the new value and the
+  corresponding referencing Column in all unique matching rows is set to the
+  null value.
 
-* When a ``DELETE`` operation attempts to delete a row from a Table that is 
-  referenced in a ``FOREIGN KEY`` Constraint defined with ``MATCH SIMPLE`` or 
-  ``MATCH FULL`` and ``ON DELETE SET NULL``, the applicable row is deleted and, 
-  for all matching rows, each referencing Column is set to the null value. When 
-  a ``DELETE`` operation attempts to delete a row from a Table that is 
-  referenced in a ``FOREIGN KEY`` Constraint defined with ``MATCH PARTIAL`` and 
-  ``ON DELETE SET NULL``, the applicable row is deleted, and, for all unique 
-  matching rows, each referencing Column is set to the null value. 
+* When a ``DELETE`` operation attempts to delete a row from a Table that is
+  referenced in a ``FOREIGN KEY`` Constraint defined with ``MATCH SIMPLE`` or
+  ``MATCH FULL`` and ``ON DELETE SET NULL``, the applicable row is deleted and,
+  for all matching rows, each referencing Column is set to the null value. When
+  a ``DELETE`` operation attempts to delete a row from a Table that is
+  referenced in a ``FOREIGN KEY`` Constraint defined with ``MATCH PARTIAL`` and
+  ``ON DELETE SET NULL``, the applicable row is deleted, and, for all unique
+  matching rows, each referencing Column is set to the null value.
 
 For an example of the ``SET DEFAULT`` option, consider the following SQL
 statements:
@@ -1597,42 +1599,42 @@ For ``TABLE_1`` and ``TABLE_2``, the effect of this SQL statement:
 
    UPDATE Table_1 SET column_1=11 where column_1=10;
 
-is that all values of ``TABLE_1.COLUMN_1`` that are equal to ``10`` are set to 
-``11``, and that all values of ``TABLE_2.COLUMN_1`` that are equal to ``10`` 
-are set to ``COLUMN_1``\'s default value, ``15``. (If no row existed where the 
-value of ``TABLE_1.COLUMN_1`` was ``15``, the ``UPDATE`` statement would fail.) 
-And the effect of this SQL statement: 
+is that all values of ``TABLE_1.COLUMN_1`` that are equal to ``10`` are set to
+``11``, and that all values of ``TABLE_2.COLUMN_1`` that are equal to ``10``
+are set to ``COLUMN_1``\'s default value, ``15``. (If no row existed where the
+value of ``TABLE_1.COLUMN_1`` was ``15``, the ``UPDATE`` statement would fail.)
+And the effect of this SQL statement:
 
 ::
 
    DELETE FROM Table_1 WHERE column_1=10;
 
-is that all applicable rows are deleted from ``TABLE_1`` and that all values in 
-``TABLE_2.COLUMN_1`` that are equal to ``10`` are set to ``COLUMN_1``\'s 
-default value, ``15``. (If no row existed where the value of 
-``TABLE_1.COLUMN_1`` was ``15``, the ``DELETE`` statement would fail.) 
+is that all applicable rows are deleted from ``TABLE_1`` and that all values in
+``TABLE_2.COLUMN_1`` that are equal to ``10`` are set to ``COLUMN_1``\'s
+default value, ``15``. (If no row existed where the value of
+``TABLE_1.COLUMN_1`` was ``15``, the ``DELETE`` statement would fail.)
 
 To summarize:
 
-* When an ``UPDATE`` operation attempts to update a non-null value in a 
-  Column that is referenced in a ``FOREIGN KEY`` Constraint defined with 
-  ``MATCH SIMPLE`` or ``MATCH FULL`` and ``ON UPDATE SET DEFAULT``, the 
-  referenced Column is set to the new value and the corresponding referencing 
-  Column in all matching rows is set to its default value. When an ``UPDATE`` 
-  operation attempts to update a non-null value in a Column that is referenced 
-  in a ``FOREIGN KEY`` Constraint defined with ``MATCH PARTIAL`` and ``ON 
-  UPDATE SET DEFAULT``, the referenced Column is set to the new value and the 
-  corresponding referencing Column in all unique matching rows is set to its 
-  default value. 
+* When an ``UPDATE`` operation attempts to update a non-null value in a
+  Column that is referenced in a ``FOREIGN KEY`` Constraint defined with
+  ``MATCH SIMPLE`` or ``MATCH FULL`` and ``ON UPDATE SET DEFAULT``, the
+  referenced Column is set to the new value and the corresponding referencing
+  Column in all matching rows is set to its default value. When an ``UPDATE``
+  operation attempts to update a non-null value in a Column that is referenced
+  in a ``FOREIGN KEY`` Constraint defined with ``MATCH PARTIAL`` and ``ON
+  UPDATE SET DEFAULT``, the referenced Column is set to the new value and the
+  corresponding referencing Column in all unique matching rows is set to its
+  default value.
 
-* When a ``DELETE`` operation attempts to delete a row from a Table that is 
-  referenced in a ``FOREIGN KEY`` Constraint defined with ``MATCH SIMPLE`` or 
-  ``MATCH FULL`` and ``ON DELETE SET DEFAULT``, the applicable row is deleted, 
-  and, for all matching rows, each referencing Column is set to its default 
-  value. When a ``DELETE`` operation attempts to delete a row from a Table that 
-  is referenced in a ``FOREIGN KEY`` Constraint defined with ``MATCH PARTIAL`` 
-  and ``ON DELETE SET DEFAULT``, the applicable row is deleted, and, for all 
-  unique matching rows, each referencing Column is set to its default value. 
+* When a ``DELETE`` operation attempts to delete a row from a Table that is
+  referenced in a ``FOREIGN KEY`` Constraint defined with ``MATCH SIMPLE`` or
+  ``MATCH FULL`` and ``ON DELETE SET DEFAULT``, the applicable row is deleted,
+  and, for all matching rows, each referencing Column is set to its default
+  value. When a ``DELETE`` operation attempts to delete a row from a Table that
+  is referenced in a ``FOREIGN KEY`` Constraint defined with ``MATCH PARTIAL``
+  and ``ON DELETE SET DEFAULT``, the applicable row is deleted, and, for all
+  unique matching rows, each referencing Column is set to its default value.
 
 .. NOTE::
 
@@ -1644,19 +1646,19 @@ To summarize:
 .. NOTE::
 
    All rows that are to be deleted by an SQL statement are effectively
-   deleted at the end of that statement's execution, prior to the checking 
+   deleted at the end of that statement's execution, prior to the checking
    of any integrity constraints.
 
-If you want to restrict your code to Core SQL, don't define your ``FOREIGN 
-KEY`` Constraints with a ``MATCH`` clause, an ``ON UPDATE`` clause or an ``ON 
-DELETE`` clause. 
+If you want to restrict your code to Core SQL, don't define your ``FOREIGN
+KEY`` Constraints with a ``MATCH`` clause, an ``ON UPDATE`` clause or an ``ON
+DELETE`` clause.
 
 Constraint_type -- NOT NULL Constraint
 ======================================
 
-A ``NOT NULL`` Constraint is a <Column Constraint>, defining a rule that 
-constrains a key to non-null values only. The required syntax for a ``NOT 
-NULL`` Constraint is: 
+A ``NOT NULL`` Constraint is a <Column Constraint>, defining a rule that
+constrains a key to non-null values only. The required syntax for a ``NOT
+NULL`` Constraint is:
 
 ::
 
@@ -1677,8 +1679,8 @@ example of a ``NOT NULL`` Constraint definition:
              CONSTRAINT constraint_1 NOT NULL DEFERRABLE INITIALLY IMMEDIATE);
        -- defines a NOT NULL <Column Constraint> in CREATE TABLE
 
-Once created, a ``NOT NULL`` <Column Constraint> logically becomes a ``CHECK`` 
-<Table Constraint>. The <Column Constraint> in this SQL statement: 
+Once created, a ``NOT NULL`` <Column Constraint> logically becomes a ``CHECK``
+<Table Constraint>. The <Column Constraint> in this SQL statement:
 
 ::
 
@@ -1693,10 +1695,10 @@ is therefore equivalent to the <Table Constraint> in this SQL statement:
      column_1 SMALLINT,
      CHECK (column_1 IS NOT NULL));
 
-A ``NOT NULL`` Constraint makes it impossible to ``COMMIT`` any operation that 
-would cause the Column to which it belongs to contain any ``NULL``\s. A ``NOT 
-NULL`` Constraint is violated if it is ``FALSE`` for any row of the Table it 
-belongs to. Consider this SQL statement: 
+A ``NOT NULL`` Constraint makes it impossible to ``COMMIT`` any operation that
+would cause the Column to which it belongs to contain any ``NULL``\s. A ``NOT
+NULL`` Constraint is violated if it is ``FALSE`` for any row of the Table it
+belongs to. Consider this SQL statement:
 
 ::
 
@@ -1704,15 +1706,15 @@ belongs to. Consider this SQL statement:
       column_1 SMALLINT CONSTRAINT constraint_1 NOT NULL,
       column_2 VARCHAR(4));
 
-For this example, ``CONSTRAINT_1`` would be violated if you tried to make 
-``COLUMN_1`` contain ``NULL``. 
+For this example, ``CONSTRAINT_1`` would be violated if you tried to make
+``COLUMN_1`` contain ``NULL``.
 
 Constraint_type -- CHECK Constraint
 ===================================
 
-A ``CHECK`` Constraint is either a <Table Constraint>, a <Column Constraint> or 
-a <Domain Constraint> and defines a rule that constrains the set of valid 
-values for a Base table. The required syntax for a ``CHECK`` Constraint is: 
+A ``CHECK`` Constraint is either a <Table Constraint>, a <Column Constraint> or
+a <Domain Constraint> and defines a rule that constrains the set of valid
+values for a Base table. The required syntax for a ``CHECK`` Constraint is:
 
 ::
 
@@ -1766,20 +1768,20 @@ Here are some examples of ``CHECK`` Constraint definitions:
       CHECK(VALUE IS NOT NULL);
    -- defines a CHECK <Domain Constraint> in ALTER DOMAIN
 
-``CHECK`` <Column Constraint>s may be defined only in a ``CREATE TABLE`` 
-statement and must be for a single Column only. ``CHECK`` <Table Constraint>s 
-may be defined in a ``CREATE TABLE`` or an ``ALTER TABLE`` statement and may be 
-for one or more Columns. ``CHECK`` <Domain Constraint>s may be defined in a 
-``CREATE DOMAIN`` or an ``ALTER DOMAIN`` statement and must contain a search 
-condition that uses the <value specification> ``VALUE``; valid only in a 
-<Domain Constraint> (the <data type> of a given instance of ``VALUE`` is the 
-<data type> of the Domain that the <Domain Constraint> belongs to). A <Domain 
-Constraint>'s search condition may not be a recursive search condition (that 
-is, it may not refer, either directly or indirectly, to the Domain that the 
-<Domain Constraint> belongs to). 
+``CHECK`` <Column Constraint>s may be defined only in a ``CREATE TABLE``
+statement and must be for a single Column only. ``CHECK`` <Table Constraint>s
+may be defined in a ``CREATE TABLE`` or an ``ALTER TABLE`` statement and may be
+for one or more Columns. ``CHECK`` <Domain Constraint>s may be defined in a
+``CREATE DOMAIN`` or an ``ALTER DOMAIN`` statement and must contain a search
+condition that uses the <value specification> ``VALUE``; valid only in a
+<Domain Constraint> (the <data type> of a given instance of ``VALUE`` is the
+<data type> of the Domain that the <Domain Constraint> belongs to). A <Domain
+Constraint>'s search condition may not be a recursive search condition (that
+is, it may not refer, either directly or indirectly, to the Domain that the
+<Domain Constraint> belongs to).
 
-Once created, a ``CHECK`` <Column Constraint> logically becomes a ``CHECK`` 
-<Table Constraint>. The <Column Constraint> in this SQL statement: 
+Once created, a ``CHECK`` <Column Constraint> logically becomes a ``CHECK``
+<Table Constraint>. The <Column Constraint> in this SQL statement:
 
 ::
 
@@ -1794,34 +1796,34 @@ is therefore equivalent to the <Table Constraint> in this SQL statement:
       column_1 SMALLINT,
       CHECK(column_1<400));
 
-A ``CHECK`` Constraint's search condition may specify any conditional 
-expression, subject to the following rules: 
+A ``CHECK`` Constraint's search condition may specify any conditional
+expression, subject to the following rules:
 
-* The search condition may not contain *(a)* a <target specification> or 
-  *(b)* a set function (i.e.: ``COUNT``, ``AVG``, ``MAX``, ``MIN`` or ``SUM``) 
-  unless the set function is contained in a subquery or *(c)* any of these 
-  functions: ``CURRENT_PATH``, ``CURRENT_USER``, ``SESSION_USER``, 
-  ``SYSTEM_USER``, ``USER``, ``CURRENT_DATE``, ``CURRENT_TIME``, 
-  ``CURRENT_TIMESTAMP``, ``LOCALTIME`` or ``LOCALTIMESTAMP`` or *(d)* any query 
-  that is possibly non-deterministic, as defined earlier in this chapter. 
+* The search condition may not contain *(a)* a <target specification> or
+  *(b)* a set function (i.e.: ``COUNT``, ``AVG``, ``MAX``, ``MIN`` or ``SUM``)
+  unless the set function is contained in a subquery or *(c)* any of these
+  functions: ``CURRENT_PATH``, ``CURRENT_USER``, ``SESSION_USER``,
+  ``SYSTEM_USER``, ``USER``, ``CURRENT_DATE``, ``CURRENT_TIME``,
+  ``CURRENT_TIMESTAMP``, ``LOCALTIME`` or ``LOCALTIMESTAMP`` or *(d)* any query
+  that is possibly non-deterministic, as defined earlier in this chapter.
 
-* The search condition may not invoke a non-deterministic routine, or a 
-  routine which possibly modifies SQL-data. 
+* The search condition may not invoke a non-deterministic routine, or a
+  routine which possibly modifies SQL-data.
 
-* If a ``CHECK`` Constraint belongs to a persistent Base table or to a 
-  Domain, its search condition may not refer to any temporary Tables. 
+* If a ``CHECK`` Constraint belongs to a persistent Base table or to a
+  Domain, its search condition may not refer to any temporary Tables.
 
-* If a ``CHECK`` Constraint belongs to a ``GLOBAL TEMPORARY`` Base table, its 
-  search condition may refer only to ``GLOBAL TEMPORARY`` Base Tables. If a 
-  ``CHECK`` Constraint belongs to a created ``LOCAL TEMPORARY`` Base table, its 
-  search condition may refer only to ``GLOBAL TEMPORARY`` Base Tables or to 
-  created ``LOCAL TEMPORARY`` Base tables. If a ``CHECK`` Constraint belongs to 
-  a declared ``LOCAL TEMPORARY`` Base table, its search condition may not refer 
-  to any persistent Base Tables. 
+* If a ``CHECK`` Constraint belongs to a ``GLOBAL TEMPORARY`` Base table, its
+  search condition may refer only to ``GLOBAL TEMPORARY`` Base Tables. If a
+  ``CHECK`` Constraint belongs to a created ``LOCAL TEMPORARY`` Base table, its
+  search condition may refer only to ``GLOBAL TEMPORARY`` Base Tables or to
+  created ``LOCAL TEMPORARY`` Base tables. If a ``CHECK`` Constraint belongs to
+  a declared ``LOCAL TEMPORARY`` Base table, its search condition may not refer
+  to any persistent Base Tables.
 
-* If a ``CHECK`` Constraint belongs to a temporary Table defined with ``ON 
-  COMMIT PRESERVE ROWS``, its search condition may not contain a subquery that 
-  refers to a temporary Table defined with ``ON COMMIT DELETE ROWS``. 
+* If a ``CHECK`` Constraint belongs to a temporary Table defined with ``ON
+  COMMIT PRESERVE ROWS``, its search condition may not contain a subquery that
+  refers to a temporary Table defined with ``ON COMMIT DELETE ROWS``.
 
 [Obscure Rule] If a ``CHECK`` Constraint's search condition can't be
 represented in ``INFORMATION_SCHEMA`` without truncation, your DBMS will return
@@ -1831,20 +1833,20 @@ schema"``.
 *Privileges*
 ------------
 
-In order to create a ``CHECK`` Constraint, the <AuthorizationID> that owns the 
-Schema to which the Constraint will belong must be the current 
-<AuthorizationID> and must have the ``REFERENCES`` Privilege on every Column 
-that is explicitly named in the ``CHECK`` Constraint's search condition. If the 
-search condition doesn't explicitly name any Columns, the current 
-<AuthorizationID> must have the ``REFERENCES`` Privilege on at least one Column 
-of every Table referred to in the search condition. 
+In order to create a ``CHECK`` Constraint, the <AuthorizationID> that owns the
+Schema to which the Constraint will belong must be the current
+<AuthorizationID> and must have the ``REFERENCES`` Privilege on every Column
+that is explicitly named in the ``CHECK`` Constraint's search condition. If the
+search condition doesn't explicitly name any Columns, the current
+<AuthorizationID> must have the ``REFERENCES`` Privilege on at least one Column
+of every Table referred to in the search condition.
 
-A ``CHECK`` Constraint makes it impossible to ``COMMIT`` any operation that 
-would cause the Constraint's search condition to evaluate to ``FALSE``. (This 
-means, of course, that if the condition evaluates to ``TRUE`` or to 
-``UNKNOWN``, the Constraint is satisfied.) Thus, for example, the Constraint 
-defined in this ``CREATE TABLE`` statement is violated if any row of 
-``TABLE_1`` contains a ``COLUMN_1`` value that is greater than ``99``: 
+A ``CHECK`` Constraint makes it impossible to ``COMMIT`` any operation that
+would cause the Constraint's search condition to evaluate to ``FALSE``. (This
+means, of course, that if the condition evaluates to ``TRUE`` or to
+``UNKNOWN``, the Constraint is satisfied.) Thus, for example, the Constraint
+defined in this ``CREATE TABLE`` statement is violated if any row of
+``TABLE_1`` contains a ``COLUMN_1`` value that is greater than ``99``:
 
 ::
 
@@ -1880,9 +1882,9 @@ values is allowed in a Column, for example:
    ALTER TABLE Table_1 ADD CONSTRAINT constraint_1
       CHECK(column_1 BETWEEN 5 AND 9) NOT DEFERRABLE;
 
-You'll often see Column values restrained like this; it's a feature in dialog 
-boxes. The second use of a ``CHECK`` <Table Constraint> is to see that two 
-Columns within the same Table agree with each other, for example: 
+You'll often see Column values restrained like this; it's a feature in dialog
+boxes. The second use of a ``CHECK`` <Table Constraint> is to see that two
+Columns within the same Table agree with each other, for example:
 
 ::
 
@@ -1926,10 +1928,10 @@ space":
    ALTER DOMAIN domain_2 ADD CONSTRAINT constraint_2
       CHECK (VALUE <> ' ');
 
-In a <Domain Constraint>'s ``CHECK`` condition, the word ``VALUE`` is a 
-placeholder: your DBMS replaces it with the appropriate <Column name> when 
-checking the Constraint. The second of these two SQL statements would force a 
-Constraint check: 
+In a <Domain Constraint>'s ``CHECK`` condition, the word ``VALUE`` is a
+placeholder: your DBMS replaces it with the appropriate <Column name> when
+checking the Constraint. The second of these two SQL statements would force a
+Constraint check:
 
 ::
 
@@ -1952,17 +1954,17 @@ suggesting that "data type checking" is just a vague form of "<Domain
 Constraint> checking"; the error messages are different, but the point is the
 same -- you are restricted as to what you can put in.
 
-If you want to restrict your code to Core SQL, don't use a subquery in a 
-``CHECK`` Constraint's search condition. Also, for Core SQL, the ``REFERENCES`` 
-Privilege isn't needed to create a ``CHECK`` Constraint. 
+If you want to restrict your code to Core SQL, don't use a subquery in a
+``CHECK`` Constraint's search condition. Also, for Core SQL, the ``REFERENCES``
+Privilege isn't needed to create a ``CHECK`` Constraint.
 
 CREATE ASSERTION Statement
 ==========================
 
-The ``CREATE ASSERTION`` statement names a new Constraint and defines the 
-Constraint's deferral mode, initial constraint check time and its ``CHECK`` 
-search condition. The required syntax for the ``CREATE ASSERTION`` statement 
-is: 
+The ``CREATE ASSERTION`` statement names a new Constraint and defines the
+Constraint's deferral mode, initial constraint check time and its ``CHECK``
+search condition. The required syntax for the ``CREATE ASSERTION`` statement
+is:
 
 ::
 
@@ -1977,17 +1979,17 @@ belongs to.
 * The <Constraint name> identifies the Assertion and the Schema that it
   belongs to. A <Constraint name> that includes an explicit <Schema name>
   qualifier belongs to the Schema named. A <Constraint name> that does not
-  include an explicit <Schema name> qualifier belongs to the SQL-session 
-  default Schema. (In both cases, that Schema must, of course, own the 
-  Tables for which the Assertion is defined.) The <Constraint name> must be 
+  include an explicit <Schema name> qualifier belongs to the SQL-session
+  default Schema. (In both cases, that Schema must, of course, own the
+  Tables for which the Assertion is defined.) The <Constraint name> must be
   unique (for all Constraints and Assertions) within the Schema that owns it.
 
-If ``CREATE ASSERTION`` is part of a ``CREATE SCHEMA`` statement, the 
-<Constraint name>, if explicitly qualified, must include the <Schema name> of 
-the Schema being created; that is, it isn't possible to create an Assertion 
-belonging to a different Schema from within ``CREATE SCHEMA``. For example, 
-this SQL statement will not return an error because the <Constraint name> will 
-default to include the qualifying <Schema name>: 
+If ``CREATE ASSERTION`` is part of a ``CREATE SCHEMA`` statement, the
+<Constraint name>, if explicitly qualified, must include the <Schema name> of
+the Schema being created; that is, it isn't possible to create an Assertion
+belonging to a different Schema from within ``CREATE SCHEMA``. For example,
+this SQL statement will not return an error because the <Constraint name> will
+default to include the qualifying <Schema name>:
 
 ::
 
@@ -2028,17 +2030,17 @@ Constraint belongs to, or the Schema's owner must be a Role that the current
 <AuthorizationID> may use. That is, only the owner of a Schema can create
 Constraints for that Schema.
 
-An Assertion's ``CHECK`` search condition may specify any conditional 
-expression (it will almost inevitably contain the <keyword> ``EXISTS``, the 
-<keyword> ``UNIQUE`` or a set function), subject to the following rules (note 
-that these rules are slightly different from the rules given earlier for a 
-``CHECK`` Constraint's search condition): 
+An Assertion's ``CHECK`` search condition may specify any conditional
+expression (it will almost inevitably contain the <keyword> ``EXISTS``, the
+<keyword> ``UNIQUE`` or a set function), subject to the following rules (note
+that these rules are slightly different from the rules given earlier for a
+``CHECK`` Constraint's search condition):
 
 * The search condition may not contain a <host parameter name>, an <SQL
   parameter name>, any of these functions: ``CURRENT_PATH``, ``CURRENT_USER``,
-  ``SESSION_USER``, ``SYSTEM_USER``, ``USER``, ``CURRENT_DATE``, 
-  ``CURRENT_TIME``, ``CURRENT_TIMESTAMP``, ``LOCALTIME`` or 
-  ``LOCALTIMESTAMP`` or any query that is possibly non-deterministic, as 
+  ``SESSION_USER``, ``SYSTEM_USER``, ``USER``, ``CURRENT_DATE``,
+  ``CURRENT_TIME``, ``CURRENT_TIMESTAMP``, ``LOCALTIME`` or
+  ``LOCALTIMESTAMP`` or any query that is possibly non-deterministic, as
   defined earlier in this chapter.
 
 * The search condition may not invoke a non-deterministic routine, or a
@@ -2051,10 +2053,10 @@ represented in ``INFORMATION_SCHEMA`` without truncation, your DBMS will return
 the ``SQLSTATE warning 01009 "warning-search condition too long for information
 schema"``.
 
-An Assertion makes it impossible to ``COMMIT`` any operation that would cause 
-the Constraint's search condition to evaluate to ``FALSE``. (This means, of 
-course, that if the condition evaluates to ``TRUE`` or to ``UNKNOWN``, the 
-Constraint is satisfied.) Thus, for example, for these two SQL statements: 
+An Assertion makes it impossible to ``COMMIT`` any operation that would cause
+the Constraint's search condition to evaluate to ``FALSE``. (This means, of
+course, that if the condition evaluates to ``TRUE`` or to ``UNKNOWN``, the
+Constraint is satisfied.) Thus, for example, for these two SQL statements:
 
 ::
 
@@ -2065,10 +2067,10 @@ Constraint is satisfied.) Thus, for example, for these two SQL statements:
    CREATE ASSERTION constraint_1
       CHECK ((SELECT AVG(column_1) FROM Table_1 >40) NOT DEFERRABLE;
 
-``CONSTRAINT_1`` is violated if the average of the ``TABLE_1.COLUMN_1`` values 
-is less than ``41``. Assume that ``TABLE_1`` contains one row, where 
-``COLUMN_1`` contains ``42``. This SQL statement would then violate 
-``CONSTRAINT_1``: 
+``CONSTRAINT_1`` is violated if the average of the ``TABLE_1.COLUMN_1`` values
+is less than ``41``. Assume that ``TABLE_1`` contains one row, where
+``COLUMN_1`` contains ``42``. This SQL statement would then violate
+``CONSTRAINT_1``:
 
 ::
 
@@ -2107,10 +2109,10 @@ Constraint>, for example with this SQL statement:
    ALTER TABLE Table_1 ADD CONSTRAINT constraint_1
       CHECK (0 <> (SELECT COUNT(*) FROM Table_1));
 
-you'll find it won't work: since a <Table Constraint> is checked once "for each 
-row", and there are no rows, the check never happens if you leave the 
-``TABLE_1`` empty. To make it work, create an Assertion to ensure the condition 
-is checked at least once. For example: 
+you'll find it won't work: since a <Table Constraint> is checked once "for each
+row", and there are no rows, the check never happens if you leave the
+``TABLE_1`` empty. To make it work, create an Assertion to ensure the condition
+is checked at least once. For example:
 
 ::
 
@@ -2127,11 +2129,11 @@ could use this <Table Constraint> and it would work:
    ALTER TABLE Picnics ADD CONSTRAINT constraint_1
       CHECK (EXISTS (SELECT * FROM Accounts WHERE balance > 0));
 
-But ``CONSTRAINT_1``, as defined, is misleading -- the SQL statement suggests 
-that there's a Constraint on the ``PICNICS`` Table. There is, of course, but 
-there's a Constraint on the ``ACCOUNTS`` Table too and this isn't immediately 
-clear. If you define the same condition with ``CREATE ASSERTION``, you'll be 
-signalling that there's more to it; for example: 
+But ``CONSTRAINT_1``, as defined, is misleading -- the SQL statement suggests
+that there's a Constraint on the ``PICNICS`` Table. There is, of course, but
+there's a Constraint on the ``ACCOUNTS`` Table too and this isn't immediately
+clear. If you define the same condition with ``CREATE ASSERTION``, you'll be
+signalling that there's more to it; for example:
 
 ::
 
@@ -2139,8 +2141,8 @@ signalling that there's more to it; for example:
       CHECK (NOT EXISTS (SELECT * FROM Picnics) OR
              EXISTS (SELECT * FROM Accounts WHERE balance > 0));
 
-If you want to restrict your code to Core SQL, don't use the ``CREATE 
-ASSERTION`` statement. 
+If you want to restrict your code to Core SQL, don't use the ``CREATE
+ASSERTION`` statement.
 
 Interlocking References
 =======================
@@ -2151,10 +2153,10 @@ An example of an interlocking reference is:
 
 * Every Department must have at least one employee.
 
-This is an "interlock" problem because there must be a reference from the 
-``EMPLOYEES`` Table to the ``DEPARTMENTS`` Table, as well as a reference going 
-the other way: from the ``DEPARTMENTS`` Table to the ``EMPLOYEES`` Table. Here 
-are the Table definitions: 
+This is an "interlock" problem because there must be a reference from the
+``EMPLOYEES`` Table to the ``DEPARTMENTS`` Table, as well as a reference going
+the other way: from the ``DEPARTMENTS`` Table to the ``EMPLOYEES`` Table. Here
+are the Table definitions:
 
 ::
 
@@ -2173,14 +2175,14 @@ are the Table definitions:
    -- this CHECK clause illustrates the normal way to make a "foreign
    reference" to a "key" which is not unique or primary
 
-In this example, the ``CREATE TABLE Employees...`` statement will return an 
-error because it refers to the ``DEPARTMENTS`` Table before that Table has been 
-created. Interchanging the statement order wouldn't help, because then the 
-``CREATE TABLE Departments...`` statement will return an error because it 
-refers to the ``EMPLOYEES`` Table before that Table has been created. You could 
-put both Table definitions inside a ``CREATE SCHEMA`` statement, but that isn't 
-a general solution. To solve the problem, split the ``CREATE TABLE`` statements 
-up like this: 
+In this example, the ``CREATE TABLE Employees...`` statement will return an
+error because it refers to the ``DEPARTMENTS`` Table before that Table has been
+created. Interchanging the statement order wouldn't help, because then the
+``CREATE TABLE Departments...`` statement will return an error because it
+refers to the ``EMPLOYEES`` Table before that Table has been created. You could
+put both Table definitions inside a ``CREATE SCHEMA`` statement, but that isn't
+a general solution. To solve the problem, split the ``CREATE TABLE`` statements
+up like this:
 
 ::
 
@@ -2229,9 +2231,9 @@ join.
 
 **Solution #2**
 
-Take advantage of the fact that ``NULL`` matches anything. Begin with the 
-assumption that the ``DEPARTMENTS`` Table is not empty, presumably because you 
-used Solution #1 for some other department. Then execute these SQL statements: 
+Take advantage of the fact that ``NULL`` matches anything. Begin with the
+assumption that the ``DEPARTMENTS`` Table is not empty, presumably because you
+used Solution #1 for some other department. Then execute these SQL statements:
 
 ::
 
@@ -2269,9 +2271,9 @@ deferred. For example:
       CHECK (dept_id IN (SELECT * FROM Employees)
          DEFERRABLE INITIALLY DEFERRED);
 
-This method causes the ``INSERT`` problem to disappear because no checks will 
-occur at ``INSERT`` time. Thus, these ``INSERT`` statements would now work 
-without returning an error: 
+This method causes the ``INSERT`` problem to disappear because no checks will
+occur at ``INSERT`` time. Thus, these ``INSERT`` statements would now work
+without returning an error:
 
 ::
 
@@ -2288,14 +2290,14 @@ on tricks.
 Dropping Constraints
 ====================
 
-Dropping a Constraint is straightforward, providing that you know the 
-<Constraint name> -- that's why we recommend that you explicitly give every 
-Constraint a name when you make it (even a ``NOT NULL`` Constraint). <Table 
-Constraint>s and <Column Constraint>s are dropped using the ``DROP CONSTRAINT`` 
-<Constraint name> clause of the ``ALTER TABLE`` statement, <Domain Constraint>s 
-are dropped using the ``DROP CONSTRAINT`` <Constraint name> clause of the 
-``ALTER DOMAIN`` statement and Assertions are dropped with the ``DROP 
-ASSERTION`` statement. 
+Dropping a Constraint is straightforward, providing that you know the
+<Constraint name> -- that's why we recommend that you explicitly give every
+Constraint a name when you make it (even a ``NOT NULL`` Constraint). <Table
+Constraint>s and <Column Constraint>s are dropped using the ``DROP CONSTRAINT``
+<Constraint name> clause of the ``ALTER TABLE`` statement, <Domain Constraint>s
+are dropped using the ``DROP CONSTRAINT`` <Constraint name> clause of the
+``ALTER DOMAIN`` statement and Assertions are dropped with the ``DROP
+ASSERTION`` statement.
 
 DROP ASSERTION Statement
 ========================
@@ -2320,13 +2322,13 @@ The effect of ``DROP ASSERTION`` <Constraint name>, e.g.:
 
    DROP ASSERTION constraint_1;
 
-is that the Assertion named ``CONSTRAINT_1`` will be destroyed, providing that 
-``CONSTRAINT_1`` is not referred to in any SQL routine or in any Trigger. If 
-the Assertion's ``CHECK`` search condition includes a ``NOT NULL`` condition 
-that causes one or more Columns to have the "known not nullable" nullability 
-characteristic, then the affected Columns' nullability characteristic becomes 
-"possibly nullable" (unless some other Constraint also constrains them to non- 
-null values). 
+is that the Assertion named ``CONSTRAINT_1`` will be destroyed, providing that
+``CONSTRAINT_1`` is not referred to in any SQL routine or in any Trigger. If
+the Assertion's ``CHECK`` search condition includes a ``NOT NULL`` condition
+that causes one or more Columns to have the "known not nullable" nullability
+characteristic, then the affected Columns' nullability characteristic becomes
+"possibly nullable" (unless some other Constraint also constrains them to non-
+null values).
 
 If you want to restrict your code to Core SQL, don't use the ``DROP ASSERTION``
 statement.
@@ -2334,9 +2336,9 @@ statement.
 Dialects
 ========
 
-In most DBMSs, it's common that the ``UNIQUE`` specification is not supported, 
-but you'll often see a (non-SQL) ``CREATE UNIQUE INDEX`` statement that gives 
-you the same functionality instead. 
+In most DBMSs, it's common that the ``UNIQUE`` specification is not supported,
+but you'll often see a (non-SQL) ``CREATE UNIQUE INDEX`` statement that gives
+you the same functionality instead.
 
 Some DBMSs reportedly don't support the ``FOREIGN KEY`` <Column Constraint>
 syntax, but do allow foreign keys to be defined as <Table Constraint>s.

--- a/docs/chapters/21.rst
+++ b/docs/chapters/21.rst
@@ -4,6 +4,8 @@
 Chapter 21 -- SQL Character Set
 ===============================
 
+.. include:: ../_include/note.rst
+
 [Obscure Rule] applies to this entire chapter.
 
 In this chapter, we'll describe SQL Character sets in detail, and show you the
@@ -17,38 +19,38 @@ syntax to use to create, alter and destroy them.
 Character Set
 =============
 
-A Schema may contain zero or more Character sets. As we explained in our 
-chapter on character strings, an *SQL Character set* is a combination of a 
-character repertoire (a set of characters) and a Form-of-use (the repertoire's 
-internal encoding scheme). Character sets are dependent on some Schema -- the 
-<Character set name> must be unique within the Schema the Character set belongs 
-to. User-defined Character sets are created and dropped using standard SQL 
-statements. 
+A Schema may contain zero or more Character sets. As we explained in our
+chapter on character strings, an *SQL Character set* is a combination of a
+character repertoire (a set of characters) and a Form-of-use (the repertoire's
+internal encoding scheme). Character sets are dependent on some Schema -- the
+<Character set name> must be unique within the Schema the Character set belongs
+to. User-defined Character sets are created and dropped using standard SQL
+statements.
 
-In SQL, a Character set may be a Character set defined by a national or 
-international standard, by your DBMS or by a user of SQL-data. 
+In SQL, a Character set may be a Character set defined by a national or
+international standard, by your DBMS or by a user of SQL-data.
 
-Standard-defined Character sets consist of a set of characters predefined by 
-some standards body and have a default Collation that is the order of the 
-characters in the relevant standard. The default Collation has the ``PAD 
-SPACE`` characteristic. The SQL Standard requires a DBMS to support, at a 
-minimum, these standard-defined Character sets: ``SQL_CHARACTER``, 
-``GRAPHIC_IRV`` (also called ``ASCII_GRAPHIC``), ``LATIN1``, ``ISO8BIT`` (also 
-called ``ASCII_FULL``) and ``UNICODE`` (also called ``ISO10646``). 
+Standard-defined Character sets consist of a set of characters predefined by
+some standards body and have a default Collation that is the order of the
+characters in the relevant standard. The default Collation has the ``PAD
+SPACE`` characteristic. The SQL Standard requires a DBMS to support, at a
+minimum, these standard-defined Character sets: ``SQL_CHARACTER``,
+``GRAPHIC_IRV`` (also called ``ASCII_GRAPHIC``), ``LATIN1``, ``ISO8BIT`` (also
+called ``ASCII_FULL``) and ``UNICODE`` (also called ``ISO10646``).
 
-Implementation-defined Character sets consist of a set of characters predefined 
-by your DBMS and have a default Collation that is also defined by your DBMS. 
-The default Collation may have either the ``PAD SPACE`` characteristic or the 
-``NO PAD`` characteristic. The SQL Standard requires a DBMS to support, at a 
-minimum, this implementation-defined Character set: ``SQL_TEXT``. 
+Implementation-defined Character sets consist of a set of characters predefined
+by your DBMS and have a default Collation that is also defined by your DBMS.
+The default Collation may have either the ``PAD SPACE`` characteristic or the
+``NO PAD`` characteristic. The SQL Standard requires a DBMS to support, at a
+minimum, this implementation-defined Character set: ``SQL_TEXT``.
 
-[NON-PORTABLE] The complete set of predefined Character sets supported by a 
-DBMS is non-standard because the SQL Standard allows implementors to include 
-support for other Character sets, in addition to the required ones. 
+[NON-PORTABLE] The complete set of predefined Character sets supported by a
+DBMS is non-standard because the SQL Standard allows implementors to include
+support for other Character sets, in addition to the required ones.
 
-[OCELOT Implementation] The OCELOT DBMS that comes with this book provides 
-support for seven other predefined Character sets, based on commonly available 
-MS-Windows codepages. They are: 
+[OCELOT Implementation] The OCELOT DBMS that comes with this book provides
+support for seven other predefined Character sets, based on commonly available
+MS-Windows codepages. They are:
 
 +-------------------+-----------------------------------+
 | ``CODEPAGE_0437`` | MS-DOS West European codepage 437 |
@@ -66,26 +68,26 @@ MS-Windows codepages. They are:
 | ``CODEPAGE_1257`` | MS-Windows Baltic codepage 1257   |
 +-------------------+-----------------------------------+
 
-The pre-defined Character sets provided by your DBMS belong to 
-``INFORMATION_SCHEMA`` (as do Collations defined by standards and Collations, 
-Translations and Form-of-use conversions defined by your DBMS). The SQL special 
-grantee, ``PUBLIC``, always has a ``USAGE`` Privilege on every predefined 
-Character set provided by your DBMS. For details on the predefined Character 
-sets, see our chapter on characters. 
+The pre-defined Character sets provided by your DBMS belong to
+``INFORMATION_SCHEMA`` (as do Collations defined by standards and Collations,
+Translations and Form-of-use conversions defined by your DBMS). The SQL special
+grantee, ``PUBLIC``, always has a ``USAGE`` Privilege on every predefined
+Character set provided by your DBMS. For details on the predefined Character
+sets, see our chapter on characters.
 
-Every Character set has a default Collation: it specifies the rules that 
-determine the results of comparisons between the Character set's characters in 
-the absence of an explicit ``COLLATE`` clause. 
+Every Character set has a default Collation: it specifies the rules that
+determine the results of comparisons between the Character set's characters in
+the absence of an explicit ``COLLATE`` clause.
 
-A Character set is defined by a descriptor that contains three pieces of 
+A Character set is defined by a descriptor that contains three pieces of
 information:
 
-1. The <Character set name>, qualified by the <Schema name> of the Schema it 
+1. The <Character set name>, qualified by the <Schema name> of the Schema it
    belongs to.
 
 2. A list of the characters that belong to the Character set.
 
-3. The name of the Character set's default Collation. (This may be the 
+3. The name of the Character set's default Collation. (This may be the
    Form-of-use encoding scheme for the Character set's repertoire.)
 
 User-defined Character sets may belong to any Schema owned by the creator. To
@@ -103,7 +105,7 @@ one can be its default Collation.
 *Character set names*
 ---------------------
 
-A <Character set name> identifies a Character set. The required syntax for a 
+A <Character set name> identifies a Character set. The required syntax for a
 <Character set name> is:
 
 ::
@@ -111,16 +113,16 @@ A <Character set name> identifies a Character set. The required syntax for a
     <Character set name> ::=
     [ <Schema name>. ] unqualified name
 
-A <Character set name> is a <SQL language identifier> that is unique (for all 
-Character sets) within the Schema it belongs to. The <Schema name> which 
-qualifies a <Character set name> names the Schema that the Character set 
-belongs to and can either be explicitly stated, or it will default to 
-``INFORMATION_SCHEMA``; that is, an unqualified <Character set name> is always 
-assumed to belong to ``INFORMATION_SCHEMA`` -- even if a ``CREATE CHARACTER 
-SET`` statement is part of a ``CREATE SCHEMA`` statement. (User-defined 
-Character sets may not belong to ``INFORMATION_SCHEMA``. Therefore, when 
-defining, using or dropping a user-defined Character set, always provide an 
-explicit <Schema name> qualifier for the <Character set name>.) 
+A <Character set name> is a <SQL language identifier> that is unique (for all
+Character sets) within the Schema it belongs to. The <Schema name> which
+qualifies a <Character set name> names the Schema that the Character set
+belongs to and can either be explicitly stated, or it will default to
+``INFORMATION_SCHEMA``; that is, an unqualified <Character set name> is always
+assumed to belong to ``INFORMATION_SCHEMA`` -- even if a ``CREATE CHARACTER
+SET`` statement is part of a ``CREATE SCHEMA`` statement. (User-defined
+Character sets may not belong to ``INFORMATION_SCHEMA``. Therefore, when
+defining, using or dropping a user-defined Character set, always provide an
+explicit <Schema name> qualifier for the <Character set name>.)
 
 Here are some examples of <Character set name>s:
 
@@ -135,15 +137,15 @@ Here are some examples of <Character set name>s:
    CATALOG_1.SCHEMA_1.CHARACTER_SET_1
    -- a fully qualified user-defined <Character set name>
 
-If you want to restrict your code to Core SQL, don't use any <Character set 
+If you want to restrict your code to Core SQL, don't use any <Character set
 name>s.
 
 CREATE CHARACTER SET Statement
 ==============================
 
-The ``CREATE CHARACTER SET`` statement names a new user-defined Character set 
-and specifies the Character set's repertoire and default Collation. The 
-required syntax for the ``CREATE CHARACTER SET`` statement is: 
+The ``CREATE CHARACTER SET`` statement names a new user-defined Character set
+and specifies the Character set's repertoire and default Collation. The
+required syntax for the ``CREATE CHARACTER SET`` statement is:
 
 
 
@@ -153,23 +155,23 @@ required syntax for the ``CREATE CHARACTER SET`` statement is:
           GET predefined <Character set name>
           [ COLLATE <Collation name> ]
 
-``CREATE CHARACTER SET`` defines a new user-defined Character set. A 
+``CREATE CHARACTER SET`` defines a new user-defined Character set. A
 Character set is owned by the Schema it belongs to.
 
-The user-defined <Character set name> identifies the new Character set and the 
-Schema that it belongs to. A <Character set name> that includes an explicit 
-<Schema name> qualifier belongs to the Schema named. A <Character set name> 
-that does not include an explicit <Schema name> qualifier belongs to 
-``INFORMATION_SCHEMA``. Since a user-defined Character set can't belong to 
-``INFORMATION_SCHEMA``, always provide an explicit <Schema name> qualifier when 
-you're creating a Character set. 
+The user-defined <Character set name> identifies the new Character set and the
+Schema that it belongs to. A <Character set name> that includes an explicit
+<Schema name> qualifier belongs to the Schema named. A <Character set name>
+that does not include an explicit <Schema name> qualifier belongs to
+``INFORMATION_SCHEMA``. Since a user-defined Character set can't belong to
+``INFORMATION_SCHEMA``, always provide an explicit <Schema name> qualifier when
+you're creating a Character set.
 
-If ``CREATE CHARACTER SET`` is part of a ``CREATE SCHEMA`` statement, the 
-<Character set name> must include the <Schema name> of the Schema being 
-created; that is, it isn't possible to create a Character set belonging to a 
-different Schema from within ``CREATE SCHEMA``. For example, this SQL statement 
-will not return an error because the <Character set name> explicitly includes a 
-qualifying <Schema name> that matches the name of the Schema being created: 
+If ``CREATE CHARACTER SET`` is part of a ``CREATE SCHEMA`` statement, the
+<Character set name> must include the <Schema name> of the Schema being
+created; that is, it isn't possible to create a Character set belonging to a
+different Schema from within ``CREATE SCHEMA``. For example, this SQL statement
+will not return an error because the <Character set name> explicitly includes a
+qualifying <Schema name> that matches the name of the Schema being created:
 
 ::
 
@@ -187,34 +189,34 @@ of the Schema being created:
       CREATE CHARACTER SET sam.charset_1 AS GET LATIN1;
    -- tries to create a Character set belonging to Schema SAM inside Schema BOB; illegal syntax
 
-If ``CREATE CHARACTER SET`` is executed as a stand-alone SQL statement, the 
-current <AuthorizationID> must either be the owner of the Schema that this new 
-Character set belongs to, or the Schema's owner must be a Role that the current 
-<AuthorizationID> may use. That is, only the owner of a Schema can create 
-Character sets for that Schema. In addition to creating a Character set, 
-``CREATE CHARACTER SET`` also causes the SQL special grantor, "``_SYSTEM``", to 
-grant a grantable ``USAGE`` Privilege on the new Character set to the Schema 
-owner <AuthorizationID> (that is, the <AuthorizationID creating the Character 
-set). 
+If ``CREATE CHARACTER SET`` is executed as a stand-alone SQL statement, the
+current <AuthorizationID> must either be the owner of the Schema that this new
+Character set belongs to, or the Schema's owner must be a Role that the current
+<AuthorizationID> may use. That is, only the owner of a Schema can create
+Character sets for that Schema. In addition to creating a Character set,
+``CREATE CHARACTER SET`` also causes the SQL special grantor, "``_SYSTEM``", to
+grant a grantable ``USAGE`` Privilege on the new Character set to the Schema
+owner <AuthorizationID> (that is, the <AuthorizationID creating the Character
+set).
 
-A user-defined Character set must be defined as using the repertoire (and 
-possibly the default Collation) of a predefined Character set provided by the 
-DBMS; that is, you can't create a Character set based on another user-defined 
-Character set. The ``GET`` clause of the ``CREATE CHARACTER SET`` statement 
-names the predefined Character set that is the source for the new Character 
-set. For example, this SQL statement: 
+A user-defined Character set must be defined as using the repertoire (and
+possibly the default Collation) of a predefined Character set provided by the
+DBMS; that is, you can't create a Character set based on another user-defined
+Character set. The ``GET`` clause of the ``CREATE CHARACTER SET`` statement
+names the predefined Character set that is the source for the new Character
+set. For example, this SQL statement:
 
 ::
 
    CREATE CHARACTER SET bob.charset_1 AS LATIN1;
 
-defines a new user-defined Character set, called ``BOB.CHARSET_1``, in the 
-Schema named ``BOB``. Except for its name, the Character set ``BOB.CHARSET_1`` 
-will be exactly the same as the ``LATIN1`` Character set -- that is, it is not 
-truly possible to "create" new Character sets; merely to rename (and possibly 
-assign new default Collations for) them. The <keyword> ``AS`` in the ``GET`` 
-clause is noise and can be omitted. For example, these two SQL statements are 
-equivalent: 
+defines a new user-defined Character set, called ``BOB.CHARSET_1``, in the
+Schema named ``BOB``. Except for its name, the Character set ``BOB.CHARSET_1``
+will be exactly the same as the ``LATIN1`` Character set -- that is, it is not
+truly possible to "create" new Character sets; merely to rename (and possibly
+assign new default Collations for) them. The <keyword> ``AS`` in the ``GET``
+clause is noise and can be omitted. For example, these two SQL statements are
+equivalent:
 
 ::
 
@@ -222,41 +224,41 @@ equivalent:
 
    CREATE CHARACTER SET bob.charset_1 GET LATIN1;
 
-The optional ``COLLATE`` clause of the ``CREATE CHARACTER SET`` statement 
-allows you to define a default Collation for your user-defined Character set 
-that is different from the default Collation of its source Character set. Your 
-current <AuthorizationID> must have the ``USAGE`` Privilege on the Collation 
-named. Here is an example: 
+The optional ``COLLATE`` clause of the ``CREATE CHARACTER SET`` statement
+allows you to define a default Collation for your user-defined Character set
+that is different from the default Collation of its source Character set. Your
+current <AuthorizationID> must have the ``USAGE`` Privilege on the Collation
+named. Here is an example:
 
 ::
 
    CREATE CHARACTER SET bob.charset_1 AS GET LATIN1
       COLLATE bob.collation_1;
 
-This SQL statement defines a new user-defined Character set, called 
-``BOB.CHARSET_1``. It contains the same characters as ``LATIN1`` does, but is 
-slightly different because its default Collation won't be ``LATIN1``\'s default 
-Collation -- instead, its default Collation is a Collation named 
-``BOB.COLLATION_1``. 
+This SQL statement defines a new user-defined Character set, called
+``BOB.CHARSET_1``. It contains the same characters as ``LATIN1`` does, but is
+slightly different because its default Collation won't be ``LATIN1``\'s default
+Collation -- instead, its default Collation is a Collation named
+``BOB.COLLATION_1``.
 
-If you want to restrict your code to Core SQL, don't use the ``CREATE 
+If you want to restrict your code to Core SQL, don't use the ``CREATE
 CHARACTER SET`` statement.
 
 DROP CHARACTER SET Statement
 ============================
 
-The ``DROP CHARACTER SET`` statement destroys a user-defined Character set. 
+The ``DROP CHARACTER SET`` statement destroys a user-defined Character set.
 The required syntax for the ``DROP CHARACTER SET`` statement is:
 
 ::
 
     DROP CHARACTER SET <Character set name>
 
-The <Character set name> must identify an existing Character set whose owner is 
-either the current <AuthorizationID> or a Role that the current 
-<AuthorizationID> may use. That is, only the <AuthorizationID> that owns the 
-Character set may drop it, and so it isn't possible to drop any of the 
-predefined Character sets provided by your DBMS. 
+The <Character set name> must identify an existing Character set whose owner is
+either the current <AuthorizationID> or a Role that the current
+<AuthorizationID> may use. That is, only the <AuthorizationID> that owns the
+Character set may drop it, and so it isn't possible to drop any of the
+predefined Character sets provided by your DBMS.
 
 The effect of ``DROP CHARACTER SET`` <Character set name>, e.g.:
 
@@ -264,12 +266,12 @@ The effect of ``DROP CHARACTER SET`` <Character set name>, e.g.:
 
    DROP CHARACTER SET bob.charset_1;
 
-is that the user-defined Character set named ``BOB.CHARSET_1`` is destroyed, 
-provided that the Character set is not referred to in any View definition, 
-Constraint or Assertion definition, Collation definition, Translation 
-definition or SQL routine. That is, ``DROP CHARACTER SET`` ensures that only a 
-Character set with no dependent Objects can be destroyed. If the Character set 
-is used by any other Object, ``DROP CHARACTER SET`` will fail. 
+is that the user-defined Character set named ``BOB.CHARSET_1`` is destroyed,
+provided that the Character set is not referred to in any View definition,
+Constraint or Assertion definition, Collation definition, Translation
+definition or SQL routine. That is, ``DROP CHARACTER SET`` ensures that only a
+Character set with no dependent Objects can be destroyed. If the Character set
+is used by any other Object, ``DROP CHARACTER SET`` will fail.
 
 If successful, ``DROP CHARACTER SET`` has a two-fold effect.
 
@@ -277,9 +279,9 @@ If successful, ``DROP CHARACTER SET`` has a two-fold effect.
 
 2. The ``USAGE`` Privilege held on the Character set by the
    <AuthorizationID> that owns it is revoked (by the SQL special grantor,
-   "``_SYSTEM``") with a ``CASCADE`` revoke behaviour, so that the ``USAGE`` 
-   Privilege held on the Character set by any other <AuthorizationID> is 
+   "``_SYSTEM``") with a ``CASCADE`` revoke behaviour, so that the ``USAGE``
+   Privilege held on the Character set by any other <AuthorizationID> is
    also revoked.
 
-If you want to restrict your code to Core SQL, don't use the ``DROP 
+If you want to restrict your code to Core SQL, don't use the ``DROP
 CHARACTER SET`` statement.

--- a/docs/chapters/22.rst
+++ b/docs/chapters/22.rst
@@ -4,9 +4,11 @@
 Chapter 22 -- SQL Collation
 ===========================
 
+.. include:: ../_include/note.rst
+
 [Obscure Rule] applies to this entire chapter.
 
-In this chapter, we'll describe SQL Collations in detail, and show you the 
+In this chapter, we'll describe SQL Collations in detail, and show you the
 syntax to use to create, alter and destroy them.
 
 .. rubric:: Table of Contents
@@ -23,7 +25,7 @@ compared. Collations are dependent on some Schema -- the <Collation name> must
 be unique within the Schema the Collation belongs to. User-defined Collations
 are created and dropped using standard SQL statements.
 
-In SQL, a Collation may be a Collation defined by a national or 
+In SQL, a Collation may be a Collation defined by a national or
 international standard, by your DBMS or by a user of SQL-data.
 
 Standard-defined Collations are collating sequences predefined for a character
@@ -32,26 +34,26 @@ a default Collation (based on the character repertoire order) for each of the
 standard-defined Character sets it supports. In each case, the default
 Collation has the ``PAD SPACE`` characteristic.
 
-Implementation-defined Collations are collating sequences predefined for a 
-character repertoire by your DBMS. These Collations may have either the ``PAD 
-SPACE`` characteristic or the ``NO PAD`` characteristic. The SQL Standard 
-requires a DBMS to provide a default Collation, called ``SQL_TEXT``, for the 
-``SQL_TEXT`` Character set. 
+Implementation-defined Collations are collating sequences predefined for a
+character repertoire by your DBMS. These Collations may have either the ``PAD
+SPACE`` characteristic or the ``NO PAD`` characteristic. The SQL Standard
+requires a DBMS to provide a default Collation, called ``SQL_TEXT``, for the
+``SQL_TEXT`` Character set.
 
-[NON-PORTABLE] The complete set of predefined Collations provided by a DBMS is 
-non-standard because the SQL Standard allows implementors to include support 
-for other Collations, in addition to the required ones. It also requires 
-implementors *(a)* to define the names for the standard-defined and (except for 
-``SQL_TEXT``) the implementation-defined Collations it provides and *(b)* to 
-define the ``PAD SPACE`` characteristic for each implementation-defined 
-Collations it provides. 
+[NON-PORTABLE] The complete set of predefined Collations provided by a DBMS is
+non-standard because the SQL Standard allows implementors to include support
+for other Collations, in addition to the required ones. It also requires
+implementors *(a)* to define the names for the standard-defined and (except for
+``SQL_TEXT``) the implementation-defined Collations it provides and *(b)* to
+define the ``PAD SPACE`` characteristic for each implementation-defined
+Collations it provides.
 
-[OCELOT Implementation] The OCELOT DBMS that comes with this book provides a 
-``SQL_TEXT`` Collation that follows the order of the Unicode Form-of-use codes. 
-The ``SQL_TEXT`` Collation has the ``PAD SPACE`` characteristic and is the 
-default Collation for both the ``SQL_TEXT`` Character set and the ``UNICODE`` 
-Character set. It also provides eleven other predefined Collations, all with 
-the ``PAD SPACE`` characteristic. They are: 
+[OCELOT Implementation] The OCELOT DBMS that comes with this book provides a
+``SQL_TEXT`` Collation that follows the order of the Unicode Form-of-use codes.
+The ``SQL_TEXT`` Collation has the ``PAD SPACE`` characteristic and is the
+default Collation for both the ``SQL_TEXT`` Character set and the ``UNICODE``
+Character set. It also provides eleven other predefined Collations, all with
+the ``PAD SPACE`` characteristic. They are:
 
 +-------------------+-------------------------------------------------------+
 | ``SQL_CHARACTER`` | default Collation for Character set ``SQL_CHARACTER`` |
@@ -77,52 +79,52 @@ the ``PAD SPACE`` characteristic. They are:
 | ``CODEPAGE_1257`` | default Collation for Character set ``CODEPAGE_1257`` |
 +-------------------+-------------------------------------------------------+
 
-The pre-defined Collations provided by your DBMS belong to 
-``INFORMATION_SCHEMA``. The SQL special grantee, ``PUBLIC``, always has a 
-``USAGE`` Privilege on every predefined Collation provided by your DBMS. 
+The pre-defined Collations provided by your DBMS belong to
+``INFORMATION_SCHEMA``. The SQL special grantee, ``PUBLIC``, always has a
+``USAGE`` Privilege on every predefined Collation provided by your DBMS.
 
-A Collation is defined by a descriptor that contains three pieces of 
-information: 
+A Collation is defined by a descriptor that contains three pieces of
+information:
 
-1. The <Collation name>, qualified by the <Schema name> of the Schema it 
+1. The <Collation name>, qualified by the <Schema name> of the Schema it
    belongs to.
 
 2. The name of the Character set on which the Collation operates.
 
-3. Whether the ``NO PAD`` or the ``PAD SPACE`` characteristic applies to the 
+3. Whether the ``NO PAD`` or the ``PAD SPACE`` characteristic applies to the
    Collation.
 
-User-defined Collations may belong to any Schema owned by the creator. To 
-create a Collation, use the ``CREATE COLLATION`` statement (either as a 
-stand-alone SQL statement or within a ``CREATE SCHEMA`` statement). ``CREATE 
-COLLATION`` specifies the enclosing Schema, names the Collation and defines the 
-Collation's Character set and ``PAD`` characteristic. To destroy a Collation, 
-use the ``DROP COLLATION`` statement. To change an existing Collation, drop and 
-then redefine it. 
+User-defined Collations may belong to any Schema owned by the creator. To
+create a Collation, use the ``CREATE COLLATION`` statement (either as a
+stand-alone SQL statement or within a ``CREATE SCHEMA`` statement). ``CREATE
+COLLATION`` specifies the enclosing Schema, names the Collation and defines the
+Collation's Character set and ``PAD`` characteristic. To destroy a Collation,
+use the ``DROP COLLATION`` statement. To change an existing Collation, drop and
+then redefine it.
 
 There is a one-to-many association between Character sets and Collations: one
 Character set can have many possible Collations defined for it, although only
 one can be its default Collation.
 
-The default Collation for a Character set is the Collation that will be used to 
-compare characters belonging to that Character set in the absence of an 
-explicit specification to the contrary and can either be a Collation defined 
-for the Character set or the Form-of-use encoding scheme for that Character 
-set's repertoire -- that is, the default Collation for a Character set can be 
-defined to be the order of the characters in the character repertoire. (For 
-example, in the 7-bit ASCII character set, the decimal code for the letter 
-``A`` is ``65`` and the decimal code for the letter ``B`` is ``66``. This is a 
-happy coincidence; it allows your DBMS to discover that ``'A'`` is less than 
-``'B'`` by merely executing a CMP: a machine-code numeric comparison. And 
-that's what is meant by "the order of the characters in the repertoire". Note 
-that, since the decimal code for the letter ``a`` is ``97``, it follows that 
-``'A'`` is less than ``'a'`` -- that is, character repertoire order specifies a 
-case-sensitive collating sequence.) 
+The default Collation for a Character set is the Collation that will be used to
+compare characters belonging to that Character set in the absence of an
+explicit specification to the contrary and can either be a Collation defined
+for the Character set or the Form-of-use encoding scheme for that Character
+set's repertoire -- that is, the default Collation for a Character set can be
+defined to be the order of the characters in the character repertoire. (For
+example, in the 7-bit ASCII character set, the decimal code for the letter
+``A`` is ``65`` and the decimal code for the letter ``B`` is ``66``. This is a
+happy coincidence; it allows your DBMS to discover that ``'A'`` is less than
+``'B'`` by merely executing a CMP: a machine-code numeric comparison. And
+that's what is meant by "the order of the characters in the repertoire". Note
+that, since the decimal code for the letter ``a`` is ``97``, it follows that
+``'A'`` is less than ``'a'`` -- that is, character repertoire order specifies a
+case-sensitive collating sequence.)
 
 *Collation Names*
 -----------------
 
-A <Collation name> identifies a Collation. The required syntax for a 
+A <Collation name> identifies a Collation. The required syntax for a
 <Collation name> is:
 
 ::
@@ -130,16 +132,16 @@ A <Collation name> identifies a Collation. The required syntax for a
     <Collation name> ::=
     [ <Schema name>. ] unqualified name
 
-A <Collation name> is a <regular identifier> or a <delimited identifier> that 
-is unique (for all Collations) within the Schema it belongs to. The <Schema 
-name> which qualifies a <Collation name> names the Schema that the Collation 
-belongs to and can either be explicitly stated, or it will default to 
-``INFORMATION_SCHEMA``; that is, an unqualified <Collation name> is always 
-assumed to belong to ``INFORMATION_SCHEMA`` -- even if a ``CREATE COLLATION`` 
-statement is part of a ``CREATE SCHEMA`` statement. (User-defined Collations 
-may not belong to ``INFORMATION_SCHEMA``. Therefore, when defining, using or 
-dropping a user-defined Collation, always provide an explicit <Schema name> 
-qualifier for the <Collation name>.) 
+A <Collation name> is a <regular identifier> or a <delimited identifier> that
+is unique (for all Collations) within the Schema it belongs to. The <Schema
+name> which qualifies a <Collation name> names the Schema that the Collation
+belongs to and can either be explicitly stated, or it will default to
+``INFORMATION_SCHEMA``; that is, an unqualified <Collation name> is always
+assumed to belong to ``INFORMATION_SCHEMA`` -- even if a ``CREATE COLLATION``
+statement is part of a ``CREATE SCHEMA`` statement. (User-defined Collations
+may not belong to ``INFORMATION_SCHEMA``. Therefore, when defining, using or
+dropping a user-defined Collation, always provide an explicit <Schema name>
+qualifier for the <Collation name>.)
 
 Here are some examples of possible <Collation name>s:
 
@@ -157,27 +159,27 @@ Here are some examples of possible <Collation name>s:
 *Form-of-Use Conversion Names*
 ------------------------------
 
-A <Form-of-Use conversion name> identifies a character repertoire's encoding 
-scheme -- the one-to-one mapping scheme between each character in the 
-repertoire and a set of internal codes (usually 8-bit values) that define how 
-the repertoire's characters are encoded as numbers. These codes are also used 
-to specify the order of the characters within the repertoire and so can be used 
-to specify the default Collation for a Character set. Supported Forms-of- use 
-are all predefined by your DBMS and thus belong to ``INFORMATION_SCHEMA``. SQL 
-provides no ability to define your own Forms-of-use. The required syntax for a 
-<Form-of-use conversion name> is: 
+A <Form-of-Use conversion name> identifies a character repertoire's encoding
+scheme -- the one-to-one mapping scheme between each character in the
+repertoire and a set of internal codes (usually 8-bit values) that define how
+the repertoire's characters are encoded as numbers. These codes are also used
+to specify the order of the characters within the repertoire and so can be used
+to specify the default Collation for a Character set. Supported Forms-of- use
+are all predefined by your DBMS and thus belong to ``INFORMATION_SCHEMA``. SQL
+provides no ability to define your own Forms-of-use. The required syntax for a
+<Form-of-use conversion name> is:
 
 ::
 
     <Form-of-use conversion name> ::=
     [ INFORMATION_SCHEMA. ] unqualified name
 
-A <Form-of-use conversion name> is a <regular identifier> or a <delimited 
-identifier> that is unique (for all Forms-of-user) within 
-``INFORMATION_SCHEMA``. The <Schema name> which qualifies a <Form-of-use 
-conversion name> names the Schema that the Form-of-use belongs to and can 
-either be explicitly stated, or it will default to ``INFORMATION_SCHEMA``: the 
-only Schema that may own a Form-of-use. 
+A <Form-of-use conversion name> is a <regular identifier> or a <delimited
+identifier> that is unique (for all Forms-of-user) within
+``INFORMATION_SCHEMA``. The <Schema name> which qualifies a <Form-of-use
+conversion name> names the Schema that the Form-of-use belongs to and can
+either be explicitly stated, or it will default to ``INFORMATION_SCHEMA``: the
+only Schema that may own a Form-of-use.
 
 Here are some examples of possible <Form-of-use conversion name>s:
 
@@ -196,19 +198,19 @@ Here are some examples of possible <Form-of-use conversion name>s:
 SQL Standard requires implementors to define which (if any) Forms-of-use they
 will explicitly provide.
 
-[OCELOT Implementation] The OCELOT DBMS that comes with this book provides 
+[OCELOT Implementation] The OCELOT DBMS that comes with this book provides
 no explicit Forms-of use.
 
-If you want to restrict your code to Core SQL, don't use any <Collation 
+If you want to restrict your code to Core SQL, don't use any <Collation
 name>s or <Form-of-use conversion name>s.
 
 CREATE COLLATION Statement
 ==========================
 
-The ``CREATE COLLATION`` statement names a new user-defined Collation and 
-specifies the Collation's ``PAD`` characteristic and the Character set that the 
-Collation is for. The required syntax for the ``CREATE COLLATION`` statement 
-is: 
+The ``CREATE COLLATION`` statement names a new user-defined Collation and
+specifies the Collation's ``PAD`` characteristic and the Character set that the
+Collation is for. The required syntax for the ``CREATE COLLATION`` statement
+is:
 
 ::
 
@@ -216,7 +218,7 @@ is:
          FOR <Character set name>
          FROM existing <Collation name> [ {NO PAD | PAD SPACE} ]
 
-``CREATE COLLATION`` defines a new user-defined Collation. A Collation is 
+``CREATE COLLATION`` defines a new user-defined Collation. A Collation is
 owned by the Schema it belongs to.
 
 The user-defined <Collation name> identifies the new Collation and the Schema
@@ -226,12 +228,12 @@ include an explicit <Schema name> qualifier belongs to ``INFORMATION_SCHEMA``.
 Since a user-defined Collation can't belong to ``INFORMATION_SCHEMA``, always
 provide an explicit <Schema name> qualifier when you're creating a Collation.
 
-If ``CREATE COLLATION`` is part of a ``CREATE SCHEMA`` statement, the 
-<Collation name> must include the <Schema name> of the Schema being created; 
-that is, it isn't possible to create a Collation belonging to a different 
-Schema from within ``CREATE SCHEMA``. For example, this SQL statement will not 
-return an error because the <Collation name> explicitly includes a qualifying 
-<Schema name> that matches the name of the Schema being created: 
+If ``CREATE COLLATION`` is part of a ``CREATE SCHEMA`` statement, the
+<Collation name> must include the <Schema name> of the Schema being created;
+that is, it isn't possible to create a Collation belonging to a different
+Schema from within ``CREATE SCHEMA``. For example, this SQL statement will not
+return an error because the <Collation name> explicitly includes a qualifying
+<Schema name> that matches the name of the Schema being created:
 
 ::
 
@@ -249,50 +251,50 @@ of the Schema being created:
       CREATE COLLATION sam.collation_1 FOR bob.charset_1 FROM SQL_TEXT;
    -- tries to create a Collation belonging to Schema SAM inside Schema BOB; illegal syntax
 
-If ``CREATE COLLATION`` is executed as a stand-alone SQL statement, the current 
-<AuthorizationID> must either be the owner of the Schema that this new View 
-belongs to, or the Schema's owner must be a Role that the current 
-<AuthorizationID> may use. That is, only the owner of a Schema can create 
-Collations for that Schema. In addition to creating a Collation, ``CREATE 
-COLLATION`` also causes the SQL special grantor, "``_SYSTEM``", to grant the 
-``USAGE`` Privilege on the new Collation to the Schema owner <AuthorizationID> 
-(that is, the <AuthorizationID creating the Collation). The Privilege is 
-grantable if the <AuthorizationID> also has a grantable ``USAGE`` Privilege on 
-the Collation named in the ``FROM`` clause of the ``CREATE COLLATION`` 
-statement. 
+If ``CREATE COLLATION`` is executed as a stand-alone SQL statement, the current
+<AuthorizationID> must either be the owner of the Schema that this new View
+belongs to, or the Schema's owner must be a Role that the current
+<AuthorizationID> may use. That is, only the owner of a Schema can create
+Collations for that Schema. In addition to creating a Collation, ``CREATE
+COLLATION`` also causes the SQL special grantor, "``_SYSTEM``", to grant the
+``USAGE`` Privilege on the new Collation to the Schema owner <AuthorizationID>
+(that is, the <AuthorizationID creating the Collation). The Privilege is
+grantable if the <AuthorizationID> also has a grantable ``USAGE`` Privilege on
+the Collation named in the ``FROM`` clause of the ``CREATE COLLATION``
+statement.
 
 A user-defined Collation must be defined to operate on a Character set. The
 ``FOR`` clause of the ``CREATE COLLATION`` statement names that Character set.
 <Character set name> must be the name of an existing Character set for which
 the current <AuthorizationID> has the ``USAGE`` Privilege.
 
-A user-defined Collation must also be defined as using the collating sequence 
-of an existing Collation that is already defined for the Character set named in 
-the ``FOR`` clause of the ``CREATE COLLATION`` statement. The ``FROM`` clause 
-of the ``CREATE COLLATION`` statement names this Collation source. The existing 
-<Collation name> must be the name of an existing Collation for which the 
-current <AuthorizationID> has the ``USAGE`` Privilege. For example, this SQL 
-statement: 
+A user-defined Collation must also be defined as using the collating sequence
+of an existing Collation that is already defined for the Character set named in
+the ``FOR`` clause of the ``CREATE COLLATION`` statement. The ``FROM`` clause
+of the ``CREATE COLLATION`` statement names this Collation source. The existing
+<Collation name> must be the name of an existing Collation for which the
+current <AuthorizationID> has the ``USAGE`` Privilege. For example, this SQL
+statement:
 
 ::
 
    CREATE COLLATION bob.collation_1 FOR bob.charset_1 FROM SQL_TEXT;
 
-defines a new user-defined Collation, called ``BOB.COLLATION_1``, in the Schema 
-named ``BOB``. Except for its name, the Collation ``BOB. COLLATION_1`` will be 
-exactly the same as the ``SQL_TEXT`` Collation -- that is, it is not truly 
-possible to "create" new Collations, merely to rename (and possibly assign a 
-new ``PAD`` characteristic to) them. To define a new Collation, the ``CREATE 
-COLLATION`` statement must use some pre-existing Collation as a Collation 
-source -- and, ultimately, all Collations can only be based on some pre-defined 
-Collation provided by your DBMS. 
+defines a new user-defined Collation, called ``BOB.COLLATION_1``, in the Schema
+named ``BOB``. Except for its name, the Collation ``BOB. COLLATION_1`` will be
+exactly the same as the ``SQL_TEXT`` Collation -- that is, it is not truly
+possible to "create" new Collations, merely to rename (and possibly assign a
+new ``PAD`` characteristic to) them. To define a new Collation, the ``CREATE
+COLLATION`` statement must use some pre-existing Collation as a Collation
+source -- and, ultimately, all Collations can only be based on some pre-defined
+Collation provided by your DBMS.
 
-The optional ``PAD`` characteristic clause of the ``CREATE COLLATION`` 
-statement allows you to define a ``PAD`` characteristic for your user-defined 
-Collation that is different from the ``PAD`` characteristic of its source 
-Collation. If you omit the ``PAD`` clause, your new Collation will have the 
-same ``PAD`` characteristic as its source Collation does. For example, this SQL 
-statement: 
+The optional ``PAD`` characteristic clause of the ``CREATE COLLATION``
+statement allows you to define a ``PAD`` characteristic for your user-defined
+Collation that is different from the ``PAD`` characteristic of its source
+Collation. If you omit the ``PAD`` clause, your new Collation will have the
+same ``PAD`` characteristic as its source Collation does. For example, this SQL
+statement:
 
 ::
 
@@ -307,7 +309,7 @@ characteristic as Collation ``SQL_TEXT`` does; that is, except for its name,
    CREATE COLLATION bob.collation_1 FOR bob.charset_1 FROM SQL_TEXT
       PAD SPACE;
 
-defines a new user-defined Collation that will have the ``PAD SPACE`` 
+defines a new user-defined Collation that will have the ``PAD SPACE``
 characteristic. And this SQL statement:
 
 ::
@@ -315,7 +317,7 @@ characteristic. And this SQL statement:
    CREATE COLLATION bob.collation_1 FOR bob.charset_1 FROM SQL_TEXT
       NO PAD;
 
-defines a new user-defined Collation that will have the ``NO PAD`` 
+defines a new user-defined Collation that will have the ``NO PAD``
 characteristic.
 
 A Collation's ``PAD`` characteristic affects the result when two strings of
@@ -328,24 +330,24 @@ the comparison is done. In this case, the result is that the shorter comparand
 will evaluate as less than the longer comparand if they contain the same
 characters for their common length -- see our chapter on character strings.
 
-If you want to restrict your code to Core SQL, don't use the ``CREATE 
+If you want to restrict your code to Core SQL, don't use the ``CREATE
 COLLATION`` statement.
 
 DROP COLLATION Statement
 ========================
 
-The ``DROP COLLATION`` statement destroys a user-defined Collation. The 
+The ``DROP COLLATION`` statement destroys a user-defined Collation. The
 required syntax for the ``DROP COLLATION`` statement is:
 
 ::
 
     DROP COLLATION <Collation name> {RESTRICT | CASCADE}
 
-The <Collation name> must identify an existing Collation whose owner is either 
-the current <AuthorizationID> or a Role that the current <AuthorizationID> may 
-use. That is, only the <AuthorizationID> that owns the Collation may drop it, 
-and so it isn't possible to drop any of the predefined Collations provided by 
-your DBMS. 
+The <Collation name> must identify an existing Collation whose owner is either
+the current <AuthorizationID> or a Role that the current <AuthorizationID> may
+use. That is, only the <AuthorizationID> that owns the Collation may drop it,
+and so it isn't possible to drop any of the predefined Collations provided by
+your DBMS.
 
 The effect of ``DROP COLLATION`` <Collation name> ``RESTRICT``, e.g.:
 
@@ -372,29 +374,29 @@ If successful, ``DROP COLLATION`` has a six-fold effect.
 
 1. The Collation named is destroyed.
 
-2. The ``USAGE`` Privilege held on the Collation by the <AuthorizationID> 
-   that owns it is revoked (by the SQL special grantor, "``_SYSTEM``") with 
-   a ``CASCADE`` revoke behaviour, so that the ``USAGE`` Privilege held on 
+2. The ``USAGE`` Privilege held on the Collation by the <AuthorizationID>
+   that owns it is revoked (by the SQL special grantor, "``_SYSTEM``") with
+   a ``CASCADE`` revoke behaviour, so that the ``USAGE`` Privilege held on
    the Collation by any other <AuthorizationID> is also revoked.
 
 3. The definition of any other Collation that named this Collation is
-   amended, so that it no longer refers to it. The effect is that each 
-   Collation that was based on the dropped Collation will subsequently use 
-   the Form-of-use encoding scheme for the repertoire of its Character set 
+   amended, so that it no longer refers to it. The effect is that each
+   Collation that was based on the dropped Collation will subsequently use
+   the Form-of-use encoding scheme for the repertoire of its Character set
    as a collating sequence.
 
-4. The definition of any Character set that named this Collation is amended, 
-   so that it no longer refers to it. The effect is that each Character set 
-   that used the dropped Collation as its default Collation will subsequently 
-   use the Form-of-use encoding scheme for its repertoire as a default 
+4. The definition of any Character set that named this Collation is amended,
+   so that it no longer refers to it. The effect is that each Character set
+   that used the dropped Collation as its default Collation will subsequently
+   use the Form-of-use encoding scheme for its repertoire as a default
    Collation.
 
 5. The definition of any Column, Domain, View, Constraint or Assertion
    that named this Collation is amended, so that it no longer refers to it. The
    effect is that each Column or Domain that used the dropped Collation as its
-   default Collation will subsequently use the default Collation of its 
+   default Collation will subsequently use the default Collation of its
    Character set as a default Collation.
 
-6. Every SQL routine that names this Collation is dropped with a ``CASCADE`` 
-   drop behaviour. If you want to restrict your code to Core SQL, don't use 
+6. Every SQL routine that names this Collation is dropped with a ``CASCADE``
+   drop behaviour. If you want to restrict your code to Core SQL, don't use
    the ``DROP COLLATION`` statement.

--- a/docs/chapters/23.rst
+++ b/docs/chapters/23.rst
@@ -4,9 +4,11 @@
 Chapter 23 -- SQL Translation
 =============================
 
+.. include:: ../_include/note.rst
+
 [Obscure Rule] applies to this entire chapter.
 
-In this chapter, we'll describe SQL Translations in detail, and show you the 
+In this chapter, we'll describe SQL Translations in detail, and show you the
 syntax to use to create, alter and destroy them.
 
 .. rubric:: Table of Contents
@@ -17,71 +19,71 @@ syntax to use to create, alter and destroy them.
 Translation
 ===========
 
-A Schema may contain zero or more Translations. An *SQL Translation* is a set 
-of rules that maps the characters from a source Character set to the characters 
-of a target Character set; effectively translating source strings into target 
-strings. Any pair of Character sets may have zero or more Translations defined 
-to translate strings belonging to one (the source Character set) into strings 
-belonging to the other (the target Character set). Translations are dependent 
-on some Schema -- the <Translation name> must be unique within the Schema the 
-Translation belongs to. User-defined Translations are created and dropped using 
-standard SQL statements. 
+A Schema may contain zero or more Translations. An *SQL Translation* is a set
+of rules that maps the characters from a source Character set to the characters
+of a target Character set; effectively translating source strings into target
+strings. Any pair of Character sets may have zero or more Translations defined
+to translate strings belonging to one (the source Character set) into strings
+belonging to the other (the target Character set). Translations are dependent
+on some Schema -- the <Translation name> must be unique within the Schema the
+Translation belongs to. User-defined Translations are created and dropped using
+standard SQL statements.
 
-In SQL, a Translation may be a Translation defined by a national or 
-international standard, by your DBMS or by a user of SQL-data. 
+In SQL, a Translation may be a Translation defined by a national or
+international standard, by your DBMS or by a user of SQL-data.
 
-Standard-defined Translations are translations predefined for two character 
-repertoires by some standards body. Implementation-defined Translations are 
-translations predefined for two Character sets by your DBMS. The pre-defined 
-Translations provided by your DBMS belong to ``INFORMATION_SCHEMA``. The SQL 
-special grantee, ``PUBLIC``, always has a ``USAGE`` Privilege on every 
-predefined Translation provided by your DBMS. 
+Standard-defined Translations are translations predefined for two character
+repertoires by some standards body. Implementation-defined Translations are
+translations predefined for two Character sets by your DBMS. The pre-defined
+Translations provided by your DBMS belong to ``INFORMATION_SCHEMA``. The SQL
+special grantee, ``PUBLIC``, always has a ``USAGE`` Privilege on every
+predefined Translation provided by your DBMS.
 
-[NON-PORTABLE] The set of predefined Translations provided by a DBMS is 
-non-standard because the SQL Standard has no required Translations: it requires 
-implementors to define any Translations supported. 
+[NON-PORTABLE] The set of predefined Translations provided by a DBMS is
+non-standard because the SQL Standard has no required Translations: it requires
+implementors to define any Translations supported.
 
-[OCELOT Implementation] The OCELOT DBMS that comes with this book provides a 
-Translation named ``OCELOT``. It translates ``SQL_TEXT`` strings to 
-``ASCII_FULL`` strings. 
+[OCELOT Implementation] The OCELOT DBMS that comes with this book provides a
+Translation named ``OCELOT``. It translates ``SQL_TEXT`` strings to
+``ASCII_FULL`` strings.
 
-A Translation is defined by a descriptor that contains four pieces of 
-information: 
+A Translation is defined by a descriptor that contains four pieces of
+information:
 
-1. The <Translation name>, qualified by the <Schema name> of the Schema it 
+1. The <Translation name>, qualified by the <Schema name> of the Schema it
    belongs to.
 
-2. The name of the Translation's source Character set: the Character set 
+2. The name of the Translation's source Character set: the Character set
    from which it translates.
 
-3. The name of the Translation's target Character set: the Character set to 
+3. The name of the Translation's target Character set: the Character set to
    which it translates.
 
 4. The mapping scheme for the Translation.
 
-Two character strings may be compared or assigned to one another only if they 
-both belong to the same Character set. The way to force a comparison or 
-assignment between strings from different Character sets is to use the 
-``TRANSLATE`` function, which uses a Translation defined for the Character sets 
-as an argument. 
+Two character strings may be compared or assigned to one another only if they
+both belong to the same Character set. The way to force a comparison or
+assignment between strings from different Character sets is to use the
+``TRANSLATE`` function, which uses a Translation defined for the Character sets
+as an argument.
 
-User-defined Translations may belong to any Schema owned by the creator. To 
-create a Translation, use the ``CREATE TRANSLATION`` statement (either as a 
-stand-alone SQL statement or within a ``CREATE SCHEMA`` statement). ``CREATE 
-TRANSLATION`` specifies the enclosing Schema, names the Translation and defines 
-the Translation's source Character set, target Character set and Translation 
-source. To destroy a Translation, use the ``DROP TRANSLATION`` statement. To 
-change an existing Translation, drop and then redefine it. 
+User-defined Translations may belong to any Schema owned by the creator. To
+create a Translation, use the ``CREATE TRANSLATION`` statement (either as a
+stand-alone SQL statement or within a ``CREATE SCHEMA`` statement). ``CREATE
+TRANSLATION`` specifies the enclosing Schema, names the Translation and defines
+the Translation's source Character set, target Character set and Translation
+source. To destroy a Translation, use the ``DROP TRANSLATION`` statement. To
+change an existing Translation, drop and then redefine it.
 
-There is a one-to-many relationship between Translations and Character sets: a 
-Translation may translate the characters of only one pair of Character sets, 
-but a Character set can be named as either the source or the target for many 
+There is a one-to-many relationship between Translations and Character sets: a
+Translation may translate the characters of only one pair of Character sets,
+but a Character set can be named as either the source or the target for many
 different Translations.
 
 *Translation Names*
 -------------------
 
-A <Translation name> identifies a Translation. The required syntax for a 
+A <Translation name> identifies a Translation. The required syntax for a
 <Translation name> is:
 
 ::
@@ -89,16 +91,16 @@ A <Translation name> identifies a Translation. The required syntax for a
     <Translation name> ::=
     [ <Schema name>. ] unqualified name
 
-A <Translation name> is a <regular identifier> or a <delimited identifier> that 
-is unique (for all Translations) within the Schema it belongs to. The <Schema 
-name> which qualifies a <Translation name> names the Schema that the 
-Translation belongs to and can either be explicitly stated, or it will default 
-to ``INFORMATION_SCHEMA``; that is, an unqualified <Translation name> is always 
-assumed to belong to ``INFORMATION_SCHEMA`` -- even if a ``CREATE TRANSLATION`` 
-statement is part of a ``CREATE SCHEMA`` statement. (User-defined Translations 
-may not belong to ``INFORMATION_SCHEMA``. Therefore, when defining, using or 
-dropping a user-defined Translation, always provide an explicit <Schema name> 
-qualifier for the <Translation name>.) 
+A <Translation name> is a <regular identifier> or a <delimited identifier> that
+is unique (for all Translations) within the Schema it belongs to. The <Schema
+name> which qualifies a <Translation name> names the Schema that the
+Translation belongs to and can either be explicitly stated, or it will default
+to ``INFORMATION_SCHEMA``; that is, an unqualified <Translation name> is always
+assumed to belong to ``INFORMATION_SCHEMA`` -- even if a ``CREATE TRANSLATION``
+statement is part of a ``CREATE SCHEMA`` statement. (User-defined Translations
+may not belong to ``INFORMATION_SCHEMA``. Therefore, when defining, using or
+dropping a user-defined Translation, always provide an explicit <Schema name>
+qualifier for the <Translation name>.)
 
 Here are some examples of possible <Translation name>s:
 
@@ -113,16 +115,16 @@ Here are some examples of possible <Translation name>s:
    CATALOG_1.SCHEMA_1.TRANSLATION_1
    -- a fully qualified <Translation name>
 
-If you want to restrict your code to Core SQL, don't use any <Translation 
+If you want to restrict your code to Core SQL, don't use any <Translation
 name>s.
 
 CREATE TRANSLATION Statement
 ============================
 
-The ``CREATE TRANSLATION`` statement names a new user-defined Translation and 
-specifies the Translation's source and target Character sets as well as the 
-Translation's source. The required syntax for the ``CREATE TRANSLATION`` 
-statement is: 
+The ``CREATE TRANSLATION`` statement names a new user-defined Translation and
+specifies the Translation's source and target Character sets as well as the
+Translation's source. The required syntax for the ``CREATE TRANSLATION``
+statement is:
 
 ::
 
@@ -135,23 +137,23 @@ statement is:
        existing <Translation name> |
        <specific routine designator>
 
-``CREATE TRANSLATION`` defines a new user-defined Translation. A Translation 
+``CREATE TRANSLATION`` defines a new user-defined Translation. A Translation
 is owned by the Schema it belongs to.
 
-The user-defined <Translation name> identifies the new Translation and the 
-Schema that it belongs to. A <Translation name> that includes an explicit 
-<Schema name> qualifier belongs to the Schema named. A <Translation name> that 
-does not include an explicit <Schema name> qualifier belongs to 
-``INFORMATION_SCHEMA``. Since a user-defined Translation can't belong to 
-``INFORMATION_SCHEMA``, always provide an explicit <Schema name> qualifier when 
-you're creating a Translation. 
+The user-defined <Translation name> identifies the new Translation and the
+Schema that it belongs to. A <Translation name> that includes an explicit
+<Schema name> qualifier belongs to the Schema named. A <Translation name> that
+does not include an explicit <Schema name> qualifier belongs to
+``INFORMATION_SCHEMA``. Since a user-defined Translation can't belong to
+``INFORMATION_SCHEMA``, always provide an explicit <Schema name> qualifier when
+you're creating a Translation.
 
-If ``CREATE TRANSLATION`` is part of a ``CREATE SCHEMA`` statement, the 
-<Translation name> must include the <Schema name> of the Schema being created; 
-that is, it isn't possible to create a Translation belonging to a different 
-Schema from within ``CREATE SCHEMA``. For example, this SQL statement will not 
-return an error because the <Translation name> explicitly includes a qualifying 
-<Schema name> that matches the name of the Schema being created: 
+If ``CREATE TRANSLATION`` is part of a ``CREATE SCHEMA`` statement, the
+<Translation name> must include the <Schema name> of the Schema being created;
+that is, it isn't possible to create a Translation belonging to a different
+Schema from within ``CREATE SCHEMA``. For example, this SQL statement will not
+return an error because the <Translation name> explicitly includes a qualifying
+<Schema name> that matches the name of the Schema being created:
 
 ::
 
@@ -160,9 +162,9 @@ return an error because the <Translation name> explicitly includes a qualifying
          FOR SQL_CHARACTER TO LATIN1 FROM function_name;
    -- creates a Translation called BOB.TRANSLATION_1 in Schema BOB
 
-But this SQL statement will return an error because the <Translation name> 
-explicitly includes a qualifying <Schema name> that is different from the name 
-of the Schema being created: 
+But this SQL statement will return an error because the <Translation name>
+explicitly includes a qualifying <Schema name> that is different from the name
+of the Schema being created:
 
 ::
 
@@ -171,69 +173,69 @@ of the Schema being created:
          FOR SQL_CHARACTER TO LATIN1 FROM function_name;
    -- tries to create a Translation belonging to Schema SAM inside Schema BOB; illegal syntax
 
-If ``CREATE TRANSLATION`` is executed as a stand-alone SQL statement, the 
-current <AuthorizationID> must either be the owner of the Schema that this new 
-Translation belongs to, or the Schema's owner must be a Role that the current 
-<AuthorizationID> may use. That is, only the owner of a Schema can create 
-Translations for that Schema. In addition to creating a Translation, ``CREATE 
-TRANSLATION`` also causes the SQL special grantor, "``_SYSTEM``", to grant the 
-``USAGE`` Privilege on the new Translation to the Schema owner 
-<AuthorizationID> (that is, the <AuthorizationID creating the Translation). The 
-Privilege is grantable if the <AuthorizationID> also has a grantable ``USAGE`` 
-Privilege on both the Translation's source Character set and its target 
-Character set. 
+If ``CREATE TRANSLATION`` is executed as a stand-alone SQL statement, the
+current <AuthorizationID> must either be the owner of the Schema that this new
+Translation belongs to, or the Schema's owner must be a Role that the current
+<AuthorizationID> may use. That is, only the owner of a Schema can create
+Translations for that Schema. In addition to creating a Translation, ``CREATE
+TRANSLATION`` also causes the SQL special grantor, "``_SYSTEM``", to grant the
+``USAGE`` Privilege on the new Translation to the Schema owner
+<AuthorizationID> (that is, the <AuthorizationID creating the Translation). The
+Privilege is grantable if the <AuthorizationID> also has a grantable ``USAGE``
+Privilege on both the Translation's source Character set and its target
+Character set.
 
-A user-defined Translation must be defined to operate on a pair of Character 
-sets. The ``FOR`` clause of the ``CREATE TRANSLATION`` statement names the 
-source Character set; the ``TO`` clause names the target Character set. In each 
-case, <Character set name> must be the name of an existing Character set for 
-which the current <AuthorizationID> has the ``USAGE`` Privilege. 
+A user-defined Translation must be defined to operate on a pair of Character
+sets. The ``FOR`` clause of the ``CREATE TRANSLATION`` statement names the
+source Character set; the ``TO`` clause names the target Character set. In each
+case, <Character set name> must be the name of an existing Character set for
+which the current <AuthorizationID> has the ``USAGE`` Privilege.
 
-A user-defined Translation must also be defined as using a source mapping 
-scheme: it defines the source and target Character sets' corresponding pairs of 
-characters. The ``FROM`` clause of the ``CREATE TRANSLATION`` statement names 
-this Translation source. If the ``FROM`` clause names some other Translation as 
-the new Translation's source, the existing <Translation name> must be the name 
-of an existing Translation for which the current <AuthorizationID> has the 
-``USAGE`` Privilege and whose source Character set and target Character set are 
-the same as the source and target Character sets you're defining for the new 
-Translation. For example, this SQL statement: 
+A user-defined Translation must also be defined as using a source mapping
+scheme: it defines the source and target Character sets' corresponding pairs of
+characters. The ``FROM`` clause of the ``CREATE TRANSLATION`` statement names
+this Translation source. If the ``FROM`` clause names some other Translation as
+the new Translation's source, the existing <Translation name> must be the name
+of an existing Translation for which the current <AuthorizationID> has the
+``USAGE`` Privilege and whose source Character set and target Character set are
+the same as the source and target Character sets you're defining for the new
+Translation. For example, this SQL statement:
 
 ::
 
    CREATE TRANSLATION bob.translation_2
       FOR SQL_CHARACTER TO LATIN1 FROM bob.translation_1;
 
-defines a new user-defined Translation, called ``BOB.TRANSLATION_2``, in the 
-Schema named ``BOB``. Except for its name, the Translation 
-``BOB.TRANSLATION_2`` will be exactly the same as the ``BOB.TRANSLATION_1`` 
-Translation -- that is, it is not truly possible to "create" new Translations 
-with this format, merely to rename them. The other option for specifying a 
-Translation source is to use a <specific routine designator> that names an 
-SQL-invoked function for which the current <AuthorizationID> has the 
-``EXECUTE`` Privilege. The function named must *(a)* have one character string 
-parameter whose Character set is this Translation's source Character set and 
-*(b)* return a character string that belongs to this Translation's target 
-Character set. 
+defines a new user-defined Translation, called ``BOB.TRANSLATION_2``, in the
+Schema named ``BOB``. Except for its name, the Translation
+``BOB.TRANSLATION_2`` will be exactly the same as the ``BOB.TRANSLATION_1``
+Translation -- that is, it is not truly possible to "create" new Translations
+with this format, merely to rename them. The other option for specifying a
+Translation source is to use a <specific routine designator> that names an
+SQL-invoked function for which the current <AuthorizationID> has the
+``EXECUTE`` Privilege. The function named must *(a)* have one character string
+parameter whose Character set is this Translation's source Character set and
+*(b)* return a character string that belongs to this Translation's target
+Character set.
 
-If you want to restrict your code to Core SQL, don't use the ``CREATE 
+If you want to restrict your code to Core SQL, don't use the ``CREATE
 TRANSLATION`` statement.
 
 DROP TRANSLATION Statement
 ==========================
 
-The ``DROP TRANSLATION`` statement destroys a user-defined Translation. The 
+The ``DROP TRANSLATION`` statement destroys a user-defined Translation. The
 required syntax for the ``DROP TRANSLATION`` statement is:
 
 ::
 
     DROP TRANSLATION <Translation name>
 
-The <Translation name> must identify an existing Translation whose owner is 
-either the current <AuthorizationID> or a Role that the current 
-<AuthorizationID> may use. That is, only the <AuthorizationID> that owns the 
-Translation may drop it, and so it isn't possible to drop any of the predefined 
-Translations provided by your DBMS. 
+The <Translation name> must identify an existing Translation whose owner is
+either the current <AuthorizationID> or a Role that the current
+<AuthorizationID> may use. That is, only the <AuthorizationID> that owns the
+Translation may drop it, and so it isn't possible to drop any of the predefined
+Translations provided by your DBMS.
 
 The effect of ``DROP TRANSLATION`` <Translation name>, e.g.:
 
@@ -252,10 +254,10 @@ If successful, ``DROP TRANSLATION`` has a two-fold effect.
 
 1. The Translation named is destroyed.
 
-2. The ``USAGE`` Privilege held on the Translation by the <AuthorizationID> 
-   that owns it is revoked (by the SQL special grantor, "``_SYSTEM``") with a 
-   ``CASCADE`` revoke behaviour, so that the ``USAGE`` Privilege held on the 
+2. The ``USAGE`` Privilege held on the Translation by the <AuthorizationID>
+   that owns it is revoked (by the SQL special grantor, "``_SYSTEM``") with a
+   ``CASCADE`` revoke behaviour, so that the ``USAGE`` Privilege held on the
    Translation by any other <AuthorizationID> is also revoked.
 
-If you want to restrict your code to Core SQL, don't use the ``DROP 
+If you want to restrict your code to Core SQL, don't use the ``DROP
 TRANSLATION`` statement.

--- a/docs/chapters/24.rst
+++ b/docs/chapters/24.rst
@@ -4,11 +4,13 @@
 Chapter 24 -- SQL Trigger
 =========================
 
-| *"If you press the SECOND dorsal fin-spine on a trigger fish, an amazing 
+.. include:: ../_include/note.rst
+
+| *"If you press the SECOND dorsal fin-spine on a trigger fish, an amazing
   event occurs. The FIRST dorsal fin-spine goes down too."*
 | *-- Applied Ichthyology*
 
-In this chapter, we'll describe SQL Triggers in detail, and show you the 
+In this chapter, we'll describe SQL Triggers in detail, and show you the
 syntax to use to create, alter and destroy them.
 
 .. rubric:: Table of Contents
@@ -19,69 +21,69 @@ syntax to use to create, alter and destroy them.
 Trigger
 =======
 
-A Schema may contain zero or more Triggers. An *SQL Trigger* is a named chain 
-reaction that you set off with an SQL data change statement: it specifies a set 
-of SQL statements that are to be executed (either once for each row or once for 
-the whole triggering ``INSERT``, ``DELETE`` or ``UPDATE`` statement) either 
-before or after rows are inserted into a Table, rows are deleted from a Table, 
-or one or more Columns are updated in rows of a Table. Triggers are dependent 
-on some Schema -- the <Trigger name> must be unique within the Schema the 
-Trigger belongs to -- and are created, altered and dropped using standard SQL 
-statements. 
+A Schema may contain zero or more Triggers. An *SQL Trigger* is a named chain
+reaction that you set off with an SQL data change statement: it specifies a set
+of SQL statements that are to be executed (either once for each row or once for
+the whole triggering ``INSERT``, ``DELETE`` or ``UPDATE`` statement) either
+before or after rows are inserted into a Table, rows are deleted from a Table,
+or one or more Columns are updated in rows of a Table. Triggers are dependent
+on some Schema -- the <Trigger name> must be unique within the Schema the
+Trigger belongs to -- and are created, altered and dropped using standard SQL
+statements.
 
-Triggers are similar to Constraints. (In fact, referential Constraints are now 
-defined by the SQL Standard as merely a type of Trigger, although they don't 
-share the same name-space.) What distinguishes a Trigger from a Constraint is 
-flexibility: the Trigger body may contain actual SQL procedure statements, that 
-you define yourself. In effect, when you "create a Trigger on Table 
-``TABLE_1``\", you are saying "whenever (in the future) a specific sort of 
-event occurs which changes Table ``TABLE_1``, execute the following further SQL 
-statements". For example, you could create a Trigger so that, whenever 
-``TABLE_1`` is updated, a counter should be incremented in a summary Table. 
+Triggers are similar to Constraints. (In fact, referential Constraints are now
+defined by the SQL Standard as merely a type of Trigger, although they don't
+share the same name-space.) What distinguishes a Trigger from a Constraint is
+flexibility: the Trigger body may contain actual SQL procedure statements, that
+you define yourself. In effect, when you "create a Trigger on Table
+``TABLE_1``\", you are saying "whenever (in the future) a specific sort of
+event occurs which changes Table ``TABLE_1``, execute the following further SQL
+statements". For example, you could create a Trigger so that, whenever
+``TABLE_1`` is updated, a counter should be incremented in a summary Table.
 
-Triggers are a SQL3 feature, but most DBMS vendors implemented them years ago. 
-People use Triggers to enforce business rules, to maintain logs or to 
-substitute for Constraints (where the rules for Constraints are too 
-restrictive). 
+Triggers are a SQL3 feature, but most DBMS vendors implemented them years ago.
+People use Triggers to enforce business rules, to maintain logs or to
+substitute for Constraints (where the rules for Constraints are too
+restrictive).
 
 A Trigger is defined by a descriptor that contains eight pieces of information:
 
-1. The <Trigger name>, qualified by the <Schema name> of the Schema it 
+1. The <Trigger name>, qualified by the <Schema name> of the Schema it
    belongs to.
 
-2. The name of the Table whose data, when changed, will cause the Trigger to 
+2. The name of the Table whose data, when changed, will cause the Trigger to
    be activated. (This is called the Trigger's *subject Table*.)
 
-3. The Trigger action time, which tells your DBMS when to execute the 
+3. The Trigger action time, which tells your DBMS when to execute the
    Trigger body (either ``BEFORE`` or ``AFTER`` the Trigger event).
 
-4. The Trigger event, which tells your DBMS which data change statement 
-   (either ``INSERT``, ``UPDATE`` or ``DELETE``), executed on the Trigger's 
+4. The Trigger event, which tells your DBMS which data change statement
+   (either ``INSERT``, ``UPDATE`` or ``DELETE``), executed on the Trigger's
    Table, activates the Trigger.
 
-5. The Trigger Column list for the Trigger event, as well as whether the 
-   list was explicitly or implicitly defined (for ``UPDATE`` Trigger events 
+5. The Trigger Column list for the Trigger event, as well as whether the
+   list was explicitly or implicitly defined (for ``UPDATE`` Trigger events
    only).
 
-6. Any old values <Correlation name>, new values <Correlation name>, old 
+6. Any old values <Correlation name>, new values <Correlation name>, old
    values Table alias or new values Table alias defined for the Trigger.
 
-7. The Trigger body: the SQL statements you want your DBMS to execute on the 
+7. The Trigger body: the SQL statements you want your DBMS to execute on the
    Trigger's Table when the Trigger is activated.
 
 8. The Trigger's timestamp: when it was created.
 
-To create a Trigger use the ``CREATE TRIGGER`` statement (either as a 
-stand-alone SQL statement or within a ``CREATE SCHEMA`` statement). ``CREATE 
-TRIGGER`` specifies the enclosing Schema, names the Trigger and defines the 
-Trigger's Table, action time, event and body. To destroy a Trigger, use the 
-``DROP TRIGGER`` statement. To change an existing Trigger, drop and then 
-redefine it. 
+To create a Trigger use the ``CREATE TRIGGER`` statement (either as a
+stand-alone SQL statement or within a ``CREATE SCHEMA`` statement). ``CREATE
+TRIGGER`` specifies the enclosing Schema, names the Trigger and defines the
+Trigger's Table, action time, event and body. To destroy a Trigger, use the
+``DROP TRIGGER`` statement. To change an existing Trigger, drop and then
+redefine it.
 
 *Trigger Names*
 ---------------
 
-A <Trigger name> identifies a Trigger. The required syntax for a <Trigger 
+A <Trigger name> identifies a Trigger. The required syntax for a <Trigger
 name> is:
 
 ::
@@ -89,18 +91,18 @@ name> is:
     <Trigger name> ::=
     [ <Schema name>. ] unqualified name
 
-A <Trigger name> is a <regular identifier> or a <delimited identifier> that is 
-unique (for all Triggers) within the Schema it belongs to. The <Schema name> 
-that qualifies a <Trigger name> names the Schema that the Trigger belongs to 
-and can either be explicitly stated, or a default will be supplied by your 
-DBMS, as follows: 
+A <Trigger name> is a <regular identifier> or a <delimited identifier> that is
+unique (for all Triggers) within the Schema it belongs to. The <Schema name>
+that qualifies a <Trigger name> names the Schema that the Trigger belongs to
+and can either be explicitly stated, or a default will be supplied by your
+DBMS, as follows:
 
-* If a <Trigger name> in a ``CREATE SCHEMA`` statement isn't qualified, the 
+* If a <Trigger name> in a ``CREATE SCHEMA`` statement isn't qualified, the
   default qualifier is the name of the Schema you're creating.
 
-* If the unqualified <Trigger name> is found in any other SQL statement in a 
-  Module, the default qualifier is the name of the Schema identified in the 
-  ``SCHEMA`` clause or ``AUTHORIZATION`` clause of the ``MODULE`` statement 
+* If the unqualified <Trigger name> is found in any other SQL statement in a
+  Module, the default qualifier is the name of the Schema identified in the
+  ``SCHEMA`` clause or ``AUTHORIZATION`` clause of the ``MODULE`` statement
   which defines that Module.
 
 Here are some examples of <Trigger name>s:
@@ -119,8 +121,8 @@ Here are some examples of <Trigger name>s:
 CREATE TRIGGER Statement
 ========================
 
-The ``CREATE TRIGGER`` statement names a new Trigger and defines the 
-Trigger's Table, action time, event and body. The required syntax for the 
+The ``CREATE TRIGGER`` statement names a new Trigger and defines the
+Trigger's Table, action time, event and body. The required syntax for the
 ``CREATE TRIGGER`` statement is:
 
 ::
@@ -158,23 +160,23 @@ Trigger's Table, action time, event and body. The required syntax for the
           SQL statement |
           BEGIN ATOMIC {SQL statement;}... END
 
-``CREATE TRIGGER`` defines a new Trigger. A Trigger is owned by the Schema 
+``CREATE TRIGGER`` defines a new Trigger. A Trigger is owned by the Schema
 it belongs to.
 
-The <Trigger name> identifies the Trigger and the Schema that it belongs to. 
-Typical <Trigger name>s include the Trigger event, e.g.: ``Employee_Update`` or 
-``After_Delete_From_Employee``. A <Trigger name> that includes an explicit 
-<Schema name> qualifier belongs to the Schema named. A <Trigger name> that does 
-not include an explicit <Schema name> qualifier belongs to the SQL-session 
-default Schema. The <Trigger name> must be unique (for all Triggers) within the 
-Schema that owns it. 
+The <Trigger name> identifies the Trigger and the Schema that it belongs to.
+Typical <Trigger name>s include the Trigger event, e.g.: ``Employee_Update`` or
+``After_Delete_From_Employee``. A <Trigger name> that includes an explicit
+<Schema name> qualifier belongs to the Schema named. A <Trigger name> that does
+not include an explicit <Schema name> qualifier belongs to the SQL-session
+default Schema. The <Trigger name> must be unique (for all Triggers) within the
+Schema that owns it.
 
-If ``CREATE TRIGGER`` is part of a ``CREATE SCHEMA`` statement, the <Trigger 
-name>, if explicitly qualified, must include the <Schema name> of the Schema 
-being created; that is, it isn't possible to create a Trigger belonging to a 
-different Schema from within ``CREATE SCHEMA``. For example, this SQL statement 
-will not return an error because the <Trigger name> will default to include the 
-qualifying <Schema name>: 
+If ``CREATE TRIGGER`` is part of a ``CREATE SCHEMA`` statement, the <Trigger
+name>, if explicitly qualified, must include the <Schema name> of the Schema
+being created; that is, it isn't possible to create a Trigger belonging to a
+different Schema from within ``CREATE SCHEMA``. For example, this SQL statement
+will not return an error because the <Trigger name> will default to include the
+qualifying <Schema name>:
 
 ::
 
@@ -184,9 +186,9 @@ qualifying <Schema name>:
          INSERT INTO Log_table VALUES ('deleted from Table_1');
    -- creates a Trigger called BOB.TRIGGER_1 in Schema BOB
 
-This SQL statement will not return an error either because the <Trigger name> 
-explicitly includes a qualifying <Schema name> that matches the name of the 
-Schema being created: 
+This SQL statement will not return an error either because the <Trigger name>
+explicitly includes a qualifying <Schema name> that matches the name of the
+Schema being created:
 
 ::
 
@@ -196,9 +198,9 @@ Schema being created:
          INSERT INTO Log_table VALUES ('deleted from Table_1');
    -- creates a Trigger called BOB.TRIGGER_1 in Schema BOB
 
-But this SQL statement will return an error because the <Trigger name> 
-explicitly includes a qualifying <Schema name> that is different from the name 
-of the Schema being created: 
+But this SQL statement will return an error because the <Trigger name>
+explicitly includes a qualifying <Schema name> that is different from the name
+of the Schema being created:
 
 ::
 
@@ -208,49 +210,49 @@ of the Schema being created:
          INSERT INTO Log_table VALUES ('deleted from Table_1');
    -- tries to create a Trigger belonging to Schema SAM inside Schema BOB; illegal syntax
 
-If ``CREATE TRIGGER`` is executed as a stand-alone SQL statement, the current 
-<AuthorizationID> must either be the owner of the Schema that this new Trigger 
-belongs to, or the Schema's owner must be a Role that the current 
-<AuthorizationID> may use. That is, only the owner of a Schema can create 
-Triggers for that Schema. 
+If ``CREATE TRIGGER`` is executed as a stand-alone SQL statement, the current
+<AuthorizationID> must either be the owner of the Schema that this new Trigger
+belongs to, or the Schema's owner must be a Role that the current
+<AuthorizationID> may use. That is, only the owner of a Schema can create
+Triggers for that Schema.
 
-The ``CREATE TRIGGER`` statement's main parts are its Table, its event (the 
-description of the SQL-data change statement that activates the Trigger) and 
-its action (the SQL statements which are to be executed by the Trigger). 
+The ``CREATE TRIGGER`` statement's main parts are its Table, its event (the
+description of the SQL-data change statement that activates the Trigger) and
+its action (the SQL statements which are to be executed by the Trigger).
 
 *ON Clause*
 -----------
 
-The ``ON`` clause of the ``CREATE TRIGGER`` statement names the Trigger's 
-Table: the Base table that, when changed, may cause the Trigger to act. The 
-Table must belong to the same Schema that the Trigger will belong to, and the 
-current <AuthorizationID> must have the ``TRIGGER`` Privilege on that Table. 
-(You do not need a Privilege to "use" a Trigger. Triggers will be activated 
-whenever you execute the appropriate SQL data-change statement on the Table, 
-whether you want them or not.) 
+The ``ON`` clause of the ``CREATE TRIGGER`` statement names the Trigger's
+Table: the Base table that, when changed, may cause the Trigger to act. The
+Table must belong to the same Schema that the Trigger will belong to, and the
+current <AuthorizationID> must have the ``TRIGGER`` Privilege on that Table.
+(You do not need a Privilege to "use" a Trigger. Triggers will be activated
+whenever you execute the appropriate SQL data-change statement on the Table,
+whether you want them or not.)
 
 *Trigger Action Time*
 ---------------------
 
-The Trigger action time defines when you want the Trigger's action to be 
-executed: it may be either ``BEFORE`` or ``AFTER``. Trigger action time should 
-be ``BEFORE`` if you want the Trigger action to occur before the Trigger event. 
-It should be ``AFTER`` if you want the Trigger action to occur after the 
-Trigger event. 
+The Trigger action time defines when you want the Trigger's action to be
+executed: it may be either ``BEFORE`` or ``AFTER``. Trigger action time should
+be ``BEFORE`` if you want the Trigger action to occur before the Trigger event.
+It should be ``AFTER`` if you want the Trigger action to occur after the
+Trigger event.
 
 *Trigger Event*
 ---------------
 
-The Trigger event defines the SQL-data change statement whose execution (on the 
-Trigger's Table) will activate the Trigger: it may be either ``INSERT``, 
-``DELETE`` or ``UPDATE``. In the case of ``UPDATE`` only, you may add an 
-optional subclause that lists the Trigger Columns: the Columns on which an 
-``UPDATE`` will activate the Trigger (``UPDATE`` on Columns not in the list 
-won't activate the Trigger). The Column list names some or all of the Trigger 
-Table's Columns (each may appear in the list only once). If you omit this 
-optional subclause, the effect is as if you included an ``OF`` clause that 
-names every Column of the Trigger's Table. For example, given this Table 
-definition: 
+The Trigger event defines the SQL-data change statement whose execution (on the
+Trigger's Table) will activate the Trigger: it may be either ``INSERT``,
+``DELETE`` or ``UPDATE``. In the case of ``UPDATE`` only, you may add an
+optional subclause that lists the Trigger Columns: the Columns on which an
+``UPDATE`` will activate the Trigger (``UPDATE`` on Columns not in the list
+won't activate the Trigger). The Column list names some or all of the Trigger
+Table's Columns (each may appear in the list only once). If you omit this
+optional subclause, the effect is as if you included an ``OF`` clause that
+names every Column of the Trigger's Table. For example, given this Table
+definition:
 
 ::
 
@@ -283,14 +285,14 @@ Here are two more Trigger definition examples:
 *REFERENCING Clause*
 --------------------
 
-The optional ``REFERENCING`` clause of the ``CREATE TRIGGER`` statement defines 
-a list of one to four unique <Correlation name>s, or aliases: one name for the 
-old row acted on by the Trigger and/or one name for the new row acted on by the 
-Trigger and/or one name for the old Table acted on by the Trigger and/or one 
-name for the new Table acted on by the Trigger (each may be specified once). 
-The <keyword> ``AS`` in each alias option is noise and may be omitted. If 
-neither ``ROW`` nor ``TABLE`` is specified, the default is ``ROW`` -- for 
-example, these four SQL statements are equivalent: 
+The optional ``REFERENCING`` clause of the ``CREATE TRIGGER`` statement defines
+a list of one to four unique <Correlation name>s, or aliases: one name for the
+old row acted on by the Trigger and/or one name for the new row acted on by the
+Trigger and/or one name for the old Table acted on by the Trigger and/or one
+name for the new Table acted on by the Trigger (each may be specified once).
+The <keyword> ``AS`` in each alias option is noise and may be omitted. If
+neither ``ROW`` nor ``TABLE`` is specified, the default is ``ROW`` -- for
+example, these four SQL statements are equivalent:
 
 ::
 
@@ -310,15 +312,15 @@ example, these four SQL statements are equivalent:
       AFTER UPDATE ON Table_1 REFERENCING OLD old_row_name
          FOR EACH ROW INSERT INTO Log_table VALUES ('updated Table_1');
 
-Your Trigger definition must include a ``REFERENCING`` clause if the Trigger 
-action contains references to the Trigger's <Table name> or any of its <Column 
-name>s. The ``OLD`` values are the values before the ``UPDATE`` / ``DELETE`` 
-Trigger event (``OLD ROW`` and ``OLD TABLE`` are not allowed if the Trigger 
-event is ``INSERT``) and the ``NEW`` values are the values after the ``UPDATE`` 
-/ ``INSERT`` Trigger event (``NEW ROW`` and ``NEW TABLE`` are not allowed if 
-the Trigger event is ``DELETE``). If Trigger action time is ``BEFORE``, a 
-``REFERENCING`` clause may not specify ``OLD TABLE`` or ``NEW TABLE``. Here are 
-some more ``REFERENCING`` clause examples: 
+Your Trigger definition must include a ``REFERENCING`` clause if the Trigger
+action contains references to the Trigger's <Table name> or any of its <Column
+name>s. The ``OLD`` values are the values before the ``UPDATE`` / ``DELETE``
+Trigger event (``OLD ROW`` and ``OLD TABLE`` are not allowed if the Trigger
+event is ``INSERT``) and the ``NEW`` values are the values after the ``UPDATE``
+/ ``INSERT`` Trigger event (``NEW ROW`` and ``NEW TABLE`` are not allowed if
+the Trigger event is ``DELETE``). If Trigger action time is ``BEFORE``, a
+``REFERENCING`` clause may not specify ``OLD TABLE`` or ``NEW TABLE``. Here are
+some more ``REFERENCING`` clause examples:
 
 ::
 
@@ -330,42 +332,42 @@ some more ``REFERENCING`` clause examples:
 
 (A table alias is either a <regular identifier> or a <delimited identifier>.)
 
-Every Trigger event has its own "execution context": it includes the old row 
-values and/or the new row values of the Trigger's Table. If the Trigger event 
-is ``INSERT``, then there are no old row values since no existing rows of a 
-Table are affected by ``INSERT``. If the Trigger event is ``DELETE``, then 
-there are no new row values since ``DELETE``\'s action is to remove rows from a 
-Table. If the Trigger event is ``UPDATE``, then there are three row versions: 
+Every Trigger event has its own "execution context": it includes the old row
+values and/or the new row values of the Trigger's Table. If the Trigger event
+is ``INSERT``, then there are no old row values since no existing rows of a
+Table are affected by ``INSERT``. If the Trigger event is ``DELETE``, then
+there are no new row values since ``DELETE``\'s action is to remove rows from a
+Table. If the Trigger event is ``UPDATE``, then there are three row versions:
 
 1. The actual row of data in the Trigger's Table.
 
-2. The "old row values" copy of the actual row -- often the same as [1], but 
-   if there are two distinct ``UPDATE`` events then there might be a difference 
-   between [1] and [2]. We'll call this the "old row" from now on. The set of 
+2. The "old row values" copy of the actual row -- often the same as [1], but
+   if there are two distinct ``UPDATE`` events then there might be a difference
+   between [1] and [2]. We'll call this the "old row" from now on. The set of
    all old rows is the "old Table".
 
-3. The "new row values" copy of the actual row -- it contains what the DBMS 
-   proposes to change the actual row to once the ``UPDATE`` statement's 
-   execution is completed. We'll call this the "new row" from now on. The set 
-   of all new rows is the "new  Table". (Note: Even with a ``BEFORE`` Trigger, 
+3. The "new row values" copy of the actual row -- it contains what the DBMS
+   proposes to change the actual row to once the ``UPDATE`` statement's
+   execution is completed. We'll call this the "new row" from now on. The set
+   of all new rows is the "new  Table". (Note: Even with a ``BEFORE`` Trigger,
    the "new row values" are known to the DBMS.)
 
-A Trigger's execution context is important (indeed, it's mandatory) if you are 
-going to refer to the Trigger's Table in the Trigger's action statements. It 
-would usually be wrong to refer to Column ``COLUMN_1`` of Table ``TABLE_1`` 
-with its <Column reference>, ``TABLE_1.COLUMN_1``, since the <Column reference> 
-refers to that Column in the actual Base table copy. What you really need to 
-refer to is either the old row or the new row. The ``REFERENCING`` clause of 
-the ``CREATE TRIGGER`` statement makes it possible to specify what context 
-names you will use for referring to ``OLD ROW`` or ``NEW ROW`` in the Trigger 
-action. 
+A Trigger's execution context is important (indeed, it's mandatory) if you are
+going to refer to the Trigger's Table in the Trigger's action statements. It
+would usually be wrong to refer to Column ``COLUMN_1`` of Table ``TABLE_1``
+with its <Column reference>, ``TABLE_1.COLUMN_1``, since the <Column reference>
+refers to that Column in the actual Base table copy. What you really need to
+refer to is either the old row or the new row. The ``REFERENCING`` clause of
+the ``CREATE TRIGGER`` statement makes it possible to specify what context
+names you will use for referring to ``OLD ROW`` or ``NEW ROW`` in the Trigger
+action.
 
-The execution context is "atomic" in the usual SQL sense of the word: if any 
-action statements fail, then all action statements fail and so does the 
-statement that caused the Trigger activation: your DBMS will return the 
-``SQLSTATE error 09000 "triggered action exception"``. In other words, the old 
-row and the new row are simply destroyed and you're left with the same thing 
-you started with: the actual row. 
+The execution context is "atomic" in the usual SQL sense of the word: if any
+action statements fail, then all action statements fail and so does the
+statement that caused the Trigger activation: your DBMS will return the
+``SQLSTATE error 09000 "triggered action exception"``. In other words, the old
+row and the new row are simply destroyed and you're left with the same thing
+you started with: the actual row.
 
 *Trigger Action*
 ----------------
@@ -377,54 +379,54 @@ when condition and the action body.
 Action Granularity
 __________________
 
-The optional ``FOR EACH`` clause of the ``CREATE TRIGGER`` statement defines 
-the Trigger action granularity: it may be either ``FOR EACH STATEMENT`` (the 
-default) or ``FOR EACH ROW``. The action granularity tells your DBMS how big 
-the field of action is. For example, suppose you create a Trigger for ``AFTER 
-UPDATE OF column_1 ON Employees``, then do this: 
+The optional ``FOR EACH`` clause of the ``CREATE TRIGGER`` statement defines
+the Trigger action granularity: it may be either ``FOR EACH STATEMENT`` (the
+default) or ``FOR EACH ROW``. The action granularity tells your DBMS how big
+the field of action is. For example, suppose you create a Trigger for ``AFTER
+UPDATE OF column_1 ON Employees``, then do this:
 
 ::
 
    UPDATE Employees SET column_1 = 5;
 
-Assume that the ``EMPLOYEES`` Table has 1000 rows. If action granularity is 
-``FOR EACH STATEMENT``, the Trigger action will occur once (just for the 
-statement). If action granularity is ``FOR EACH ROW``, the Trigger action will 
-occur 1000 times (once for each row of the Trigger Table). As stated earlier, 
-the default is ``FOR EACH STATEMENT``, but "row" granularity is more common. In 
-fact, if your Trigger definition contains a ``REFERENCING`` clause that 
-includes either ``OLD ROW`` or ``NEW ROW``, it must also include an action 
-granularity clause of ``FOR EACH ROW``. 
+Assume that the ``EMPLOYEES`` Table has 1000 rows. If action granularity is
+``FOR EACH STATEMENT``, the Trigger action will occur once (just for the
+statement). If action granularity is ``FOR EACH ROW``, the Trigger action will
+occur 1000 times (once for each row of the Trigger Table). As stated earlier,
+the default is ``FOR EACH STATEMENT``, but "row" granularity is more common. In
+fact, if your Trigger definition contains a ``REFERENCING`` clause that
+includes either ``OLD ROW`` or ``NEW ROW``, it must also include an action
+granularity clause of ``FOR EACH ROW``.
 
 Action When Condition
 _____________________
 
-The optional ``WHEN`` clause of the ``CREATE TRIGGER`` statement defines the 
-Trigger action when condition: it may be any parenthesized search condition. 
-When the Trigger is activated, if the search condition is ``TRUE``, the Trigger 
-action will occur, if the search condition is ``FALSE``, the Trigger action 
-will not occur and if the search condition is ``UNKNOWN``, then apparently the 
-Trigger action will not occur (the Standard document is unclear about this 
-point: see "satisfies" in the Glossary). If you omit the ``WHEN`` clause from a 
-Trigger definition, the Trigger action will occur as soon as the Trigger is 
-activated. 
+The optional ``WHEN`` clause of the ``CREATE TRIGGER`` statement defines the
+Trigger action when condition: it may be any parenthesized search condition.
+When the Trigger is activated, if the search condition is ``TRUE``, the Trigger
+action will occur, if the search condition is ``FALSE``, the Trigger action
+will not occur and if the search condition is ``UNKNOWN``, then apparently the
+Trigger action will not occur (the Standard document is unclear about this
+point: see "satisfies" in the Glossary). If you omit the ``WHEN`` clause from a
+Trigger definition, the Trigger action will occur as soon as the Trigger is
+activated.
 
-Typically, you'd add a ``WHEN`` clause to your Trigger definition if the 
-Trigger event definition is too general for your purposes. For example, the 
-Trigger event might be "``UPDATE Employees``", but the Trigger action should 
-occur only "``WHEN salary > 1000.00``". Such specificity only makes sense if 
-the action granularity is ``FOR EACH ROW``. 
+Typically, you'd add a ``WHEN`` clause to your Trigger definition if the
+Trigger event definition is too general for your purposes. For example, the
+Trigger event might be "``UPDATE Employees``", but the Trigger action should
+occur only "``WHEN salary > 1000.00``". Such specificity only makes sense if
+the action granularity is ``FOR EACH ROW``.
 
 Action Body
 ___________
 
-The action body of the ``CREATE TRIGGER`` statement defines the Trigger action 
-itself: the SQL statement(s) you want your DBMS to execute when the Trigger is 
-activated. The action body may be either a single SQL statement or it may be a 
-series of SQL statements, delimited by semicolons, with a ``BEGIN ATOMIC ... 
-END`` subclause. Here are two examples of Trigger action bodies (the first 
-shows an action body using a single SQL statement and the second shows an 
-action body showing multiple SQL statements): 
+The action body of the ``CREATE TRIGGER`` statement defines the Trigger action
+itself: the SQL statement(s) you want your DBMS to execute when the Trigger is
+activated. The action body may be either a single SQL statement or it may be a
+series of SQL statements, delimited by semicolons, with a ``BEGIN ATOMIC ...
+END`` subclause. Here are two examples of Trigger action bodies (the first
+shows an action body using a single SQL statement and the second shows an
+action body showing multiple SQL statements):
 
 ::
 
@@ -442,42 +444,42 @@ transaction statement, an SQL-Connection statement, an SQL-Schema statement or
 an SQL-session statement (see chapter 1, SQL statement classes). A variety of
 SQL statements are legal inside the Trigger body, though.
 
-* If Trigger action time is ``BEFORE``, the Trigger action may include these 
-  SQL statements: ``DECLARE TABLE``, ``DECLARE CURSOR``, ``OPEN``, ``CLOSE``, 
-  ``FETCH``, ``SELECT`` (for a single row only), ``FREE LOCATOR``, ``HOLD 
-  LOCATOR``, ``CALL``, ``RETURN`` and ``GET DIAGNOSTICS``. It may also name an 
-  SQL-invoked routine, as long as that routine isn't one that possibly modifies 
-  SQL-data. 
+* If Trigger action time is ``BEFORE``, the Trigger action may include these
+  SQL statements: ``DECLARE TABLE``, ``DECLARE CURSOR``, ``OPEN``, ``CLOSE``,
+  ``FETCH``, ``SELECT`` (for a single row only), ``FREE LOCATOR``, ``HOLD
+  LOCATOR``, ``CALL``, ``RETURN`` and ``GET DIAGNOSTICS``. It may also name an
+  SQL-invoked routine, as long as that routine isn't one that possibly modifies
+  SQL-data.
 
-* If Trigger action time is ``AFTER``, the Trigger action may include all of 
-  the SQL statements allowed for ``BEFORE`` Triggers, plus: ``INSERT``, 
-  ``UPDATE`` and ``DELETE``. It may also name any SQL-invoked routine. 
+* If Trigger action time is ``AFTER``, the Trigger action may include all of
+  the SQL statements allowed for ``BEFORE`` Triggers, plus: ``INSERT``,
+  ``UPDATE`` and ``DELETE``. It may also name any SQL-invoked routine.
 
-Of the SQL statements available to you for a Trigger action, ``OPEN``, 
-``FETCH``, ``CLOSE``, single-row ``SELECT`` and ``GET DIAGNOSTICS`` are not 
-very useful because it is forbidden to include host variables and parameters 
-inside the action body of a Trigger definition. ``INSERT``, ``UPDATE`` and 
-``DELETE`` are much more useful; often a Trigger action body consists of just 
-one such SQL-data change statement. (Remember, though, that you can't use them 
-with a ``BEFORE`` Trigger.) SQL-invoked routines are useful too. In effect, a 
-procedure in your host language program can be called by a Trigger -- compare 
-the various "callback" situations in the Windows API. 
+Of the SQL statements available to you for a Trigger action, ``OPEN``,
+``FETCH``, ``CLOSE``, single-row ``SELECT`` and ``GET DIAGNOSTICS`` are not
+very useful because it is forbidden to include host variables and parameters
+inside the action body of a Trigger definition. ``INSERT``, ``UPDATE`` and
+``DELETE`` are much more useful; often a Trigger action body consists of just
+one such SQL-data change statement. (Remember, though, that you can't use them
+with a ``BEFORE`` Trigger.) SQL-invoked routines are useful too. In effect, a
+procedure in your host language program can be called by a Trigger -- compare
+the various "callback" situations in the Windows API.
 
-If you want to restrict your code to Core SQL, don't use the ``CREATE TRIGGER`` 
-statement. 
+If you want to restrict your code to Core SQL, don't use the ``CREATE TRIGGER``
+statement.
 
 Activation of Triggers
 ======================
 
-In our discussion of the ``CREATE TRIGGER`` statement, we made this true, 
-but imprecise statement: "When the Trigger event occurs, the Trigger is 
-activated." Let's get more precise about the meaning of "when" and 
+In our discussion of the ``CREATE TRIGGER`` statement, we made this true,
+but imprecise statement: "When the Trigger event occurs, the Trigger is
+activated." Let's get more precise about the meaning of "when" and
 "activated".
 
-The meaning of "when" depends on the Trigger action time (``BEFORE`` or 
-``AFTER``) and on the Trigger's priority relative to other Triggers or 
-Constraints. For example, suppose we associate three Triggers and one 
-Constraint with Table ``TABLE_1``: 
+The meaning of "when" depends on the Trigger action time (``BEFORE`` or
+``AFTER``) and on the Trigger's priority relative to other Triggers or
+Constraints. For example, suppose we associate three Triggers and one
+Constraint with Table ``TABLE_1``:
 
 ::
 
@@ -489,38 +491,38 @@ Constraint with Table ``TABLE_1``:
 
    ALTER TABLE Table_1 ADD CONSTRAINT Constraint_1 ...;
 
-What is the effect when an ``UPDATE`` on ``TABLE_1`` is executed? Since such an 
-``UPDATE`` is a Trigger event for ``TABLE_1``, several things happen -- in a 
-rigid order of events. 
+What is the effect when an ``UPDATE`` on ``TABLE_1`` is executed? Since such an
+``UPDATE`` is a Trigger event for ``TABLE_1``, several things happen -- in a
+rigid order of events.
 
-* First, ``TRIGGER_2`` is activated. It's a ``BEFORE`` Trigger, so it's 
-  first. The DBMS executes ``TRIGGER_2``\'s action (if ``TRIGGER_2``\'s 
-  definition includes a ``WHEN`` clause, this happens only if the search 
+* First, ``TRIGGER_2`` is activated. It's a ``BEFORE`` Trigger, so it's
+  first. The DBMS executes ``TRIGGER_2``\'s action (if ``TRIGGER_2``\'s
+  definition includes a ``WHEN`` clause, this happens only if the search
   condition is ``TRUE``).
 
-* Second, the DBMS updates ``TABLE_1``. Trigger events follow ``BEFORE`` 
+* Second, the DBMS updates ``TABLE_1``. Trigger events follow ``BEFORE``
   Trigger actions.
 
-* Third, ``CONSTRAINT_1`` is checked. Constraint checks occur at 
+* Third, ``CONSTRAINT_1`` is checked. Constraint checks occur at
   end-of-statement.
 
-* Fourth, ``TRIGGER_1`` is activated. It's an ``AFTER`` Trigger, so it 
-  occurs after execution of the action statement -- and after any Constraint 
+* Fourth, ``TRIGGER_1`` is activated. It's an ``AFTER`` Trigger, so it
+  occurs after execution of the action statement -- and after any Constraint
   checking associated with the action statement.
 
-* Fifth, ``TRIGGER_3`` is activated. It's another ``AFTER`` Trigger, and it 
-  follows ``TRIGGER_1`` because it was created later (Triggers are timestamped 
-  so the DBMS knows the order in which Triggers were created: older Triggers 
+* Fifth, ``TRIGGER_3`` is activated. It's another ``AFTER`` Trigger, and it
+  follows ``TRIGGER_1`` because it was created later (Triggers are timestamped
+  so the DBMS knows the order in which Triggers were created: older Triggers
   have priority).
 
-To sum it up, the order-of-execution for any Triggered SQL-data change 
-statement is: *(1)* ``BEFORE`` Triggers, *(2)* SQL-data change statement 
-itself, *(3)* Constraint checks on SQL-data change statement, *(4)* ``AFTER`` 
-Triggers -- and within that, old Triggers before young Triggers. 
+To sum it up, the order-of-execution for any Triggered SQL-data change
+statement is: *(1)* ``BEFORE`` Triggers, *(2)* SQL-data change statement
+itself, *(3)* Constraint checks on SQL-data change statement, *(4)* ``AFTER``
+Triggers -- and within that, old Triggers before young Triggers.
 
-The meaning of "activated" means "the Trigger action happens". Remember that 
-the Trigger action is defined by three separate clauses in the ``CREATE 
-TRIGGER`` statement: 
+The meaning of "activated" means "the Trigger action happens". Remember that
+the Trigger action is defined by three separate clauses in the ``CREATE
+TRIGGER`` statement:
 
 ::
 
@@ -529,15 +531,15 @@ TRIGGER`` statement:
    SQL statement |                       -- body
    BEGIN ATOMIC {SQL statement;}... END
 
-If Trigger action doesn't include "``WHEN`` (search condition)" or if Trigger 
-action does include "``WHEN`` (search condition)" and the condition is 
-``TRUE``, the DBMS decides that the Trigger action has happened. This 
-specifically means that: 
+If Trigger action doesn't include "``WHEN`` (search condition)" or if Trigger
+action does include "``WHEN`` (search condition)" and the condition is
+``TRUE``, the DBMS decides that the Trigger action has happened. This
+specifically means that:
 
 * If the action body is a SQL statement, the DBMS executes that SQL statement.
 
-* Otherwise, the action body must be ``BEGIN ATOMIC ... END``, and the DBMS 
-  executes all of the SQL statements that occur between the <keyword>s 
+* Otherwise, the action body must be ``BEGIN ATOMIC ... END``, and the DBMS
+  executes all of the SQL statements that occur between the <keyword>s
   ``ATOMIC`` and ``END``, in the order that they are defined.
 
 If any part of the Trigger action can't be executed successfully, that SQL
@@ -550,15 +552,15 @@ Trigger might have affected.
 Trigger Examples
 ================
 
-The following four scenarios show the use of a Trigger in a real-life 
+The following four scenarios show the use of a Trigger in a real-life
 situation.
 
 *Trigger Example -- Logging Deletions*
 --------------------------------------
 
-Scenario: We want to keep a log file containing data from rows that have been 
-deleted from the ``BOOKS`` Table. Here's a Trigger definition that accomplishes 
-this: 
+Scenario: We want to keep a log file containing data from rows that have been
+deleted from the ``BOOKS`` Table. Here's a Trigger definition that accomplishes
+this:
 
 ::
 
@@ -569,31 +571,31 @@ this:
       INSERT INTO Books_Deleted_Log
          VALUES (Old.title);             /* See note (d) */
 
-This Trigger copies the title of every book deleted from the ``BOOKS`` Table 
+This Trigger copies the title of every book deleted from the ``BOOKS`` Table
 into a Table (the log) called ``BOOKS_DELETED_LOG``.
 
 .. NOTE::
 
-   (a) The Trigger action has to be ``AFTER``, since the Trigger 
+   (a) The Trigger action has to be ``AFTER``, since the Trigger
        action includes an SQL-data change statement.
 
-   (b) It is conventional to use the alias ``Old`` or ``Old_Row`` for 
+   (b) It is conventional to use the alias ``Old`` or ``Old_Row`` for
        the old row.
 
-   (c) No log will occur for a ``DELETE`` statement that affects zero 
+   (c) No log will occur for a ``DELETE`` statement that affects zero
        rows.
 
-   (d) ``OLD`` is an alias for a single old row, so ``OLD.TITLE`` is 
+   (d) ``OLD`` is an alias for a single old row, so ``OLD.TITLE`` is
        the scalar value derived from the ``TITLE`` Column of that old row.
 
 *Trigger Example -- Inserting Default Expressions*
 --------------------------------------------------
 
-Scenario: When we add a client, we want the default value for 
-``HOME_TELEPHONE`` to be the same as the ``WORK_TELEPHONE`` number. The 
-``DEFAULT`` clause is no good for cases like this, because "``DEFAULT`` <Column 
-name>" is not a legal option. Here's a Trigger definition that accomplishes 
-this: 
+Scenario: When we add a client, we want the default value for
+``HOME_TELEPHONE`` to be the same as the ``WORK_TELEPHONE`` number. The
+``DEFAULT`` clause is no good for cases like this, because "``DEFAULT`` <Column
+name>" is not a legal option. Here's a Trigger definition that accomplishes
+this:
 
 ::
 
@@ -615,10 +617,10 @@ With this Trigger in place, this SQL statement:
    INSERT INTO Clients (work_telephone)
    VALUES ('493-1125');
 
-will insert a new row into ``CLIENTS`` that has ``'493-1125'`` in the 
-``HOME_TELEPHONE`` Column as well as in the ``WORK_TELEPHONE`` Column. This 
-Trigger must be activated ``BEFORE`` the ``INSERT``, but it is possible to see 
-in advance what values the DBMS has tentatively assigned for the new row. 
+will insert a new row into ``CLIENTS`` that has ``'493-1125'`` in the
+``HOME_TELEPHONE`` Column as well as in the ``WORK_TELEPHONE`` Column. This
+Trigger must be activated ``BEFORE`` the ``INSERT``, but it is possible to see
+in advance what values the DBMS has tentatively assigned for the new row.
 
 *Trigger Example: Constraint Substitute*
 ----------------------------------------
@@ -633,21 +635,21 @@ Here's a Trigger definition that accomplishes this -- but it has some flaws:
    WHEN (CURRENT_TIME > '17:00:00')             /* second flaw */
       SELECT MAX(budget) / 0 FROM Departments;  /* third flaw */
 
-Since this ``CREATE TRIGGER`` statement contains no action granularity clause, 
-the default applies: ``FOR EACH STATEMENT``. This means that if this SQL 
-statement is executed: 
+Since this ``CREATE TRIGGER`` statement contains no action granularity clause,
+the default applies: ``FOR EACH STATEMENT``. This means that if this SQL
+statement is executed:
 
 ::
 
    UPDATE Departments SET budget = <value>;
 
-the Trigger's ``SELECT`` action will be executed -- and it will fail, since it 
-contains a division-by-zero expression. This, in turn, will cause the Trigger 
-event -- the ``UPDATE`` statement -- to fail too, since execution context is 
-atomic. (Actually there will be two errors. The main one will be "Triggered 
-action exception" and the secondary one will be "Division by zero".) Therefore, 
-this Trigger prevents anyone from updating ``DEPARTMENTS.BUDGET`` after 5 pm. 
-Usually it works, but sometimes it doesn't work -- it contains subtle flaws. 
+the Trigger's ``SELECT`` action will be executed -- and it will fail, since it
+contains a division-by-zero expression. This, in turn, will cause the Trigger
+event -- the ``UPDATE`` statement -- to fail too, since execution context is
+atomic. (Actually there will be two errors. The main one will be "Triggered
+action exception" and the secondary one will be "Division by zero".) Therefore,
+this Trigger prevents anyone from updating ``DEPARTMENTS.BUDGET`` after 5 pm.
+Usually it works, but sometimes it doesn't work -- it contains subtle flaws.
 
 The first flaw is that a SQL statement like this:
 
@@ -655,9 +657,9 @@ The first flaw is that a SQL statement like this:
 
    UPDATE Departments SET budget = <value>, name = <value>;
 
-might fail to activate the Trigger. In strict Standard SQL, a Trigger's 
-explicit ``UPDATE`` Column list -- which in this case is ``budget`` -- must 
-exactly match the Columns in the ``UPDATE`` statement. 
+might fail to activate the Trigger. In strict Standard SQL, a Trigger's
+explicit ``UPDATE`` Column list -- which in this case is ``budget`` -- must
+exactly match the Columns in the ``UPDATE`` statement.
 
 The second flaw is that the ``WHEN`` clause is non-deterministic. In a sense,
 that's the point of using a Trigger here rather than a Constraint: SQL doesn't
@@ -702,10 +704,10 @@ popularity to drop. Here are two Trigger definitions that map this situation:
         approval_rating = approval_rating - 0.01;
    END;
 
-In this example, some updates of the ``PRIME_MINISTERS`` Table will cause an 
-update of the ``TAXPAYERS`` Table, and updates of ``TAXPAYERS`` will cause both 
-an update of the ``NATIONAL_DEBT`` Table and of ``PRIME_MINISTERS``. Shown as a 
-diagram, with --> as a symbol for "causes possible ``UPDATE`` of", we have: 
+In this example, some updates of the ``PRIME_MINISTERS`` Table will cause an
+update of the ``TAXPAYERS`` Table, and updates of ``TAXPAYERS`` will cause both
+an update of the ``NATIONAL_DEBT`` Table and of ``PRIME_MINISTERS``. Shown as a
+diagram, with --> as a symbol for "causes possible ``UPDATE`` of", we have:
 
 ::
 
@@ -715,64 +717,64 @@ diagram, with --> as a symbol for "causes possible ``UPDATE`` of", we have:
          |                 |
          -------------------
 
-There is an apparent cycle here, but the second ``UPDATE`` to 
-``PRIME_MINISTERS`` is for a different Column than the first, so the effects 
-don't cascade forever. If we said "a change in the national debt will Trigger 
-Bob's overthrow", then we would have a true cycle -- that would be bad. Your 
-DBMS is supposed to detect it if the same Column changes value twice in a 
-cycle, and cause the Trigger action (and the SQL data-change statement that 
-activated the Trigger) to fail: it will return the ``SQLSTATE error 27000 
-"triggered data change violation"``. 
+There is an apparent cycle here, but the second ``UPDATE`` to
+``PRIME_MINISTERS`` is for a different Column than the first, so the effects
+don't cascade forever. If we said "a change in the national debt will Trigger
+Bob's overthrow", then we would have a true cycle -- that would be bad. Your
+DBMS is supposed to detect it if the same Column changes value twice in a
+cycle, and cause the Trigger action (and the SQL data-change statement that
+activated the Trigger) to fail: it will return the ``SQLSTATE error 27000
+"triggered data change violation"``.
 
 Triggers versus Constraints
 ===========================
 
-The essential idea of a Trigger is that if you change a Table, you cause a 
-given set of SQL statements to be executed. This idea is good: it allows you to 
-associate "rules" with Tables. And it can be efficient in a client-server 
-environment, because Trigger actions are pre-parsed and stored on the server. 
-However, Triggers are not the only way to implement this idea. There are other 
-ways to accomplish the same effect. 
+The essential idea of a Trigger is that if you change a Table, you cause a
+given set of SQL statements to be executed. This idea is good: it allows you to
+associate "rules" with Tables. And it can be efficient in a client-server
+environment, because Trigger actions are pre-parsed and stored on the server.
+However, Triggers are not the only way to implement this idea. There are other
+ways to accomplish the same effect.
 
-As one alternative, you could incorporate SQL statements in "method" 
-procedures. This requires somewhat advanced procedures; see our chapter on 
-UDTs. 
+As one alternative, you could incorporate SQL statements in "method"
+procedures. This requires somewhat advanced procedures; see our chapter on
+UDTs.
 
-As another alternative, you could use a Constraint to declare what the most 
-important rules are. As we said earlier though, the advantage of using a 
-Trigger, instead of a Constraint, is *flexibility*. You can use a wide variety 
-of SQL statements in a Trigger, while the only things you can do with 
-Constraints are integrity checks and foreign key options. But is flexibility a 
-good thing? There are reasons why you should prefer the "rigidity" that 
-Constraints imply: 
+As another alternative, you could use a Constraint to declare what the most
+important rules are. As we said earlier though, the advantage of using a
+Trigger, instead of a Constraint, is *flexibility*. You can use a wide variety
+of SQL statements in a Trigger, while the only things you can do with
+Constraints are integrity checks and foreign key options. But is flexibility a
+good thing? There are reasons why you should prefer the "rigidity" that
+Constraints imply:
 
-* Your DBMS can recognize exactly what you're trying to accomplish, and 
+* Your DBMS can recognize exactly what you're trying to accomplish, and
   optimize accordingly.
 
-* You know what the consequences are because people thought them through 
+* You know what the consequences are because people thought them through
   when they devised the rigid syntax -- so there's less chance of bugs.
 
-* Constraints have been part of standard SQL for a long time, while Triggers 
+* Constraints have been part of standard SQL for a long time, while Triggers
   have not been.
 
-* Constraints are deferrable; Triggers aren't. Most experts appear to agree 
-  that you should use Constraints instead of Triggers, if you can. Triggers 
+* Constraints are deferrable; Triggers aren't. Most experts appear to agree
+  that you should use Constraints instead of Triggers, if you can. Triggers
   are tricky.
 
 DROP TRIGGER Statement
 ======================
 
-The ``DROP TRIGGER`` statement destroys a Trigger. The required syntax for 
+The ``DROP TRIGGER`` statement destroys a Trigger. The required syntax for
 the ``DROP TRIGGER`` statement is:
 
 ::
 
     DROP TRIGGER <Trigger name>
 
-``DROP TRIGGER`` destroys a Trigger. The <Trigger name> must identify an 
-existing Trigger whose owner is either the current <AuthorizationID> or a Role 
-that the current <AuthorizationID> may use. That is, only the <AuthorizationID> 
-that owns the Trigger may drop it. 
+``DROP TRIGGER`` destroys a Trigger. The <Trigger name> must identify an
+existing Trigger whose owner is either the current <AuthorizationID> or a Role
+that the current <AuthorizationID> may use. That is, only the <AuthorizationID>
+that owns the Trigger may drop it.
 
 The effect of ``DROP TRIGGER`` <Table name>, e.g.:
 
@@ -780,11 +782,11 @@ The effect of ``DROP TRIGGER`` <Table name>, e.g.:
 
    DROP TRIGGER Trigger_1;
 
-is that the Trigger named is destroyed: it will have no further effect on 
-SQL-data. No other Objects are affected by ``DROP TRIGGER``, since no 
+is that the Trigger named is destroyed: it will have no further effect on
+SQL-data. No other Objects are affected by ``DROP TRIGGER``, since no
 Objects are dependent on Triggers.
 
-If you want to restrict your code to Core SQL, don't use the ``DROP 
+If you want to restrict your code to Core SQL, don't use the ``DROP
 TRIGGER`` statement.
 
 Dialects
@@ -797,16 +799,16 @@ from SQL3 and from each other. Here are some deviations we have noticed:
 
 * There is no ``TRIGGER`` Privilege; only Table owners can create Triggers.
 
-* A given Table can have only one ``BEFORE`` Trigger and one ``AFTER`` 
+* A given Table can have only one ``BEFORE`` Trigger and one ``AFTER``
   Trigger, or can have only a limited number of Triggers (e.g. 12) in total.
 
 * Trigger events are conglomerable, e.g.: ``BEFORE INSERT OR UPDATE OF ...``.
 
-* It is illegal to access the subject Table during the Trigger action, 
-  except through "new" and "old" row references. Such references must always 
+* It is illegal to access the subject Table during the Trigger action,
+  except through "new" and "old" row references. Such references must always
   be preceded by a colon (as if they're host variables).
 
 * The ``WHEN`` clause is not supported.
 
-* Assignments do not include the keyword ``SET``, and are legal only for 
+* Assignments do not include the keyword ``SET``, and are legal only for
   Triggers.

--- a/docs/chapters/25.rst
+++ b/docs/chapters/25.rst
@@ -4,7 +4,9 @@
 Chapter 25 -- SQL-invoked Routine
 =================================
 
-In this chapter, we'll describe SQL-invoked routines in detail, and show you 
+.. include:: ../_include/note.rst
+
+In this chapter, we'll describe SQL-invoked routines in detail, and show you
 the syntax to use to create, alter and destroy them.
 
 .. rubric:: Table of Contents
@@ -15,42 +17,42 @@ the syntax to use to create, alter and destroy them.
 Routine
 =======
 
-A Schema may contain zero or more SQL-invoked routines. An *SQL-invoked 
-routine* (or SQL routine), is the generic name for either a procedure 
-(SQL-invoked procedure) or a function (SQL-invoked function). SQL routines are 
-dependent on some Schema (they're also called *Schema-level routines*) and are 
-created, altered and dropped using standard SQL statements. 
+A Schema may contain zero or more SQL-invoked routines. An *SQL-invoked
+routine* (or SQL routine), is the generic name for either a procedure
+(SQL-invoked procedure) or a function (SQL-invoked function). SQL routines are
+dependent on some Schema (they're also called *Schema-level routines*) and are
+created, altered and dropped using standard SQL statements.
 
-The concepts of "procedure" and "function" are the same in SQL as in other 
-languages, so the ideas in this chapter will be old hat to any programmer. 
-However, the syntax is all new: there was no standardized way to make SQL 
-routines until SQL3. Actually there still isn't -- it will take time before all 
-vendors fall in line -- but it's certainly time that everybody knows what 
-routines are, according to the SQL Standard. 
+The concepts of "procedure" and "function" are the same in SQL as in other
+languages, so the ideas in this chapter will be old hat to any programmer.
+However, the syntax is all new: there was no standardized way to make SQL
+routines until SQL3. Actually there still isn't -- it will take time before all
+vendors fall in line -- but it's certainly time that everybody knows what
+routines are, according to the SQL Standard.
 
-In SQL, a routine consists of at least three items: a <Routine name>, a set of 
-parameter declarations and a routine body. An SQL procedure is a routine that 
-is invoked with a ``CALL`` statement; it may have input parameters, output 
-parameters and parameters that are both input parameters and output parameters. 
-An SQL function is a routine that returns a value when invoked by a <routine 
-invocation>; it has only input parameters, one of which may be defined as the 
-result parameter (if you do this, the function is called a *type-preserving 
-function* because the <data type> of the result is a subtype of the <data type> 
-of the result parameter). A function can also be defined as an SQL-invoked 
-method; it is invoked by a <method invocation> and its first parameter (called 
-the subject parameter) must be a UDT. 
+In SQL, a routine consists of at least three items: a <Routine name>, a set of
+parameter declarations and a routine body. An SQL procedure is a routine that
+is invoked with a ``CALL`` statement; it may have input parameters, output
+parameters and parameters that are both input parameters and output parameters.
+An SQL function is a routine that returns a value when invoked by a <routine
+invocation>; it has only input parameters, one of which may be defined as the
+result parameter (if you do this, the function is called a *type-preserving
+function* because the <data type> of the result is a subtype of the <data type>
+of the result parameter). A function can also be defined as an SQL-invoked
+method; it is invoked by a <method invocation> and its first parameter (called
+the subject parameter) must be a UDT.
 
-The case for routines can be summarized by noting these advantages: 
+The case for routines can be summarized by noting these advantages:
 
 **Flexibility**
 
-You can do even more with routines than you can with Constraints or 
+You can do even more with routines than you can with Constraints or
 Triggers, and you can do them in a wider variety of scenarios.
 
 **Efficiency**
 
-Quite often, it's possible to replace slow generic SQL statements with 
-painstakingly-optimized routines, especially "external routines" (i.e.: 
+Quite often, it's possible to replace slow generic SQL statements with
+painstakingly-optimized routines, especially "external routines" (i.e.:
 routines written in languages other than SQL).
 
 **Cleanliness**
@@ -59,23 +61,23 @@ Routines let you avoid writing the same SQL code in two places.
 
 **Globalization**
 
-Is your SQL code enforcing the rules of the whole business? Then it should 
-be associated with the entire database. Procedures are particularly useful 
+Is your SQL code enforcing the rules of the whole business? Then it should
+be associated with the entire database. Procedures are particularly useful
 for specialized Privilege checking.
 
 **Sharing**
 
-Routines are (usually) cached on the server, and are (sometimes) accessible 
-to all programmers. You needn't re-transmit and re-prepare every 
+Routines are (usually) cached on the server, and are (sometimes) accessible
+to all programmers. You needn't re-transmit and re-prepare every
 frequently-used code piece.
 
-An SQL-invoked routine is defined by a descriptor that contains 18 pieces of 
+An SQL-invoked routine is defined by a descriptor that contains 18 pieces of
 information:
 
-1. The not necessarily unique <Routine name> of the routine, qualified by 
+1. The not necessarily unique <Routine name> of the routine, qualified by
    the <Schema name> of the Schema it belongs to (or by ``MODULE``).
 
-2. The unique <specific name> of the routine, qualified by the <Schema name> 
+2. The unique <specific name> of the routine, qualified by the <Schema name>
    of the Schema it belongs to.
 
 3. The <external routine name> of the routine (for external routines).
@@ -86,22 +88,22 @@ information:
 
 6. The language the routine is written in.
 
-7. A descriptor for every parameter in the routine. The parameter descriptor 
-   contains the <SQL parameter name> (if any), the parameter's <data type>, 
-   the ordinal position of the parameter in the routine body and whether the 
+7. A descriptor for every parameter in the routine. The parameter descriptor
+   contains the <SQL parameter name> (if any), the parameter's <data type>,
+   the ordinal position of the parameter in the routine body and whether the
    parameter is an input parameter, an output parameter or both.
 
-8. Whether the routine is an SQL-invoked function or an SQL-invoked 
+8. Whether the routine is an SQL-invoked function or an SQL-invoked
    procedure and, in the first case, whether it is also an SQL-invoked method.
 
 9. The maximum number of dynamic result sets (for procedures).
 
 10. Whether the routine is deterministic or possibly non-deterministic.
 
-11. Whether the routine possibly modifies SQL-data, possibly reads SQL-data, 
+11. Whether the routine possibly modifies SQL-data, possibly reads SQL-data,
     possibly contains SQL or does not possibly contain SQL.
 
-12. The <returns data type> of the routine, and whether the return value is 
+12. The <returns data type> of the routine, and whether the return value is
     a locator (for functions).
 
 13. Whether the routine is a type-preserving function or a mutator function.
@@ -114,32 +116,32 @@ information:
 
 17. The routine's last-altered timestamp: when it was last changed.
 
-18. The routine body of the routine: the SQL procedure statement that is 
-    executed when the routine is run (for SQL routines) or the host language 
-    statements that are executed when the routine is run (for external 
+18. The routine body of the routine: the SQL procedure statement that is
+    executed when the routine is run (for SQL routines) or the host language
+    statements that are executed when the routine is run (for external
     routines).
 
-An SQL-invoked routine can be an SQL routine (a routine written in SQL) or an 
-external routine (a routine written in a standard host language). Routines can, 
-of course, also be externally-invoked routines, but in this chapter, we are 
-concerned strictly with "Schema routines" -- SQL-invoked routines that are 
-stored in the database, just like other Schema Objects (Tables, Domains, etc.). 
-Our aim is to describe how routines are created and how they are "invoked" 
-(i.e.: called). The first part is the hard part. 
+An SQL-invoked routine can be an SQL routine (a routine written in SQL) or an
+external routine (a routine written in a standard host language). Routines can,
+of course, also be externally-invoked routines, but in this chapter, we are
+concerned strictly with "Schema routines" -- SQL-invoked routines that are
+stored in the database, just like other Schema Objects (Tables, Domains, etc.).
+Our aim is to describe how routines are created and how they are "invoked"
+(i.e.: called). The first part is the hard part.
 
-To create an SQL-invoked routine use the ``CREATE FUNCTION`` or ``CREATE 
-PROCEDURE`` statements (either as stand-alone SQL statements or within a 
-``CREATE SCHEMA`` statement). ``CREATE FUNCTION`` and ``CREATE PROCEDURE`` 
-specify the enclosing Schema, name the SQL-invoked routine and define the 
-routine's body and routine characteristics. To destroy an SQL-invoked routine, 
-use the ``DROP ROUTINE``, ``DROP FUNCTION`` or ``DROP PROCEDURE`` statements. 
-To change an existing routine, drop and then redefine it. 
+To create an SQL-invoked routine use the ``CREATE FUNCTION`` or ``CREATE
+PROCEDURE`` statements (either as stand-alone SQL statements or within a
+``CREATE SCHEMA`` statement). ``CREATE FUNCTION`` and ``CREATE PROCEDURE``
+specify the enclosing Schema, name the SQL-invoked routine and define the
+routine's body and routine characteristics. To destroy an SQL-invoked routine,
+use the ``DROP ROUTINE``, ``DROP FUNCTION`` or ``DROP PROCEDURE`` statements.
+To change an existing routine, drop and then redefine it.
 
 *SQL-invoked Routine Names*
 ---------------------------
 
-An SQL-invoked routine name is either a <Routine name> or a <specific name>: 
-both identify an SQL-invoked routine. The required syntax for an SQL-invoked 
+An SQL-invoked routine name is either a <Routine name> or a <specific name>:
+both identify an SQL-invoked routine. The required syntax for an SQL-invoked
 routine name is:
 
 ::
@@ -151,26 +153,26 @@ routine name is:
     <specific name> ::=
     [ <Schema name>. ] unqualified name
 
-A <Routine name> and a <specific name> are both a <regular identifier> or a 
-<delimited identifier>. The <Schema name> that qualifies a <Routine name> or a 
-<specific name> names the Schema that the SQL-invoked routine belongs to and 
-can either be explicitly stated, or a default will be supplied by your DBMS, as 
-follows: 
+A <Routine name> and a <specific name> are both a <regular identifier> or a
+<delimited identifier>. The <Schema name> that qualifies a <Routine name> or a
+<specific name> names the Schema that the SQL-invoked routine belongs to and
+can either be explicitly stated, or a default will be supplied by your DBMS, as
+follows:
 
-* If a <Routine name> or a <specific name> in a ``CREATE SCHEMA`` statement 
-  isn't qualified, the default qualifier is the name of the Schema you're 
+* If a <Routine name> or a <specific name> in a ``CREATE SCHEMA`` statement
+  isn't qualified, the default qualifier is the name of the Schema you're
   creating.
 
-* If the unqualified <Routine name> or <specific name> is found in any other 
-  SQL statement in a Module, the default qualifier is the name of the Schema 
-  identified in the ``SCHEMA`` clause or ``AUTHORIZATION`` clause of the 
+* If the unqualified <Routine name> or <specific name> is found in any other
+  SQL statement in a Module, the default qualifier is the name of the Schema
+  identified in the ``SCHEMA`` clause or ``AUTHORIZATION`` clause of the
   ``MODULE`` statement which defines that Module.
 
-More than one SQL-invoked routine in a Schema may have the same <Routine 
+More than one SQL-invoked routine in a Schema may have the same <Routine
 name>s. Your DBMS will determine which routine is being invoked as follows:
 
-* Since procedures and functions are created with separate SQL statements, 
-  your DBMS can uniquely identify the type of multiple routines identified by 
+* Since procedures and functions are created with separate SQL statements,
+  your DBMS can uniquely identify the type of multiple routines identified by
   the same <Routine name>.
 
 * Two procedures in a Schema may have the same <Routine name> only if
@@ -178,8 +180,8 @@ name>s. Your DBMS will determine which routine is being invoked as follows:
   uniquely identify one procedure from another by checking the parameters of
   each procedure with the same <Routine name>.
 
-* Two functions in a Schema must have unique <specific name>s. Thus, your 
-  DBMS can uniquely identify one function from another by checking the 
+* Two functions in a Schema must have unique <specific name>s. Thus, your
+  DBMS can uniquely identify one function from another by checking the
   <specific name> of each function with the same <Routine name>.
 
 Here are some examples of <Routine name>s:
@@ -214,15 +216,15 @@ Here are some examples of <specific name>s:
 *SQL Parameter Names*
 ---------------------
 
-An <SQL parameter name> identifies an SQL parameter. The required syntax for 
+An <SQL parameter name> identifies an SQL parameter. The required syntax for
 an <SQL parameter name> is:
 
 ::
 
     <SQL parameter name> ::= <identifier>
 
-An <SQL parameter name> is a <regular identifier> or a <delimited 
-identifier> that is unique (for all parameters) in the routine it belongs 
+An <SQL parameter name> is a <regular identifier> or a <delimited
+identifier> that is unique (for all parameters) in the routine it belongs
 to. Here are some examples of <SQL parameter name>s:
 
 ::
@@ -236,10 +238,10 @@ to. Here are some examples of <SQL parameter name>s:
 CREATE PROCEDURE/FUNCTION Statement
 ===================================
 
-The ``CREATE PROCEDURE/FUNCTION`` statement names a new SQL-invoked procedure 
-or function and defines the routine's SQL parameters, characteristics and 
-routine body. The required syntax for the ``CREATE PROCEDURE/FUNCTION`` 
-statement is: 
+The ``CREATE PROCEDURE/FUNCTION`` statement names a new SQL-invoked procedure
+or function and defines the routine's SQL parameters, characteristics and
+routine body. The required syntax for the ``CREATE PROCEDURE/FUNCTION``
+statement is:
 
 ::
 
@@ -305,7 +307,7 @@ statement is:
           [ TRANSFORM GROUP <group name> ]
           [ WITH {HOLD | RELEASE} ]
 
-The ``CREATE PROCEDURE/CREATE FUNCTION`` statement lets you define an 
+The ``CREATE PROCEDURE/CREATE FUNCTION`` statement lets you define an
 SQL-invoked routine. Here's a simpler version of the required syntax:
 
 ::
@@ -326,43 +328,43 @@ SQL-invoked routine. Here's a simpler version of the required syntax:
     [STATIC DISPATCH]                                     /* for function only */
     <routine body>
 
-As you can see, our "simpler" version isn't much simpler -- there's lots of 
-options! So what we'll do with this SQL statement is first give you a quick 
-one-paragraph description of each clause, then we'll start with some examples 
-of simple SQL routines and work our way up -- piece by piece -- to fairly 
-complicated matters. 
+As you can see, our "simpler" version isn't much simpler -- there's lots of
+options! So what we'll do with this SQL statement is first give you a quick
+one-paragraph description of each clause, then we'll start with some examples
+of simple SQL routines and work our way up -- piece by piece -- to fairly
+complicated matters.
 
 *CREATE ... <Routine name> Clause*
 ----------------------------------
 
-First of all, to create an SQL-invoked routine, the <keyword> phrase ``CREATE 
-PROCEDURE`` or ``CREATE FUNCTION`` is the basic choice. Either way, you are 
-creating a "routine". But there are two kinds of routines: "procedures" (which 
-don't return values) and "functions" (which do return values). Your choice at 
-this stage will determine how the routine is called later. ``CREATE PROCEDURE`` 
-defines a new SQL-invoked procedure. ``CREATE FUNCTION`` defines a new 
-SQL-invoked function. A routine is owned by the Schema it belongs to. 
+First of all, to create an SQL-invoked routine, the <keyword> phrase ``CREATE
+PROCEDURE`` or ``CREATE FUNCTION`` is the basic choice. Either way, you are
+creating a "routine". But there are two kinds of routines: "procedures" (which
+don't return values) and "functions" (which do return values). Your choice at
+this stage will determine how the routine is called later. ``CREATE PROCEDURE``
+defines a new SQL-invoked procedure. ``CREATE FUNCTION`` defines a new
+SQL-invoked function. A routine is owned by the Schema it belongs to.
 
-The <Routine name> identifies the routine and the Schema that it belongs to -- 
-this is the name of the routine as it appears to SQL. The description of the 
-routine is stored (as a Schema Object) in ``INFORMATION_SCHEMA``, so <Routine 
-name> has to follow the same rules as any other Schema Object name. A <Routine 
-name> that includes an explicit <Schema name> qualifier belongs to the Schema 
-named. A <Routine name> that does not include an explicit <Schema name> 
-qualifier belongs to the SQL-session default Schema. However -- an unusual 
-point -- <Routine name> does not have to be unique within its Schema; that is, 
-two different routines in the same Schema may have the same <Routine name> 
-because your DBMS will have other ways of uniquely identifying a routine (this 
-easement of the usual rule is not allowed in Core SQL.) 
+The <Routine name> identifies the routine and the Schema that it belongs to --
+this is the name of the routine as it appears to SQL. The description of the
+routine is stored (as a Schema Object) in ``INFORMATION_SCHEMA``, so <Routine
+name> has to follow the same rules as any other Schema Object name. A <Routine
+name> that includes an explicit <Schema name> qualifier belongs to the Schema
+named. A <Routine name> that does not include an explicit <Schema name>
+qualifier belongs to the SQL-session default Schema. However -- an unusual
+point -- <Routine name> does not have to be unique within its Schema; that is,
+two different routines in the same Schema may have the same <Routine name>
+because your DBMS will have other ways of uniquely identifying a routine (this
+easement of the usual rule is not allowed in Core SQL.)
 
-If ``CREATE PROCEDURE/CREATE FUNCTION`` is part of a ``CREATE SCHEMA`` 
-statement, the <Routine name>, if explicitly qualified, must include the 
-<Schema name> of the Schema being created; that is, it isn't possible to create 
-a routine belonging to a different Schema from within ``CREATE SCHEMA``. The 
-owner of a Schema always has the ``EXECUTE`` Privilege on every routine that 
-belongs to that Schema. This Privilege is a grantable Privilege only if *(a)* 
-the routine is an SQL routine and the Schema owner has a grantable Privilege 
-for every part of the routine body or *(b)* the routine is an external routine. 
+If ``CREATE PROCEDURE/CREATE FUNCTION`` is part of a ``CREATE SCHEMA``
+statement, the <Routine name>, if explicitly qualified, must include the
+<Schema name> of the Schema being created; that is, it isn't possible to create
+a routine belonging to a different Schema from within ``CREATE SCHEMA``. The
+owner of a Schema always has the ``EXECUTE`` Privilege on every routine that
+belongs to that Schema. This Privilege is a grantable Privilege only if *(a)*
+the routine is an SQL routine and the Schema owner has a grantable Privilege
+for every part of the routine body or *(b)* the routine is an external routine.
 
 *Parameter Declaration List*
 ----------------------------
@@ -379,14 +381,14 @@ mandatory, but it may be blank -- for example: "()".
 *RETURNS Clause*
 ----------------
 
-The ``RETURNS`` clause -- ``RETURNS`` <data type> <result cast> -- is a 
-mandatory clause if your SQL statement is ``CREATE FUNCTION``. Usually this 
-clause describes the <data type> of what the function returns, for example: 
-``RETURNS SMALLINT``. Sometimes it is necessary to cast the result, for 
-example: ``RETURNS CHAR(10) CAST FROM DATE``. 
+The ``RETURNS`` clause -- ``RETURNS`` <data type> <result cast> -- is a
+mandatory clause if your SQL statement is ``CREATE FUNCTION``. Usually this
+clause describes the <data type> of what the function returns, for example:
+``RETURNS SMALLINT``. Sometimes it is necessary to cast the result, for
+example: ``RETURNS CHAR(10) CAST FROM DATE``.
 
-Having described the initial mandatory parts of the routine specification, we 
-can now give you a rough analogy for the C function declaration: 
+Having described the initial mandatory parts of the routine specification, we
+can now give you a rough analogy for the C function declaration:
 
 ::
 
@@ -399,8 +401,8 @@ In SQL, this is:
    CREATE FUNCTION function1
       (IN param1 SMALLINT) RETURNS INTEGER ...
 
-At this point, we need to emphasize that this example is a rough analogy. 
-The SQL statement is executable (it is not a mere function declaration), and 
+At this point, we need to emphasize that this example is a rough analogy.
+The SQL statement is executable (it is not a mere function declaration), and
 it is far from finished yet.
 
 *Routine Characteristics Clause*
@@ -413,122 +415,122 @@ optional characteristic specification subclauses, in any order.
 LANGUAGE Subclause
 __________________
 
-The ``LANGUAGE`` subclause names the language the routine is written in. The 
-official expectation is that the routine is written in one of the ISO 
-"standard" languages: Ada, C, COBOL, FORTRAN, MUMPS, Pascal, PLI (note the 
-spelling) or SQL. In practice, your DBMS probably won't support all of the 
-standard languages (for example, MUMPS is often excluded); but it may support 
-others (for example, BASIC or Java). If you omit the ``LANGUAGE`` subclause, 
-the default is ``LANGUAGE SQL`` and your routine is an SQL routine. A routine 
-written in any language other than SQL, is an external routine to SQL. 
+The ``LANGUAGE`` subclause names the language the routine is written in. The
+official expectation is that the routine is written in one of the ISO
+"standard" languages: Ada, C, COBOL, FORTRAN, MUMPS, Pascal, PLI (note the
+spelling) or SQL. In practice, your DBMS probably won't support all of the
+standard languages (for example, MUMPS is often excluded); but it may support
+others (for example, BASIC or Java). If you omit the ``LANGUAGE`` subclause,
+the default is ``LANGUAGE SQL`` and your routine is an SQL routine. A routine
+written in any language other than SQL, is an external routine to SQL.
 
 PARAMETER STYLE Subclause
 _________________________
 
-The ``PARAMETER STYLE`` subclause is only necessary for external routines and 
-can be specified only once in a routine definition -- you can only put it in 
-either one of the <routine characteristics> clause or the <external body 
-reference> clause. If you omit the ``PARAMETER STYLE`` subclause, the default 
-is ``PARAMETER STYLE SQL``. Again, we'll discuss parameter details when we have 
-some examples to show you. 
+The ``PARAMETER STYLE`` subclause is only necessary for external routines and
+can be specified only once in a routine definition -- you can only put it in
+either one of the <routine characteristics> clause or the <external body
+reference> clause. If you omit the ``PARAMETER STYLE`` subclause, the default
+is ``PARAMETER STYLE SQL``. Again, we'll discuss parameter details when we have
+some examples to show you.
 
 SPECIFIC Subclause
 __________________
 
-The ``SPECIFIC`` <specific name> subclause uniquely identifies the routine. 
-Since your routine definition will already contain a <Routine name>, what would 
-you need a <specific name> for? Well, it mostly relates to UDTs and we'll defer 
-discussing routines for UDTs to our chapter on UDTs. 
+The ``SPECIFIC`` <specific name> subclause uniquely identifies the routine.
+Since your routine definition will already contain a <Routine name>, what would
+you need a <specific name> for? Well, it mostly relates to UDTs and we'll defer
+discussing routines for UDTs to our chapter on UDTs.
 
 Deterministic Characteristic Subclause
 ______________________________________
 
-The ``DETERMINISTIC | NOT DETERMINISTIC`` subclause is important if you intend 
-to include the routine in a Constraint, since Constraint routines must be 
-deterministic. If you omit the deterministic characteristic subclause, the 
-default is ``NOT DETERMINISTIC`` (which actually means "possibly 
-non-deterministic"; see our chapter on Constraints and Assertions). A 
-``DETERMINISTIC`` function always returns the same value for a given list of 
-SQL arguments. A ``DETERMINISTIC`` procedure always returns the same values in 
-its SQL parameters for a given list of SQL arguments. A possibly ``NOT 
-DETERMINISTIC`` routine might, at different times, return different results 
-even though the SQL-data is the same. You may not specify ``DETERMINISTIC`` if 
-the routine could return different results at different times. 
+The ``DETERMINISTIC | NOT DETERMINISTIC`` subclause is important if you intend
+to include the routine in a Constraint, since Constraint routines must be
+deterministic. If you omit the deterministic characteristic subclause, the
+default is ``NOT DETERMINISTIC`` (which actually means "possibly
+non-deterministic"; see our chapter on Constraints and Assertions). A
+``DETERMINISTIC`` function always returns the same value for a given list of
+SQL arguments. A ``DETERMINISTIC`` procedure always returns the same values in
+its SQL parameters for a given list of SQL arguments. A possibly ``NOT
+DETERMINISTIC`` routine might, at different times, return different results
+even though the SQL-data is the same. You may not specify ``DETERMINISTIC`` if
+the routine could return different results at different times.
 
 SQL Data Access Indication Subclause
 ____________________________________
 
-The ``NO SQL | CONTAINS SQL | READS SQL DATA | MODIFIES SQL DATA`` subclause 
-specifies what sort of SQL statements are in the routine (if any). If your 
-routine ``LANGUAGE`` subclause is ``LANGUAGE SQL``, then the routine will 
-certainly "contain" SQL statements, but even an external ``LANGUAGE PASCAL`` 
-routine can contain SQL/CLI functions or embedded SQL statements, so ``LANGUAGE 
-PASCAL ... CONTAINS SQL`` is a valid specification. If a routine contains any 
-SQL-data change statements (``INSERT``, ``UPDATE`` and/or ``DELETE``), its SQL 
-data access subclause must state ``MODIFIES SQL DATA``; otherwise if the 
-routine contains any other SQL-data statements (e.g.: ``SELECT`` or ``FETCH``), 
-the SQL data access subclause must state ``READS SQL DATA``; otherwise if the 
-routine contains any other SQL statements, the SQL data access subclause must 
-state ``CONTAINS SQL``; otherwise if the routine contains no SQL statements at 
-all, the SQL data access subclause must state ``NO SQL``. If you omit the SQL 
-data access indication subclause, the default is ``CONTAINS SQL``. 
+The ``NO SQL | CONTAINS SQL | READS SQL DATA | MODIFIES SQL DATA`` subclause
+specifies what sort of SQL statements are in the routine (if any). If your
+routine ``LANGUAGE`` subclause is ``LANGUAGE SQL``, then the routine will
+certainly "contain" SQL statements, but even an external ``LANGUAGE PASCAL``
+routine can contain SQL/CLI functions or embedded SQL statements, so ``LANGUAGE
+PASCAL ... CONTAINS SQL`` is a valid specification. If a routine contains any
+SQL-data change statements (``INSERT``, ``UPDATE`` and/or ``DELETE``), its SQL
+data access subclause must state ``MODIFIES SQL DATA``; otherwise if the
+routine contains any other SQL-data statements (e.g.: ``SELECT`` or ``FETCH``),
+the SQL data access subclause must state ``READS SQL DATA``; otherwise if the
+routine contains any other SQL statements, the SQL data access subclause must
+state ``CONTAINS SQL``; otherwise if the routine contains no SQL statements at
+all, the SQL data access subclause must state ``NO SQL``. If you omit the SQL
+data access indication subclause, the default is ``CONTAINS SQL``.
 
 Null-Call Subclause
 ___________________
 
-The ``RETURN NULL ON NULL INPUT | CALL ON NULL INPUT`` subclause is for 
-functions written in a host language, since a host language cannot handle 
-``NULL``\s. When the null-call subclause is ``RETURN NULL ON NULL INPUT``, the 
-routine is a "null-call" routine. If you call a null-call routine with any 
-parameter set to the null value, the return is immediate: the function returns 
-``NULL``. When the null-call subclause is ``CALL ON NULL INPUT`` and you call 
-the routine with any parameter set to the null value, execution of the routine 
-follows standard rules for operations with null values (e.g.: comparisons of 
-nulls to other values return ``UNKNOWN``, and so on). If you omit the null-call 
-subclause, the default is ``CALL ON NULL INPUT``. 
+The ``RETURN NULL ON NULL INPUT | CALL ON NULL INPUT`` subclause is for
+functions written in a host language, since a host language cannot handle
+``NULL``\s. When the null-call subclause is ``RETURN NULL ON NULL INPUT``, the
+routine is a "null-call" routine. If you call a null-call routine with any
+parameter set to the null value, the return is immediate: the function returns
+``NULL``. When the null-call subclause is ``CALL ON NULL INPUT`` and you call
+the routine with any parameter set to the null value, execution of the routine
+follows standard rules for operations with null values (e.g.: comparisons of
+nulls to other values return ``UNKNOWN``, and so on). If you omit the null-call
+subclause, the default is ``CALL ON NULL INPUT``.
 
 DYNAMIC RESULT SETS Subclause
 _____________________________
 
-The ``DYNAMIC RESULT SETS`` subclause is legal only within a ``CREATE 
-PROCEDURE`` statement. The "result sets" in question are query results, and the 
-concept here is that, within the routine, a certain number of Cursors (the 
-unsigned integer) can be opened for the results. In other words, you can 
-``CALL`` a procedure which ``STATIC DISPATCH`` clause contains up to *n* 
-``OPEN`` (Cursor) statements, and those Cursors will be visible after you 
-return from the procedure. If you omit the ``DYNAMIC RESULT SETS`` subclause, 
-the default is ``DYNAMIC RESULT SETS 0``. 
+The ``DYNAMIC RESULT SETS`` subclause is legal only within a ``CREATE
+PROCEDURE`` statement. The "result sets" in question are query results, and the
+concept here is that, within the routine, a certain number of Cursors (the
+unsigned integer) can be opened for the results. In other words, you can
+``CALL`` a procedure which ``STATIC DISPATCH`` clause contains up to *n*
+``OPEN`` (Cursor) statements, and those Cursors will be visible after you
+return from the procedure. If you omit the ``DYNAMIC RESULT SETS`` subclause,
+the default is ``DYNAMIC RESULT SETS 0``.
 
-Remember that the "routine characteristics" subclauses may be defined in any 
-order in a routine definition. The final two clauses must appear at the end of 
-the SQL statement. 
+Remember that the "routine characteristics" subclauses may be defined in any
+order in a routine definition. The final two clauses must appear at the end of
+the SQL statement.
 
 *STATIC DISPATCH Clause*
 ------------------------
 
-The optional ``STATIC DISPATCH`` clause is legal only within a ``CREATE 
-FUNCTION`` statement. It must be specified for functions that are not also 
-SQL-invoked methods, and that contain parameters whose <data type> is either a 
-<reference type>, a UDT or an ``ARRAY`` whose element <data type> is either a 
-<reference type> or a UDT. 
+The optional ``STATIC DISPATCH`` clause is legal only within a ``CREATE
+FUNCTION`` statement. It must be specified for functions that are not also
+SQL-invoked methods, and that contain parameters whose <data type> is either a
+<reference type>, a UDT or an ``ARRAY`` whose element <data type> is either a
+<reference type> or a UDT.
 
 *<routine body>*
 ----------------
 
-The <routine body> is a mandatory part of a routine definition. For a 
-``LANGUAGE SQL`` routine, you'd put a SQL procedure statement here (it may be 
-any SQL statement other than an SQL-Schema statement, an SQL-Connection 
-statement or an SQL-transaction statement). For an external routine, you'd put 
-an external interface description here. Clearly, the body of the routine is 
-what really matters. 
+The <routine body> is a mandatory part of a routine definition. For a
+``LANGUAGE SQL`` routine, you'd put a SQL procedure statement here (it may be
+any SQL statement other than an SQL-Schema statement, an SQL-Connection
+statement or an SQL-transaction statement). For an external routine, you'd put
+an external interface description here. Clearly, the body of the routine is
+what really matters.
 
 Routine Parameters
 ==================
 
-A routine's SQL parameter declaration list is a parenthesized, comma-delimited 
-list of definitions for the routine's parameters. Here's the required syntax 
-for a parameter definition in a ``CREATE PROCEDURE/CREATE FUNCTION`` statement 
-again: 
+A routine's SQL parameter declaration list is a parenthesized, comma-delimited
+list of definitions for the routine's parameters. Here's the required syntax
+for a parameter definition in a ``CREATE PROCEDURE/CREATE FUNCTION`` statement
+again:
 
 ::
 
@@ -541,13 +543,13 @@ again:
 *Parameter Mode*
 ----------------
 
-The optional ``[IN | OUT | INOUT]`` parameter mode specification is legal only 
-within ``CREATE PROCEDURE`` statements. ``IN`` defines an input SQL parameter, 
-``OUT`` defines an output SQL parameter and ``INOUT`` defines both an input SQL 
-parameter and an output SQL parameter. (In SQL routines, the SQL parameters may 
-not be named in a host variable or parameter specification in the routine 
-body.) This is a directional specification. If you omit the parameter mode 
-subclause, the default is ``IN``. 
+The optional ``[IN | OUT | INOUT]`` parameter mode specification is legal only
+within ``CREATE PROCEDURE`` statements. ``IN`` defines an input SQL parameter,
+``OUT`` defines an output SQL parameter and ``INOUT`` defines both an input SQL
+parameter and an output SQL parameter. (In SQL routines, the SQL parameters may
+not be named in a host variable or parameter specification in the routine
+body.) This is a directional specification. If you omit the parameter mode
+subclause, the default is ``IN``.
 
 *<SQL parameter name>*
 ----------------------
@@ -573,11 +575,11 @@ either ``BLOB``, ``CLOB``, ``NCLOB``, ``ARRAY`` or a UDT.
 *RESULT*
 --------
 
-The optional <keyword> ``RESULT`` is applicable only for UDTs, and is noted 
-here only for completeness at this time. 
+The optional <keyword> ``RESULT`` is applicable only for UDTs, and is noted
+here only for completeness at this time.
 
-Here's an example of a parameter declaration list for a ``CREATE PROCEDURE`` 
-statement: 
+Here's an example of a parameter declaration list for a ``CREATE PROCEDURE``
+statement:
 
 ::
 
@@ -585,12 +587,12 @@ statement:
       IN Apple CHAR(6), OUT Orange CHAR(6))
       ...
 
-The list is legal only within a ``CREATE PROCEDURE`` statement because it 
-contains ``IN`` and ``OUT`` declarations (within a ``CREATE FUNCTION`` 
-statement, all parameters are assumed to be ``IN``). The parameter named 
-``APPLE`` is a 6-character input parameter; the parameter named ``ORANGE`` is a 
-6-character output parameter. Here's an example of a parameter declaration list 
-for a ``CREATE FUNCTION`` statement: 
+The list is legal only within a ``CREATE PROCEDURE`` statement because it
+contains ``IN`` and ``OUT`` declarations (within a ``CREATE FUNCTION``
+statement, all parameters are assumed to be ``IN``). The parameter named
+``APPLE`` is a 6-character input parameter; the parameter named ``ORANGE`` is a
+6-character output parameter. Here's an example of a parameter declaration list
+for a ``CREATE FUNCTION`` statement:
 
 ::
 
@@ -600,13 +602,13 @@ for a ``CREATE FUNCTION`` statement:
 Invoking Routines
 =================
 
-Creating a routine is complex. Invoking a routine can be easy. The secret 
+Creating a routine is complex. Invoking a routine can be easy. The secret
 is: don't use the same <Routine name> twice in the same Schema.
 
 *CALL Statement*
 ----------------
 
-The ``CALL`` statement invokes a procedure. The required syntax for the 
+The ``CALL`` statement invokes a procedure. The required syntax for the
 ``CALL`` statement is:
 
 ::
@@ -620,10 +622,10 @@ The ``CALL`` statement invokes a procedure. The required syntax for the
           scalar_expression_argument |
           <host parameter name> [ [ INDICATOR ] <host parameter name> ] |
 
-The <Routine name> must identify an SQL-invoked procedure and the <SQL argument 
-list> must correspond to that procedure's parameter declarations in both number 
-and comparable <data type>. (A ``scalar_expression_argument`` is any expression 
-which evaluates to a single value.) For example, for this procedure: 
+The <Routine name> must identify an SQL-invoked procedure and the <SQL argument
+list> must correspond to that procedure's parameter declarations in both number
+and comparable <data type>. (A ``scalar_expression_argument`` is any expression
+which evaluates to a single value.) For example, for this procedure:
 
 ::
 
@@ -637,17 +639,17 @@ use this ``CALL`` statement to invoke it:
 
    CALL procedure_1(5,5);
 
-The SQL argument for an ``IN`` SQL parameter or an ``INOUT`` SQL parameter must 
-be a ``scalar_expression_argument``. The SQL argument for an ``OUT`` SQL 
-parameter may be a host language variable. 
+The SQL argument for an ``IN`` SQL parameter or an ``INOUT`` SQL parameter must
+be a ``scalar_expression_argument``. The SQL argument for an ``OUT`` SQL
+parameter may be a host language variable.
 
-Your current <AuthorizationID> must have the ``EXECUTE`` Privilege on a 
-procedure to ``CALL`` it. 
+Your current <AuthorizationID> must have the ``EXECUTE`` Privilege on a
+procedure to ``CALL`` it.
 
 *<routine invocation>*
 ----------------------
 
-A <routine invocation> invokes a function. The required syntax for a 
+A <routine invocation> invokes a function. The required syntax for a
 <routine invocation> is:
 
 ::
@@ -670,7 +672,7 @@ which evaluates to a single value.) For example, for this function:
 
    CREATE FUNCTION function_1 (in_param SMALLINT) ...;
 
-use this <routine invocation> to invoke it wherever it's legal to use a 
+use this <routine invocation> to invoke it wherever it's legal to use a
 value expression:
 
 ::
@@ -683,21 +685,21 @@ Here's an example:
 
    INSERT INTO Table_1 VALUES (function_1(5));
 
-Your current <AuthorizationID> must have the ``EXECUTE`` Privilege on a 
+Your current <AuthorizationID> must have the ``EXECUTE`` Privilege on a
 function to invoke it.
 
 Routine Examples
 ================
 
-Here are four examples of SQL-invoked routines that might be used in 
+Here are four examples of SQL-invoked routines that might be used in
 real-life situations.
 
 *Routine Example -- Reset Procedure*
 ------------------------------------
 
-Objective: Define and invoke a procedure which sets Column ``COLUMN_1``, in 
-Table ``TABLE_1``, to zero for all rows. Here's a procedure definition to 
-accomplish this: 
+Objective: Define and invoke a procedure which sets Column ``COLUMN_1``, in
+Table ``TABLE_1``, to zero for all rows. Here's a procedure definition to
+accomplish this:
 
 ::
 
@@ -713,7 +715,7 @@ To invoke ``RESET_TABLE_1``, use this SQL statement:
 
    CALL Reset_table_1();
 
-When you invoke a routine, you're telling your DBMS to execute the routine 
+When you invoke a routine, you're telling your DBMS to execute the routine
 body. For this example, this SQL statement:
 
 ::
@@ -728,16 +730,16 @@ has the same effect as this SQL statement:
 
 Details worth noting:
 
-* It's fairly common for a <Routine name> to consist of a verb and an 
+* It's fairly common for a <Routine name> to consist of a verb and an
   Object, as in this case. The style of routine definitions is still evolving.
 
-* Even though there are no parameters, the parentheses which enclose the 
-  parameter declaration list are necessary, both during creation and during 
+* Even though there are no parameters, the parentheses which enclose the
+  parameter declaration list are necessary, both during creation and during
   invocation.
 
-* The SQL-data access clause -- ``MODIFIES SQL DATA`` -- is necessary in 
-  this case because the procedure contains the SQL-data change statement 
-  ``INSERT``. It's a good habit to specify the data access clause even when it 
+* The SQL-data access clause -- ``MODIFIES SQL DATA`` -- is necessary in
+  this case because the procedure contains the SQL-data change statement
+  ``INSERT``. It's a good habit to specify the data access clause even when it
   is not necessary.
 
 *Routine Example -- Constant Function*
@@ -745,8 +747,8 @@ Details worth noting:
 
 .. |pi| unicode:: U+03C0
 
-Objective: Define and invoke a function which returns the constant pi (|pi|), 
-as a ``DECIMAL`` value. Here's a function definition to accomplish this: 
+Objective: Define and invoke a function which returns the constant pi (|pi|),
+as a ``DECIMAL`` value. Here's a function definition to accomplish this:
 
 ::
 
@@ -757,19 +759,19 @@ as a ``DECIMAL`` value. Here's a function definition to accomplish this:
       CONTAINS SQL                 /* Data access clause */
       RETURN 3.14;                 /* The routine body */
 
-To invoke ``PI``, use the <routine invocation> ``Pi()`` in an SQL statement, 
+To invoke ``PI``, use the <routine invocation> ``Pi()`` in an SQL statement,
 for example:
 
 ::
 
    INSERT INTO Table_1 (decimal_column) VALUES (Pi());
 
-In this example, the routine body contains a ``RETURN`` statement, which is 
-legal only within SQL functions. ``RETURN`` must specify some value (you can 
-put any expression which evaluates to a single value here) with a <data type> 
-that is assignable to the <data type> defined in the function definition's 
-``RETURNS`` clause. In this case, the function invocation in this SQL 
-statement: 
+In this example, the routine body contains a ``RETURN`` statement, which is
+legal only within SQL functions. ``RETURN`` must specify some value (you can
+put any expression which evaluates to a single value here) with a <data type>
+that is assignable to the <data type> defined in the function definition's
+``RETURNS`` clause. In this case, the function invocation in this SQL
+statement:
 
 ::
 
@@ -783,14 +785,14 @@ has the same effect as this SQL statement:
 
 .. TIP::
 
-   You can't define constants in SQL, but you can define constant functions. 
-   They help ensure that values like ``p`` (pi) are defined only once, and 
+   You can't define constants in SQL, but you can define constant functions.
+   They help ensure that values like ``p`` (pi) are defined only once, and
    are referenced by a name rather than a <literal>.
 
 *Routine Example -- Subquery Function*
 --------------------------------------
 
-Objective is: Define and invoke a replacement for a frequently-used 
+Objective is: Define and invoke a replacement for a frequently-used
 subquery. Here's a function definition to accomplish this:
 
 ::
@@ -805,7 +807,7 @@ subquery. Here's a function definition to accomplish this:
          FROM   Table_1
          WHERE  smallint_column > 5);
 
-To invoke ``MAX_``, use the <routine invocation> ``Max_()`` in an SQL 
+To invoke ``MAX_``, use the <routine invocation> ``Max_()`` in an SQL
 statement, for example:
 
 ::
@@ -817,16 +819,16 @@ than ``SELECT MAX(date_column) FROM Table_1 WHERE smallint_column > 5);``. It's
 also safer -- if a subquery is long and complex and used frequently, you'll
 reduce the chances of error by putting the subquery into a function.
 
-A far less likely advantage is that the ``MAX_`` routine is parsed and done 
-only once. Although that sort of optimization is theoretically possible, there 
-are some hidden dynamic variables that could change each time ``MAX_`` is 
-invoked (for example, the Schema that contains ``TABLE_1``). One does not call 
-functions like this for "efficiency" reasons. 
+A far less likely advantage is that the ``MAX_`` routine is parsed and done
+only once. Although that sort of optimization is theoretically possible, there
+are some hidden dynamic variables that could change each time ``MAX_`` is
+invoked (for example, the Schema that contains ``TABLE_1``). One does not call
+functions like this for "efficiency" reasons.
 
 *Routine Example -- Withdrawal Procedure*
 -----------------------------------------
 
-Objective: Perform a logged balanced withdrawal, like real banks do. Here's 
+Objective: Perform a logged balanced withdrawal, like real banks do. Here's
 a procedure definition to accomplish this:
 
 ::
@@ -850,7 +852,7 @@ a procedure definition to accomplish this:
            parameter_amount);
       END;
 
-To invoke ``WITHDRAW``, use a ``CALL`` statement that names the procedure 
+To invoke ``WITHDRAW``, use a ``CALL`` statement that names the procedure
 and provides a value for each of its parameters, for example:
 
 ::
@@ -863,34 +865,34 @@ Therefore, in the real world, withdrawals are done via procedures. This
 example is translated from a procedure written in a host language (not SQL);
 however, the routine is really used in a real bank. Details worth noting:
 
-* The parameters (all of which are ``IN`` SQL parameters) are simply 
+* The parameters (all of which are ``IN`` SQL parameters) are simply
   referenced by name within the routine body.
 
-* The routine body contains a compound SQL procedure statement (a sequence 
-  of SQL statements within a ``BEGIN ATOMIC ... END`` block). Correctly, 
-  compound SQL statements are only legal in Triggers, or as part of the 
-  "Persistent Stored Modules" SQL package (see our chapter on PSM) -- so this 
+* The routine body contains a compound SQL procedure statement (a sequence
+  of SQL statements within a ``BEGIN ATOMIC ... END`` block). Correctly,
+  compound SQL statements are only legal in Triggers, or as part of the
+  "Persistent Stored Modules" SQL package (see our chapter on PSM) -- so this
   example shows the use of an extension to Standard Core SQL.
 
-Routines are particularly applicable to Roles. For example, a bank teller might 
-not have the Privilege to access a Table, but would have the Privilege to 
-``EXECUTE`` the ``WITHDRAW`` Procedure. Typically, one finds that when groups 
-of employees are involved, the applicable Privilege is not an "access Privilege 
-on a Table" but an "``EXECUTE`` Privilege on a routine". 
+Routines are particularly applicable to Roles. For example, a bank teller might
+not have the Privilege to access a Table, but would have the Privilege to
+``EXECUTE`` the ``WITHDRAW`` Procedure. Typically, one finds that when groups
+of employees are involved, the applicable Privilege is not an "access Privilege
+on a Table" but an "``EXECUTE`` Privilege on a routine".
 
 RETURN Statement
 ================
 
-The ``RETURN`` statement returns a value from an SQL-invoked function. The 
+The ``RETURN`` statement returns a value from an SQL-invoked function. The
 required syntax for the ``RETURN`` statement is:
 
 ::
 
     RETURN <value expression> | NULL
 
-The ``RETURN`` statement ends the execution of an SQL-invoked function, 
-returning the function's result. The return can either be a <value expression> 
-or, if the function's result is a null value, the <keyword> ``NULL``. 
+The ``RETURN`` statement ends the execution of an SQL-invoked function,
+returning the function's result. The return can either be a <value expression>
+or, if the function's result is a null value, the <keyword> ``NULL``.
 
 External Routines
 =================
@@ -898,27 +900,27 @@ External Routines
 | *"Host calls DBMS: no story. DBMS calls host: story!"*
 | *-- Journalist's man-bites-dog rule, slightly adapted*
 
-Since most applications involve two languages -- SQL and the host -- there 
+Since most applications involve two languages -- SQL and the host -- there
 are four possible routine interface situations:
 
-1. Host invokes SQL -- this is a common situation, discussed in our chapters 
+1. Host invokes SQL -- this is a common situation, discussed in our chapters
    on SQL/CLI and embedded SQL.
 
-2. Host invokes host -- this is also common, but none of our business: this 
+2. Host invokes host -- this is also common, but none of our business: this
    is an SQL book.
 
-3. SQL invokes SQL -- this is the situation we've shown you in the example 
+3. SQL invokes SQL -- this is the situation we've shown you in the example
    so far; they've all been SQL routines.
 
-4. SQL invokes host -- this is not a common situation, but external 
+4. SQL invokes host -- this is not a common situation, but external
    routines" are conceivably quite useful.
 
-You can write Standard SQL routines in Ada, C, COBOL, Fortran, MUMPS, Pascal or 
-PL/1. If you do, the routine definition must include a ``LANGUAGE`` clause that 
-names the host language you're using and its routine body would have to be a 
-reference to an external routine, instead of an SQL procedure statement. Here, 
-once again, is the required syntax for an <external body reference> in a 
-``CREATE PROCEDURE/CREATE FUNCTION`` statement: 
+You can write Standard SQL routines in Ada, C, COBOL, Fortran, MUMPS, Pascal or
+PL/1. If you do, the routine definition must include a ``LANGUAGE`` clause that
+names the host language you're using and its routine body would have to be a
+reference to an external routine, instead of an SQL procedure statement. Here,
+once again, is the required syntax for an <external body reference> in a
+``CREATE PROCEDURE/CREATE FUNCTION`` statement:
 
 ::
 
@@ -934,20 +936,20 @@ The <keyword> ``EXTERNAL`` tells your DBMS you're defining an external routine.
 -------------
 
 The optional ``NAME`` clause specifies the routine's external name. If you omit
-the ``NAME`` clause, it will default to the routine's unqualified <Routine 
+the ``NAME`` clause, it will default to the routine's unqualified <Routine
 name>.
 
 *PARAMETER STYLE Clause*
 ------------------------
 
-The optional ``PARAMETER STYLE`` clause determines whether some additional 
-parameters will be passed automatically and has two options: ``SQL`` or 
-``GENERAL``. If the specification is ``PARAMETER STYLE SQL``, then automatic 
-parameters (such as indicators) will be passed as well. If the specification is 
-``PARAMETER STYLE GENERAL``, then there is no automatic parameter passing. If 
-you omit the clause, the default is ``PARAMETER STYLE SQL``. Remember not to 
-use a parameter style clause here if there is already a parameter style clause 
-in the main definition. 
+The optional ``PARAMETER STYLE`` clause determines whether some additional
+parameters will be passed automatically and has two options: ``SQL`` or
+``GENERAL``. If the specification is ``PARAMETER STYLE SQL``, then automatic
+parameters (such as indicators) will be passed as well. If the specification is
+``PARAMETER STYLE GENERAL``, then there is no automatic parameter passing. If
+you omit the clause, the default is ``PARAMETER STYLE SQL``. Remember not to
+use a parameter style clause here if there is already a parameter style clause
+in the main definition.
 
 *TRANSFORM GROUP Clause*
 ------------------------
@@ -959,7 +961,7 @@ omit the clause, the default is ``TRANSFORM GROUP DEFAULT``.
 *WITH Clause*
 -------------
 
-The optional ``WITH {HOLD | RELEASE}`` clause is a future consideration; the 
+The optional ``WITH {HOLD | RELEASE}`` clause is a future consideration; the
 presumption is that it has to do with holdable Cursors.
 
 Here's an example of an external routine that is an SQL-invoked procedure:
@@ -983,21 +985,21 @@ External routines are necessary, or at least very useful, for these things:
 
 **Accessing the operating system**
 
-For example, you can't call the Windows API from SQL, but you can create an 
-external routine which does so. The ability to access the operating system is 
-particularly useful for Privilege checks. 
+For example, you can't call the Windows API from SQL, but you can create an
+external routine which does so. The ability to access the operating system is
+particularly useful for Privilege checks.
 
 **Translating data**
 
-The traditional usage here is encryption/decryption. We'd also note that, if 
-your DBMS produces error messages in English and you want them in Italian, this 
-is a good place to intercept them. 
+The traditional usage here is encryption/decryption. We'd also note that, if
+your DBMS produces error messages in English and you want them in Italian, this
+is a good place to intercept them.
 
 **Optimizing**
 
-Since SQL is not famous for low-level efficiency, it's usually faster to 
-write some routines in a compiled language, or better yet in assembler 
-(shameless plug: see our book *OPTIMIZING C WITH ASSEMBLY CODE*). Hashing 
+Since SQL is not famous for low-level efficiency, it's usually faster to
+write some routines in a compiled language, or better yet in assembler
+(shameless plug: see our book *OPTIMIZING C WITH ASSEMBLY CODE*). Hashing
 and pattern matching would make good examples here.
 
 External routines are not so wonderful if you're trying to write purely
@@ -1005,10 +1007,10 @@ portable SQL applications. Also, their existence can confuse the DBMS's
 optimizer, and even confuse application programmers. We suggest that you keep
 it simple: don't write external routines that call SQL.
 
-If you want to restrict your code to Core SQL, don't use ``LOCATOR`` 
-indicators, ``DYNAMIC RESULT SETS`` clauses, ``TRANSFORM GROUP`` clauses or 
-duplicate <Routine name>s when defining an SQL-invoked routine and don't define 
-any SQL-invoked methods. 
+If you want to restrict your code to Core SQL, don't use ``LOCATOR``
+indicators, ``DYNAMIC RESULT SETS`` clauses, ``TRANSFORM GROUP`` clauses or
+duplicate <Routine name>s when defining an SQL-invoked routine and don't define
+any SQL-invoked methods.
 
 ALTER ROUTINE/PROCEDURE/FUNCTION/METHOD Statement
 =================================================
@@ -1081,23 +1083,23 @@ ROUTINE/PROCEDURE/FUNCTION`` statement is:
        {ROUTINE | FUNCTION | PROCEDURE} <Routine name>
           [ ([ <data type> [ {,<data type>}... ] ]) ]
 
-``DROP ROUTINE/PROCEDURE/FUNCTION`` destroys an SQL-invoked routine. The 
-<Routine name> must identify an existing SQL-invoked routine whose owner is 
-either the current <AuthorizationID> or a Role that the current 
-<AuthorizationID> may use. That is, only the <AuthorizationID> that owns the 
-routine may drop it. If <Routine name> is not unique within the routine's 
-Schema, then you must include a <data type> list that provides the <data type> 
-of each of the routine's parameters -- your DBMS will match this list to the 
-parameter declaration lists of every routine called "<Routine name>" to find 
-the one you want to drop. If you remember to always give unique <Routine name>s 
-to your routines, you'll avoid a great deal of potential difficulty. 
+``DROP ROUTINE/PROCEDURE/FUNCTION`` destroys an SQL-invoked routine. The
+<Routine name> must identify an existing SQL-invoked routine whose owner is
+either the current <AuthorizationID> or a Role that the current
+<AuthorizationID> may use. That is, only the <AuthorizationID> that owns the
+routine may drop it. If <Routine name> is not unique within the routine's
+Schema, then you must include a <data type> list that provides the <data type>
+of each of the routine's parameters -- your DBMS will match this list to the
+parameter declaration lists of every routine called "<Routine name>" to find
+the one you want to drop. If you remember to always give unique <Routine name>s
+to your routines, you'll avoid a great deal of potential difficulty.
 
-``DROP ROUTINE`` drops either an SQL-invoked function or an SQL-invoked 
-procedure, so it's best to be more specific. ``DROP FUNCTION`` drops an 
-SQL-invoked function, so <Routine name> must identify a function. ``DROP 
-PROCEDURE`` drops an SQL- invoked procedure, so <Routine name> must identify a 
-procedure. In no case may <Routine name> identify a routine that was created as 
-part of a UDT definition. 
+``DROP ROUTINE`` drops either an SQL-invoked function or an SQL-invoked
+procedure, so it's best to be more specific. ``DROP FUNCTION`` drops an
+SQL-invoked function, so <Routine name> must identify a function. ``DROP
+PROCEDURE`` drops an SQL- invoked procedure, so <Routine name> must identify a
+procedure. In no case may <Routine name> identify a routine that was created as
+part of a UDT definition.
 
 The effect of ``DROP`` routine type <Routine name> ``RESTRICT``, e.g.:
 
@@ -1109,14 +1111,14 @@ The effect of ``DROP`` routine type <Routine name> ``RESTRICT``, e.g.:
 
    DROP PROCEDURE procedure_1 RESTRICT;
 
-is that the routine named is destroyed, provided that the routine is not 
-invoked or used by any other routine or in a View definition, Constraint 
-definition, Assertion definition, Trigger definition, Column definition or 
-Domain definition and provided that the routine is not a from-sql function or a 
-to-sql function associated with an external routine. That is, ``RESTRICT`` 
-ensures that only a routine with no dependent Objects can be destroyed. If the 
-routine is used by any other Object, ``DROP ROUTINE/FUNCTION/PROCEDURE ... 
-RESTRICT`` will fail. 
+is that the routine named is destroyed, provided that the routine is not
+invoked or used by any other routine or in a View definition, Constraint
+definition, Assertion definition, Trigger definition, Column definition or
+Domain definition and provided that the routine is not a from-sql function or a
+to-sql function associated with an external routine. That is, ``RESTRICT``
+ensures that only a routine with no dependent Objects can be destroyed. If the
+routine is used by any other Object, ``DROP ROUTINE/FUNCTION/PROCEDURE ...
+RESTRICT`` will fail.
 
 The effect of ``DROP`` routine type <Routine name> ``CASCADE``, e.g.:
 
@@ -1134,16 +1136,16 @@ Successfully destroying a routine has a three-fold effect:
 
 1. The routine named is destroyed.
 
-2. The ``EXECUTE`` Privilege held on the routine by the <AuthorizationID> 
-   that owns it is revoked (by the SQL special grantor, "``_SYSTEM``") with a 
-   ``CASCADE`` revoke behaviour, so that all ``EXECUTE`` Privileges held on the 
-   routine by any other <AuthorizationID> are also revoked. 
+2. The ``EXECUTE`` Privilege held on the routine by the <AuthorizationID>
+   that owns it is revoked (by the SQL special grantor, "``_SYSTEM``") with a
+   ``CASCADE`` revoke behaviour, so that all ``EXECUTE`` Privileges held on the
+   routine by any other <AuthorizationID> are also revoked.
 
-3. All SQL routines, Views, Constraints, Assertions, Triggers, Columns and 
-   Domains that depend on the routine are dropped with a ``CASCADE`` drop 
-   behaviour. 
+3. All SQL routines, Views, Constraints, Assertions, Triggers, Columns and
+   Domains that depend on the routine are dropped with a ``CASCADE`` drop
+   behaviour.
 
-If you want to restrict your code to Core SQL, don't use the ``CASCADE`` 
+If you want to restrict your code to Core SQL, don't use the ``CASCADE``
 drop behaviour for your ``DROP ROUTINE/FUNCTION/PROCEDURE`` statements.
 
 Dialects

--- a/docs/chapters/26.rst
+++ b/docs/chapters/26.rst
@@ -4,23 +4,25 @@
 Chapter 26 -- PSM: Not just Persistent Stored Modules
 =====================================================
 
+.. include:: ../_include/note.rst
+
 The initials *PSM* refer to the specifications of a document labelled "ISO/IEC
 9075-4 Information Technology - Database Languages - SQL: Part 4: Persistent
 Stored Modules (SQL/PSM)". Part 4 is one of the standard SQL documents, but it
 is not essential -- that is, it describes SQL features that are optional. A
 DBMS that complies with part 4 can claim "enhanced SQL conformance" (provided,
 of course, that it also fully supports Core SQL). We will use the phrase
-"essential SQL" to mean "SQL without PSM, as defined in Parts 1 and 2 of the 
+"essential SQL" to mean "SQL without PSM, as defined in Parts 1 and 2 of the
 SQL Standard".
 
-In essential SQL, the concept of Modules -- that is, SQL-client Modules -- is 
-defined and used frequently (in effect, every type of SQL binding style 
-conceptually uses Modules, at least implicitly). However, nobody implements 
-them and nobody cares. What vendors have implemented, and what programmers have 
-used throughout SQL's history, is some variant of: *(a)* embedded SQL, *(b)* 
-SQL/CLI or *(c)* both. There has been no popular implementation of a complete 
-SQL language which can do all the things that other programming languages 
-offer. 
+In essential SQL, the concept of Modules -- that is, SQL-client Modules -- is
+defined and used frequently (in effect, every type of SQL binding style
+conceptually uses Modules, at least implicitly). However, nobody implements
+them and nobody cares. What vendors have implemented, and what programmers have
+used throughout SQL's history, is some variant of: *(a)* embedded SQL, *(b)*
+SQL/CLI or *(c)* both. There has been no popular implementation of a complete
+SQL language which can do all the things that other programming languages
+offer.
 
 For example, in essential SQL, there is no easy way to do these things:
 
@@ -38,7 +40,7 @@ specification. Since one important extension is the ability to create and
 destroy program modules, the package name is "Persistent Stored Modules".
 However, the other extensions -- variable handling and program control -- can
 be implemented independently. For example, some DBMSs allow "assignment"
-statements to be used within Triggers, even though they have no support for 
+statements to be used within Triggers, even though they have no support for
 persistent stored modules.
 
 .. rubric:: Table of Contents
@@ -56,12 +58,12 @@ Tables and Domains and other Schema Objects are. (The actual storage is on the
 server and these Objects are sometimes called "SQL-server Modules", but their
 physical location is not important.)
 
-It is, then, reasonable to think of a Persistent Stored Module as a [program] 
-Module which is stored permanently within a Schema of an SQL "database". As 
-with other Schema Objects, there are ``CREATE``, ``ALTER`` and ``DROP`` 
-statements for creating, altering and dropping Modules. In this chapter, we'll 
-briefly describe these Modules, and show you the syntax to use to create, alter 
-and destroy them. 
+It is, then, reasonable to think of a Persistent Stored Module as a [program]
+Module which is stored permanently within a Schema of an SQL "database". As
+with other Schema Objects, there are ``CREATE``, ``ALTER`` and ``DROP``
+statements for creating, altering and dropping Modules. In this chapter, we'll
+briefly describe these Modules, and show you the syntax to use to create, alter
+and destroy them.
 
 A Schema may contain zero or more Modules. An SQL Module is a named group of
 SQL statements. Modules are dependent on some Schema -- the <Module name> must
@@ -81,19 +83,19 @@ procedure. SQL procedures must reference parameters to pass values between the
 program and SQL-data. Since parameters must map to host language variables,
 they are not nullable unless they are coupled with an indicator parameter.
 
-SQL provides a status parameter -- ``SQLSTATE`` -- whose value indicates 
-whether or not an SQL statement was successfully executed. All procedures must 
-contain an ``SQLSTATE`` declaration. 
+SQL provides a status parameter -- ``SQLSTATE`` -- whose value indicates
+whether or not an SQL statement was successfully executed. All procedures must
+contain an ``SQLSTATE`` declaration.
 
 A Module is defined by a descriptor that contains six pieces of information:
 
-1. The <Module name>, qualified by the <Schema name> of the Schema it 
+1. The <Module name>, qualified by the <Schema name> of the Schema it
    belongs to.
 
-2. The name of the Character set that is used to express the names of all 
+2. The name of the Character set that is used to express the names of all
    Schema Objects mentioned in the Module's definition.
 
-3. The Module's <AuthorizationID> -- this is the <AuthorizationID> that owns 
+3. The Module's <AuthorizationID> -- this is the <AuthorizationID> that owns
    the Module's Schema.
 
 4. The list of <Schema name>s contained in the Module's path specification.
@@ -102,20 +104,20 @@ A Module is defined by a descriptor that contains six pieces of information:
 
 6. A descriptor for every SQL-invoked routine contained in the Module.
 
-To create a Module, use the ``CREATE MODULE`` statement (either as a 
-stand-alone SQL statement or within a ``CREATE SCHEMA`` statement). ``CREATE 
-MODULE`` specifies the enclosing Schema, names the Module and identifies the 
-Module's Character set, declared Tables and routines. To change an existing 
-Module, use the ``ALTER MODULE`` statement. To destroy a Module, use the ``DROP 
-MODULE`` statement. 
+To create a Module, use the ``CREATE MODULE`` statement (either as a
+stand-alone SQL statement or within a ``CREATE SCHEMA`` statement). ``CREATE
+MODULE`` specifies the enclosing Schema, names the Module and identifies the
+Module's Character set, declared Tables and routines. To change an existing
+Module, use the ``ALTER MODULE`` statement. To destroy a Module, use the ``DROP
+MODULE`` statement.
 
-There is a one-to-many association between Schemas and Modules: one Schema 
+There is a one-to-many association between Schemas and Modules: one Schema
 can own multiple Modules.
 
 *Module Names*
 --------------
 
-A <Module name> identifies a Module. The required syntax for a <Module name> 
+A <Module name> identifies a Module. The required syntax for a <Module name>
 is:
 
 ::
@@ -123,18 +125,18 @@ is:
     <Module name> ::=
     [ <Schema name>. ] unqualified name
 
-A <Module name> is a <regular identifier> or a <delimited identifier> that is 
-unique (for all Modules) within the Schema it belongs to. The <Schema name> 
-which qualifies a <Module name> names the Schema that the Module belongs to and 
-can either be explicitly stated, or a default will be supplied by your DBMS as 
-follows: 
+A <Module name> is a <regular identifier> or a <delimited identifier> that is
+unique (for all Modules) within the Schema it belongs to. The <Schema name>
+which qualifies a <Module name> names the Schema that the Module belongs to and
+can either be explicitly stated, or a default will be supplied by your DBMS as
+follows:
 
-* If a <Module name> in a ``CREATE SCHEMA`` statement isn't qualified, the 
+* If a <Module name> in a ``CREATE SCHEMA`` statement isn't qualified, the
   default qualifier is the name of the Schema you're creating.
 
 * If the unqualified <Module name> is found in any other SQL statement,
   the default qualifier is the name of the Schema identified in the ``SCHEMA``
-  clause or ``AUTHORIZATION`` clause of the ``CREATE MODULE`` statement that 
+  clause or ``AUTHORIZATION`` clause of the ``CREATE MODULE`` statement that
   defines that Module.
 
 Here are some examples of <Module name>s:
@@ -153,8 +155,8 @@ Here are some examples of <Module name>s:
 CREATE MODULE Statement
 =======================
 
-The ``CREATE MODULE`` statement creates an SQL-server Module: a Module that 
-belongs to a Schema. The required syntax for the ``CREATE MODULE`` statement 
+The ``CREATE MODULE`` statement creates an SQL-server Module: a Module that
+belongs to a Schema. The required syntax for the ``CREATE MODULE`` statement
 is:
 
 ::
@@ -167,11 +169,11 @@ is:
        <SQL-invoked routine>; ...
        END MODULE
 
-``CREATE MODULE`` defines a new SQL-server Module -- don't get this mixed up 
-with the simple ``MODULE`` statement that is part of essential SQL, it defines 
-an SQL- client Module and, although the two are similar, PSM statements won;t 
-work on anything but a PSM Module. An SQL-server Module is owned by the Schema 
-it belongs to. 
+``CREATE MODULE`` defines a new SQL-server Module -- don't get this mixed up
+with the simple ``MODULE`` statement that is part of essential SQL, it defines
+an SQL- client Module and, although the two are similar, PSM statements won;t
+work on anything but a PSM Module. An SQL-server Module is owned by the Schema
+it belongs to.
 
 The <Module name> identifies the Module and the Schema that it belongs to. A
 <Module name> that includes an explicit <Schema name> qualifier belongs to the
@@ -179,20 +181,20 @@ Schema named. A <Module name> that does not include an explicit <Schema name>
 qualifier belongs to the SQL-session default Schema. The <Module name> must be
 unique within the Schema that owns it.
 
-If ``CREATE MODULE`` is part of a ``CREATE SCHEMA`` statement, the <Module 
-name>, if explicitly qualified, must include the <Schema name> of the Schema 
-being created; that is, it isn't possible to create a Module belonging to a 
-different Schema from within ``CREATE SCHEMA``. 
+If ``CREATE MODULE`` is part of a ``CREATE SCHEMA`` statement, the <Module
+name>, if explicitly qualified, must include the <Schema name> of the Schema
+being created; that is, it isn't possible to create a Module belonging to a
+different Schema from within ``CREATE SCHEMA``.
 
-The optional ``NAMES ARE`` clause provides the name of the Character set that 
-is used to express the names of all Schema Objects mentioned in the Module's 
-definition. If you omit the clause, the Module's Character set is the default 
-Character set of the Schema it belongs to. 
+The optional ``NAMES ARE`` clause provides the name of the Character set that
+is used to express the names of all Schema Objects mentioned in the Module's
+definition. If you omit the clause, the Module's Character set is the default
+Character set of the Schema it belongs to.
 
-The optional ``SCHEMA`` clause names the default Schema for the Module -- that 
-is, the name of the Schema that owns the Schema Objects referred to in the 
-Module. If you omit the clause, the default <Schema name> is the name of the 
-Schema that owns the Module. 
+The optional ``SCHEMA`` clause names the default Schema for the Module -- that
+is, the name of the Schema that owns the Schema Objects referred to in the
+Module. If you omit the clause, the default <Schema name> is the name of the
+Schema that owns the Module.
 
 The optional ``PATH`` clause names the Module's default path: the path used to
 qualify unqualified <Routine name>s that identify <routine invocation>s that
@@ -202,10 +204,10 @@ all of the Schemas named must belong to the same Catalog. If you omit the
 clause, your DBMS will give the Module a default path that includes the name
 of the Schema that the Module belongs to.
 
-The Module can contain zero or more ``DECLARE TABLE`` statements, each 
-declaring a local temporary Table that will only be visible to this Module. 
+The Module can contain zero or more ``DECLARE TABLE`` statements, each
+declaring a local temporary Table that will only be visible to this Module.
 
-The Module can contain one or more SQL-invoked routines -- these do the 
+The Module can contain one or more SQL-invoked routines -- these do the
 Module's work. Here's a simple example:
 
 ::
@@ -222,20 +224,20 @@ Module's work. Here's a simple example:
           INSERT INTO Employees VALUES (5);
       END MODULE
 
-If your memory stretches back to our chapter on SQL routines, you'll recognize 
-the ``PROCEDURE`` statements here -- procedures and functions are part of 
-essential SQL. What the ``CREATE MODULE`` statement allows you to do is 
-construct a "package" of procedures, in the same way that a C implementation 
-allows the construction of a library. Our example is a rather crude attempt to 
-"package" the main SQL-data change statements that can happen with the 
-``EMPLOYEES`` Table. Note: The ``DECLARE`` <keyword> before ``PROCEDURE`` is 
+If your memory stretches back to our chapter on SQL routines, you'll recognize
+the ``PROCEDURE`` statements here -- procedures and functions are part of
+essential SQL. What the ``CREATE MODULE`` statement allows you to do is
+construct a "package" of procedures, in the same way that a C implementation
+allows the construction of a library. Our example is a rather crude attempt to
+"package" the main SQL-data change statements that can happen with the
+``EMPLOYEES`` Table. Note: The ``DECLARE`` <keyword> before ``PROCEDURE`` is
 optional.
 
 
 ALTER MODULE Statement
 ======================
 
-The ``ALTER MODULE`` statement lets you change a Module's definition. The 
+The ``ALTER MODULE`` statement lets you change a Module's definition. The
 required syntax for the ``ALTER MODULE`` statement is:
 
 ::
@@ -243,9 +245,9 @@ required syntax for the ``ALTER MODULE`` statement is:
     ALTER MODULE <Module name>
        {ADD | DROP} <Module contents> ...
 
-``ALTER MODULE`` changes an existing Module. <Module contents> can be a 
-function, a procedure or any of the other things that might be part of a Module 
-(exceptions, handlers, variables, Cursors, declared Tables and so on). 
+``ALTER MODULE`` changes an existing Module. <Module contents> can be a
+function, a procedure or any of the other things that might be part of a Module
+(exceptions, handlers, variables, Cursors, declared Tables and so on).
 
 Here's an example of an ``ALTER MODULE`` statement:
 
@@ -254,14 +256,14 @@ Here's an example of an ``ALTER MODULE`` statement:
    ALTER Module Employees_Module
      DROP PROCEDURE Insert_Employees;
 
-After the execution of this ``ALTER MODULE`` statement, the 
-``EMPLOYEES_MODULE`` Module will have only two procedures left: 
-``Delete_Employees`` and ``Update_Employees``. 
+After the execution of this ``ALTER MODULE`` statement, the
+``EMPLOYEES_MODULE`` Module will have only two procedures left:
+``Delete_Employees`` and ``Update_Employees``.
 
 DROP MODULE Statement
 =====================
 
-The ``DROP MODULE`` statement destroys an SQL-server Module. The required syntax 
+The ``DROP MODULE`` statement destroys an SQL-server Module. The required syntax
 for the ``DROP MODULE`` statement is:
 
 ::
@@ -278,13 +280,13 @@ The effect of ``DROP MODULE`` <Module name> ``RESTRICT``, e.g.:
 
    DROP MODULE module_1 RESTRICT;
 
-is that the Module named is destroyed, provided that the Module doesn't contain 
-the definition of an SQL-invoked routine that is invoked outside of the Module 
--- i.e.: in an SQL routine that isn't defined in this Module or in any View 
-definition, Trigger definition, Constraint or Assertion definition. That is, 
-``RESTRICT`` ensures that only a Module with no dependent Objects can be 
-destroyed. If the Module is used by any other Object, ``DROP MODULE ... 
-RESTRICT`` will fail. 
+is that the Module named is destroyed, provided that the Module doesn't contain
+the definition of an SQL-invoked routine that is invoked outside of the Module
+-- i.e.: in an SQL routine that isn't defined in this Module or in any View
+definition, Trigger definition, Constraint or Assertion definition. That is,
+``RESTRICT`` ensures that only a Module with no dependent Objects can be
+destroyed. If the Module is used by any other Object, ``DROP MODULE ...
+RESTRICT`` will fail.
 
 The effect of ``DROP MODULE`` <Module name> ``CASCADE``, e.g.:
 
@@ -299,23 +301,23 @@ Successfully dropping a Module has a three-fold effect:
 1. The Module named is destroyed.
 
 2. All Privileges held on the Module by the <AuthorizationID> that owns
-   it are revoked (by the SQL special grantor, "``_SYSTEM``") with a 
-   ``CASCADE`` revoke behaviour, so that all Privileges held on the Module by 
+   it are revoked (by the SQL special grantor, "``_SYSTEM``") with a
+   ``CASCADE`` revoke behaviour, so that all Privileges held on the Module by
    any other <AuthorizationID> are also revoked.
 
-3. All SQL routines, Triggers, Views and Constraints that depend on the 
+3. All SQL routines, Triggers, Views and Constraints that depend on the
    Module are dropped with a ``CASCADE`` drop behaviour.
 
 BEGIN ... END: compound Statement
 =================================
 
-Advance warning: ``BEGIN ... END`` has several optional clauses. We are going 
-to start with the simplest form, and examine the options in following sections. 
+Advance warning: ``BEGIN ... END`` has several optional clauses. We are going
+to start with the simplest form, and examine the options in following sections.
 
-In its simplest form, ``BEGIN ... END`` in SQL serves the same purpose as 
-"begin...end" in Pascal or "{...}" in C. ``BEGIN ... END`` encloses a sequence 
-of statements which are part of the same syntactical unit: a compound 
-statement. The simplest required syntax is: 
+In its simplest form, ``BEGIN ... END`` in SQL serves the same purpose as
+"begin...end" in Pascal or "{...}" in C. ``BEGIN ... END`` encloses a sequence
+of statements which are part of the same syntactical unit: a compound
+statement. The simplest required syntax is:
 
 ::
 
@@ -335,7 +337,7 @@ Here's a simple example:
 *ATOMIC Statements*
 -------------------
 
-A slightly more complicated form of a compound statement has one extra 
+A slightly more complicated form of a compound statement has one extra
 optional clause: ``[NOT] ATOMIC``. The required syntax is:
 
 ::
@@ -344,9 +346,9 @@ optional clause: ``[NOT] ATOMIC``. The required syntax is:
       [ <SQL statement>; ... ]
     END
 
-If ``ATOMIC`` is specified, the compound statement may not contain ``COMMIT`` 
-or ``ROLLBACK``. If you omit the clause, it defaults to ``NOT ATOMIC``: the 
-compound statement may contain ``COMMIT`` or ``ROLLBACK``. Here's an example: 
+If ``ATOMIC`` is specified, the compound statement may not contain ``COMMIT``
+or ``ROLLBACK``. If you omit the clause, it defaults to ``NOT ATOMIC``: the
+compound statement may contain ``COMMIT`` or ``ROLLBACK``. Here's an example:
 
 ::
 
@@ -355,14 +357,14 @@ compound statement may contain ``COMMIT`` or ``ROLLBACK``. Here's an example:
       INSERT INTO Table_2 VALUES (6);
    END
 
-We've already discussed the idea that transactions are atomic, and individual 
-SQL statements are atomic. Compound SQL statements can be atomic too, provided 
-that they are explicitly designated by the <keyword> ``ATOMIC``. Thus, in the 
-above example, if the first ``INSERT`` statement succeeds but the second 
-``INSERT`` statement fails, then the effects of the first ``INSERT`` is 
-cancelled. It's as if there was a savepoint at the beginning of the compound 
-statement and a ``ROLLBACK TO SAVEPOINT`` was executed when the second 
-``INSERT`` failed. 
+We've already discussed the idea that transactions are atomic, and individual
+SQL statements are atomic. Compound SQL statements can be atomic too, provided
+that they are explicitly designated by the <keyword> ``ATOMIC``. Thus, in the
+above example, if the first ``INSERT`` statement succeeds but the second
+``INSERT`` statement fails, then the effects of the first ``INSERT`` is
+cancelled. It's as if there was a savepoint at the beginning of the compound
+statement and a ``ROLLBACK TO SAVEPOINT`` was executed when the second
+``INSERT`` failed.
 
 *Variables*
 -----------
@@ -397,32 +399,32 @@ Here's an example:
 .. CAUTION::
 
    Don't get confused by the similarity to a <Column definition>. A
-   variable definition can contain ONLY a <data type> and (optionally) a 
-   ``DEFAULT`` clause. It cannot contain a <Domain name>, a <Constraint> or a 
+   variable definition can contain ONLY a <data type> and (optionally) a
+   ``DEFAULT`` clause. It cannot contain a <Domain name>, a <Constraint> or a
    ``COLLATE`` clause.
 
-In our example we defined five variables: ``v1, v2, v3, v4, v5``. ``BEGIN ... 
-END`` defines a "local scope", which means that *(a)* these variable names have 
-no meaning outside the compound statement, *(b)* the values in these variables 
-are not saved when the compound statement ends and *(c)* the values in these 
-variables are not reset by execution of a ``ROLLBACK`` statement, because 
-variables are not part of the database. 
+In our example we defined five variables: ``v1, v2, v3, v4, v5``. ``BEGIN ...
+END`` defines a "local scope", which means that *(a)* these variable names have
+no meaning outside the compound statement, *(b)* the values in these variables
+are not saved when the compound statement ends and *(c)* the values in these
+variables are not reset by execution of a ``ROLLBACK`` statement, because
+variables are not part of the database.
 
-The example uses the first four variables as targets in a singleton ``SELECT`` 
-statement. It also uses all five variables as sources in an ``INSERT`` 
-statement. Variables can be used in all sorts of <value expression>s. Variables 
-are extremely useful for temporary storage, and it's a wonder that most SQL 
-implementations get along without them. The designers of SQL don't give us the 
-option of using variables for persistent storage: we're supposed to use Base 
-tables for that. 
+The example uses the first four variables as targets in a singleton ``SELECT``
+statement. It also uses all five variables as sources in an ``INSERT``
+statement. Variables can be used in all sorts of <value expression>s. Variables
+are extremely useful for temporary storage, and it's a wonder that most SQL
+implementations get along without them. The designers of SQL don't give us the
+option of using variables for persistent storage: we're supposed to use Base
+tables for that.
 
 *Assignment Statements*
 -----------------------
 
-Assignment statements begin with the <keyword> ``SET`` -- but don't call them 
-"``SET`` statements", to avoid confusion with non-PSM statements that also 
-begin with ``SET``. Assignment statements are syntactically similar to the 
-``SET`` clauses used in ``UPDATE`` statements. Here is the required syntax: 
+Assignment statements begin with the <keyword> ``SET`` -- but don't call them
+"``SET`` statements", to avoid confusion with non-PSM statements that also
+begin with ``SET``. Assignment statements are syntactically similar to the
+``SET`` clauses used in ``UPDATE`` statements. Here is the required syntax:
 
 ::
 
@@ -459,7 +461,7 @@ clause: a Cursor declaration list. The required syntax is:
       [ <SQL statement>; ... ]
     END
 
-The mechanics of Cursors are the same for PSM as they are for embedded SQL 
+The mechanics of Cursors are the same for PSM as they are for embedded SQL
 and for SQL/CLI. Here's an example:
 
 ::
@@ -476,7 +478,7 @@ and for SQL/CLI. Here's an example:
 
 Objects that you declare in a compound statement have "local scope", so the
 <Cursor name> in this example -- ``cc`` -- can only be  used by SQL statements
-within the ``BEGIN ... END``. The example could be replaced with this SQL 
+within the ``BEGIN ... END``. The example could be replaced with this SQL
 statement:
 
 ::
@@ -488,10 +490,10 @@ if there is only one row in ``TABLE_1``.
 *Conditions*
 ------------
 
-A slightly more complicated form of a compound statement changes the optional 
-variable declaration clause: instead of a variable declaration list, ``BEGIN 
-... END`` actually allows a variable or condition declaration list, so that you 
-can declare conditions as well as variables. The required syntax is: 
+A slightly more complicated form of a compound statement changes the optional
+variable declaration clause: instead of a variable declaration list, ``BEGIN
+... END`` actually allows a variable or condition declaration list, so that you
+can declare conditions as well as variables. The required syntax is:
 
 ::
 
@@ -531,7 +533,7 @@ Here's an example of the latest form of ``BEGIN ... END``:
      INSERT INTO Table_2 VALUES (1);               /* statement */
    END
 
-In this example, we have simply given condition names to three of the 
+In this example, we have simply given condition names to three of the
 possible ``SQLSTATE`` values.
 
 *Handlers*
@@ -557,7 +559,7 @@ clause: a handler declaration list. The required syntax is:
          <handler action> ::= <SQL statement>
 
          <condition value list> ::= <condition value> [ {,<condition value>}... ]
-         
+
              <condition value> ::=
              <sqlstate value>|
              <condition name>|
@@ -584,29 +586,29 @@ value, the second is for a condition name and the third is for any warning
     INSERT INTO Table_2 VALUES (v1);               /* statement */
   END
 
-To see the effect of these handlers, consider what will happen with the SQL 
+To see the effect of these handlers, consider what will happen with the SQL
 statement:
 
 ::
 
    INSERT INTO Table_1 VALUES (99999);
 
-If this SQL statement fails due to overflow, then variable ``v1`` gets 
-``'Ovflw'``; if it fails due to an integrity Constraint violation, then 
-variable ``v1`` gets ``'c-err'``; if it succeeds but there is some warning, 
-then variable ``v1`` gets ``'?????'``. But, regardless, play continues because 
-all the handlers are ``CONTINUE`` handlers. So the second ``INSERT`` statement 
-will put in one of the values ``'Ovflw'``, ``'c-err'``, ``'?????'`` or 
-``'Okay!'`` (``'Okay!'`` is the default value for ``v1`` so this is what goes 
-in if the result of the first ``INSERT`` is success with no warnings). 
+If this SQL statement fails due to overflow, then variable ``v1`` gets
+``'Ovflw'``; if it fails due to an integrity Constraint violation, then
+variable ``v1`` gets ``'c-err'``; if it succeeds but there is some warning,
+then variable ``v1`` gets ``'?????'``. But, regardless, play continues because
+all the handlers are ``CONTINUE`` handlers. So the second ``INSERT`` statement
+will put in one of the values ``'Ovflw'``, ``'c-err'``, ``'?????'`` or
+``'Okay!'`` (``'Okay!'`` is the default value for ``v1`` so this is what goes
+in if the result of the first ``INSERT`` is success with no warnings).
 
-What if exception ``'42000'`` happens? That would be an "unhandled exception" 
-since we did not define a handler for exception ``'42000'``. The result would 
-be that the second ``INSERT`` is not attempted -- the whole compound statement 
-fails. 
+What if exception ``'42000'`` happens? That would be an "unhandled exception"
+since we did not define a handler for exception ``'42000'``. The result would
+be that the second ``INSERT`` is not attempted -- the whole compound statement
+fails.
 
-The following chart compares the exception-handling features of embedded SQL, 
-the CLI and the PSM. 
+The following chart compares the exception-handling features of embedded SQL,
+the CLI and the PSM.
 
 +--------------------------------+-----------------------+----------+---------------------+
 |                                | **EMBEDDED SQL**      | **CLI**  | **PSM**             |
@@ -624,8 +626,8 @@ the CLI and the PSM.
 | handles specific status codes? | no                    | N/A      | yes                 |
 +--------------------------------+-----------------------+----------+---------------------+
 
-Among the SQL statements that a handler can execute are two new special 
-ones: the ``SIGNAL`` statement and the ``RESIGNAL`` statement. These SQL 
+Among the SQL statements that a handler can execute are two new special
+ones: the ``SIGNAL`` statement and the ``RESIGNAL`` statement. These SQL
 statements affect the diagnostics area.
 
 *Labels*
@@ -667,13 +669,13 @@ statements, which we will discuss later. Here's an example:
 
 This is our final version of ``BEGIN .. END``. It looks quite imposing. That's
 because MOST SYNTACTIC ITEMS ARE LOCAL TO THE COMPOUND STATEMENT. Therefore
-everything is within the compound statement and, by contrast, the Module 
+everything is within the compound statement and, by contrast, the Module
 definition is trivial.
 
 SIGNAL Statement
 ================
 
-The ``SIGNAL`` statement is used to clear the diagnostics area. The required 
+The ``SIGNAL`` statement is used to clear the diagnostics area. The required
 syntax for the ``SIGNAL`` statement is:
 
 ::
@@ -688,21 +690,21 @@ syntax for the ``SIGNAL`` statement is:
           <condition information item name> = <simple value specification>
 
 The ``SIGNAL`` statement clears every record in the diagnostics area. The end
-result is a record containing the passed condition name or ``sqlstate`` 
-value. If you include the optional ``SET`` clause, your DBMS effectively 
+result is a record containing the passed condition name or ``sqlstate``
+value. If you include the optional ``SET`` clause, your DBMS effectively
 executes:
 
 ::
 
    RESIGNAL <signal information item list>;
 
-Note: You'll find the list of <condition information item name>s in our 
+Note: You'll find the list of <condition information item name>s in our
 chapter on embedded SQL -- see the ``GET DIAGNOSTICS`` statement.
 
 RESIGNAL Statement
 ==================
 
-The ``RESIGNAL`` statement is used to pass conditions on to another handler. 
+The ``RESIGNAL`` statement is used to pass conditions on to another handler.
 The required syntax for the ``RESIGNAL`` statement is:
 
 ::
@@ -723,10 +725,10 @@ first condition area in the diagnostics area is changed to the value indicated.
 -----------------
 
 Essential SQL has almost nothing that can control the program flow (except for
-the ``CALL`` and ``RETURN`` statements which are associated with SQL 
-routines). By contrast, a DBMS with PSM support will allow eight control 
-statements. Of these, seven are similar to statements which appear in other 
-languages. The eighth, ``FOR``, depends on Objects which are unique to the 
+the ``CALL`` and ``RETURN`` statements which are associated with SQL
+routines). By contrast, a DBMS with PSM support will allow eight control
+statements. Of these, seven are similar to statements which appear in other
+languages. The eighth, ``FOR``, depends on Objects which are unique to the
 SQL environment. Here's a list of these statements:
 
 * ``CASE`` -- Switch depending on condition.
@@ -748,8 +750,8 @@ SQL environment. Here's a list of these statements:
 *CASE Statement*
 ----------------
 
-The ``CASE`` statement is useful for switching between possible execution 
-paths. There are two forms -- one contains search conditions, the other 
+The ``CASE`` statement is useful for switching between possible execution
+paths. There are two forms -- one contains search conditions, the other
 contains value expressions. The required syntax for the ``CASE`` statement is:
 
 ::
@@ -769,9 +771,9 @@ contains value expressions. The required syntax for the ``CASE`` statement is:
     END CASE
 
 A "simple ``CASE`` statement" is merely a shorthand, and may be replaced by a
-"searched ``CASE`` statement" which has the form: "``CASE WHEN`` <when 
-value> = <case value> ...". Thus, the following examples, showing a searched 
-``CASE`` statement on the left and a simple ``CASE`` statement on the right, 
+"searched ``CASE`` statement" which has the form: "``CASE WHEN`` <when
+value> = <case value> ...". Thus, the following examples, showing a searched
+``CASE`` statement on the left and a simple ``CASE`` statement on the right,
 are exactly equivalent:
 
 ::
@@ -784,13 +786,13 @@ are exactly equivalent:
      ELSE INSERT INTO t VALUES (0);      ELSE INSERT INTO t VALUES (0);
    END CASE                            END CASE
 
-When executing a ``CASE`` statement, the DBMS goes through the ``WHEN`` clauses 
-from top to bottom, looking for a ``TRUE`` condition. If it finds one, it 
-executes the statement(s) after ``THEN``, and the ``CASE`` terminates. If it 
-finds none, it executes the statements(s) after ``ELSE`` -- or, if there is no 
-``ELSE``, returns this ``SQLSTATE error: 20000 "case not found for case 
-statement"``. For the above example, then, if the value of ``parameter_value`` 
-is 5, then the DBMS will execute this SQL statement: 
+When executing a ``CASE`` statement, the DBMS goes through the ``WHEN`` clauses
+from top to bottom, looking for a ``TRUE`` condition. If it finds one, it
+executes the statement(s) after ``THEN``, and the ``CASE`` terminates. If it
+finds none, it executes the statements(s) after ``ELSE`` -- or, if there is no
+``ELSE``, returns this ``SQLSTATE error: 20000 "case not found for case
+statement"``. For the above example, then, if the value of ``parameter_value``
+is 5, then the DBMS will execute this SQL statement:
 
 ::
 
@@ -800,14 +802,14 @@ is 5, then the DBMS will execute this SQL statement:
 
    The syntax for the ``CASE`` statement is somewhat different from the
    syntax for the SQL ``CASE`` expression (see our chapter on simple search
-   conditions). In particular, the ``CASE`` statement has no equivalent for 
-   the ``ELSE NULL`` clause, and the terminator is ``END CASE`` rather than 
+   conditions). In particular, the ``CASE`` statement has no equivalent for
+   the ``ELSE NULL`` clause, and the terminator is ``END CASE`` rather than
    ``END``.
 
 *IF Statement*
 --------------
 
-The ``IF`` statement is useful for simple "if (x) then (do this)" situations. 
+The ``IF`` statement is useful for simple "if (x) then (do this)" situations.
 The required syntax for the ``IF`` statement is:
 
 ::
@@ -825,14 +827,14 @@ Here's an example:
        5=5 THEN UPDATE Table_1 SET column_1 = column_1 + 1;
       END IF
 
-In this example, the search condition is ``TRUE``, so the ``UPDATE`` 
-statement will be executed. If the search condition had been ``FALSE`` or 
+In this example, the search condition is ``TRUE``, so the ``UPDATE``
+statement will be executed. If the search condition had been ``FALSE`` or
 ``UNKNOWN``, then the ``UPDATE`` statement would not have been executed.
 
 *LOOP Statement*
 ----------------
 
-The ``LOOP`` statement is useful for repeated execution of SQL statements. The 
+The ``LOOP`` statement is useful for repeated execution of SQL statements. The
 required syntax for the ``LOOP`` statement is:
 
 ::
@@ -842,8 +844,8 @@ required syntax for the ``LOOP`` statement is:
        <SQL statement>(s)
     END LOOP [ <end_label> ]
 
-The SQL statements between ``LOOP`` and ``END LOOP`` are repeated until the 
-loop finishes. The <beginning_label> and the <end_label> must be equivalent, 
+The SQL statements between ``LOOP`` and ``END LOOP`` are repeated until the
+loop finishes. The <beginning_label> and the <end_label> must be equivalent,
 if you use them both. Here's an example:
 
 ::
@@ -852,13 +854,13 @@ if you use them both. Here's an example:
       SET x = x + 1;
    END LOOP
 
-This example shows an infinite loop. The usual way to exit from a loop is 
+This example shows an infinite loop. The usual way to exit from a loop is
 with the ``LEAVE`` statement.
 
 *LEAVE Statement*
 -----------------
 
-The ``LEAVE`` statement is useful for exiting a block or for exiting a loop. 
+The ``LEAVE`` statement is useful for exiting a block or for exiting a loop.
 The required syntax for the ``LEAVE`` statement is:
 
 LEAVE <statement_label>
@@ -878,8 +880,8 @@ In this example, the loop will be exited once the value of x passes 1000.
 *WHILE statement*
 -----------------
 
-The ``WHILE`` statement is useful for repeated execution of SQL statements, 
-with a built-in equivalent to the ``LEAVE`` statement. The required syntax 
+The ``WHILE`` statement is useful for repeated execution of SQL statements,
+with a built-in equivalent to the ``LEAVE`` statement. The required syntax
 for the ``WHILE`` statement is:
 
 ::
@@ -889,9 +891,9 @@ for the ``WHILE`` statement is:
        <SQL statement>(s)
     END WHILE [ <end_label> ]
 
-As long as the <search condition> is ``TRUE``, the SQL statements between 
-``WHILE`` and ``END WHILE`` are repeatedly executed. The <beginning_label> 
-and the <end_label> must be equivalent, if you use them both. Here's an 
+As long as the <search condition> is ``TRUE``, the SQL statements between
+``WHILE`` and ``END WHILE`` are repeatedly executed. The <beginning_label>
+and the <end_label> must be equivalent, if you use them both. Here's an
 example:
 
 ::
@@ -900,15 +902,15 @@ example:
       SET x = x + 1;
    END WHILE
 
-This example will loop, incrementing ``x``, until ``x <= 1000`` is either 
-``FALSE`` or ``UNKNOWN``. If the <search condition> is ``FALSE`` or 
+This example will loop, incrementing ``x``, until ``x <= 1000`` is either
+``FALSE`` or ``UNKNOWN``. If the <search condition> is ``FALSE`` or
 ``UNKNOWN`` when the loop begins, then nothing happens.
 
 *REPEAT Statement*
 ------------------
 
 The ``REPEAT`` statement is much like the ``WHILE`` statement, except that the
-condition is tested *after* the execution of the SQL statement(s). The 
+condition is tested *after* the execution of the SQL statement(s). The
 required syntax for the ``REPEAT`` statement is:
 
 ::
@@ -918,9 +920,9 @@ required syntax for the ``REPEAT`` statement is:
        <SQL statement>(s) UNTIL <search condition>
     END REPEAT [ <end_label> ]
 
-As long as the <search condition> is ``FALSE`` or ``UNKNOWN``, the SQL 
-statements between ``REPEAT`` and ``END REPEAT`` are repeatedly executed. 
-The <beginning_label> and the <end_label> must be equivalent, if you use 
+As long as the <search condition> is ``FALSE`` or ``UNKNOWN``, the SQL
+statements between ``REPEAT`` and ``END REPEAT`` are repeatedly executed.
+The <beginning_label> and the <end_label> must be equivalent, if you use
 them both. Here's an example:
 
 ::
@@ -931,8 +933,8 @@ them both. Here's an example:
       UNTIL x > 5
    END REPEAT
 
-In this example, the ``UPDATE`` statement will be repeated until ``x`` is 
-greater than 5 -- that is, the loop will repeat until after the condition is 
+In this example, the ``UPDATE`` statement will be repeated until ``x`` is
+greater than 5 -- that is, the loop will repeat until after the condition is
 ``TRUE``.
 
 .. CAUTION::
@@ -942,8 +944,8 @@ greater than 5 -- that is, the loop will repeat until after the condition is
 *FOR Statement*
 ---------------
 
-The ``FOR`` statement is useful for simplified ``FETCH`` loops. Execution 
-takes place for each row of a result set. The required syntax for the 
+The ``FOR`` statement is useful for simplified ``FETCH`` loops. Execution
+takes place for each row of a result set. The required syntax for the
 ``FOR`` statement is:
 
 ::
@@ -975,7 +977,7 @@ languages.
 *ITERATE Statement*
 -------------------
 
-The ``ITERATE`` statement is useful for "re-starting": going back to the 
+The ``ITERATE`` statement is useful for "re-starting": going back to the
 beginning of the list of statements inside a loop, and proceeding with the next
 iteration of the loop. The required syntax for the ``ITERATE`` statement is:
 
@@ -983,13 +985,13 @@ iteration of the loop. The required syntax for the ``ITERATE`` statement is:
 
    ITERATE <statement_label>
 
-The ``ITERATE`` statement can appear only within an "iterated SQL statement" -- 
-that is, within ``LOOP``, ``WHILE``, ``REPEAT`` or ``FOR``). The 
-<statement_label> must be the <beginning_label> of the iterated SQL statement. 
-If the iteration condition for the iterated SQL statement is ``TRUE``, or if 
-the statement doesn't have an iteration condition, ``ITERATE`` causes the next 
-iteration of the loop to start. If the iteration condition is ``FALSE`` or 
-``UNKNOWN``, ``ITERATE`` causes the loop to end. Here's an example: 
+The ``ITERATE`` statement can appear only within an "iterated SQL statement" --
+that is, within ``LOOP``, ``WHILE``, ``REPEAT`` or ``FOR``). The
+<statement_label> must be the <beginning_label> of the iterated SQL statement.
+If the iteration condition for the iterated SQL statement is ``TRUE``, or if
+the statement doesn't have an iteration condition, ``ITERATE`` causes the next
+iteration of the loop to start. If the iteration condition is ``FALSE`` or
+``UNKNOWN``, ``ITERATE`` causes the loop to end. Here's an example:
 
 ::
 
@@ -1008,7 +1010,7 @@ Should everything be in SQL?
 
 PSM is an extension package which makes SQL3 a reasonably complete language.
 There are still some things you can't do (such as disk or screen I/O), but
-anybody could write external-routine libraries which would plug the 
+anybody could write external-routine libraries which would plug the
 remaining gaps.
 
 So what?
@@ -1017,20 +1019,20 @@ For several years, programmers have written applications in "host languages"
 and invoked SQL statements either via embedded SQL or via the CLI. By now
 there is an awful lot of legacy code in those host languages. It has to be
 expected, too, that there are good host-language optimizers out there -- don't
-bother pitting C and SQL head-to-head with a "Sieve of Eratosthenes" 
+bother pitting C and SQL head-to-head with a "Sieve of Eratosthenes"
 benchmark. The SQL code would lose.
 
 On the other hand, we could say that:
 
-* Yes, SQL optimizers are inferior for low-level benchmarks, but they're 
-  better at the high level -- and you'd be helping SQL optimizers if 
-  you could pass them groups of SQL statements, rather than individual SQL 
+* Yes, SQL optimizers are inferior for low-level benchmarks, but they're
+  better at the high level -- and you'd be helping SQL optimizers if
+  you could pass them groups of SQL statements, rather than individual SQL
   statements.
 
 * A lot of programming effort is spent solving the "impedance mismatch"
   problem -- the fact that host languages don't store data the SQL way, or
   process sets the SQL way, or have the same ideas of access control. With
-  Modules inside the SQL environment, DBMSs can act in a consistent way across 
+  Modules inside the SQL environment, DBMSs can act in a consistent way across
   platforms.
 
 * Remote Data Access is feasible with SQL, but not with a host language.
@@ -1042,8 +1044,8 @@ Dialects
 ========
 
 PSM's features are vaguely similar to Oracle's PL/SQL, which also has: ``BEGIN
-... END``, ``LOOP``, ``WHILE``, and (using different keywords) assignment 
-statements and handlers. Informix SQL has a FOREACH statement, which does 
+... END``, ``LOOP``, ``WHILE``, and (using different keywords) assignment
+statements and handlers. Informix SQL has a FOREACH statement, which does
 the same thing as the standard ``FOR`` statement.
 
 Even if a vendor does not support any form of PSM, you may find that some of

--- a/docs/chapters/27.rst
+++ b/docs/chapters/27.rst
@@ -4,40 +4,42 @@
 Chapter 27 -- User-defined Types
 ================================
 
+.. include:: ../_include/note.rst
+
 [Obscure Rule] applies for this entire chapter.
 
-SQL began life as a procedurally oriented language, or -- properly speaking -- 
-as a language with procedures that worked on sets. Nowadays the rage is for 
-object oriented languages -- like C++ and Java. The popularity of object 
-orientation ("OO" for short) has been so great, that some have attempted to 
-supersede SQL with pure "OO DBMSs" (POET is an example). On the other hand, a 
-great deal of time and trouble has been invested getting SQL to where it is 
-today, so most users and experts have looked to a more moderate solution. 
-Namely: extending SQL so that it can handle databases the OO way, but without 
-abandoning the current language. We'll call this hybrid *object/relational*, or 
-O/R for short. 
+SQL began life as a procedurally oriented language, or -- properly speaking --
+as a language with procedures that worked on sets. Nowadays the rage is for
+object oriented languages -- like C++ and Java. The popularity of object
+orientation ("OO" for short) has been so great, that some have attempted to
+supersede SQL with pure "OO DBMSs" (POET is an example). On the other hand, a
+great deal of time and trouble has been invested getting SQL to where it is
+today, so most users and experts have looked to a more moderate solution.
+Namely: extending SQL so that it can handle databases the OO way, but without
+abandoning the current language. We'll call this hybrid *object/relational*, or
+O/R for short.
 
-The inspirations have come from languages like C++ and Object Pascal, which are 
-extensions of C and Pascal. Those extended languages have been successful. It 
-appears that there will be an equivalent success for the Object Oriented SQL 
-extensions, once DBMS vendors implement them and users get acquainted with 
-them. 
+The inspirations have come from languages like C++ and Object Pascal, which are
+extensions of C and Pascal. Those extended languages have been successful. It
+appears that there will be an equivalent success for the Object Oriented SQL
+extensions, once DBMS vendors implement them and users get acquainted with
+them.
 
-We're not at that stage yet. What you're going to read about in this chapter is 
-the very latest stuff, just accepted as part of the SQL Standard, and still 
-quite wet around the edges. Since that's so, we will depart from the usual 
-chapter organization. The first parts of this chapter are merely a tutorial 
-which (we hope) you'll find is fairly light reading, peppered with liberating 
-slogans like "a type is a class" or "a row is an object". The middle parts of 
-this chapter are more of a syntactical slog as we get into the details of 
-``CREATE TYPE`` and the various SQL statements associated with it; however, we 
-have omitted some details which we think will not be part of real DBMS 
-implementations for some years. 
+We're not at that stage yet. What you're going to read about in this chapter is
+the very latest stuff, just accepted as part of the SQL Standard, and still
+quite wet around the edges. Since that's so, we will depart from the usual
+chapter organization. The first parts of this chapter are merely a tutorial
+which (we hope) you'll find is fairly light reading, peppered with liberating
+slogans like "a type is a class" or "a row is an object". The middle parts of
+this chapter are more of a syntactical slog as we get into the details of
+``CREATE TYPE`` and the various SQL statements associated with it; however, we
+have omitted some details which we think will not be part of real DBMS
+implementations for some years.
 
-If you've ever used an object oriented language, you'll find the concepts are 
-familiar (which they're supposed to be -- that's the point). However, you must 
-start with a good recollection of the earlier chapters on <data type>s, 
-procedures and SQL syntax. 
+If you've ever used an object oriented language, you'll find the concepts are
+familiar (which they're supposed to be -- that's the point). However, you must
+start with a good recollection of the earlier chapters on <data type>s,
+procedures and SQL syntax.
 
 .. rubric:: Table of Contents
 
@@ -57,39 +59,39 @@ easy to use as predefined data types; however, they are a lot harder to set up.
 Just consider some of the things which are already handled for you (programmed
 in the DBMS) if you use a predefined data type:
 
-* There's a way of storing the data physically in a Table (this is the concept 
-  of *instantiation*, which we'll have some trouble with later). 
+* There's a way of storing the data physically in a Table (this is the concept
+  of *instantiation*, which we'll have some trouble with later).
 
-* There are comparison operations for the <data type>s, so you can tell whether 
-  two values are the same, or one is greater than the other (this is the 
-  concept of *ordering*). 
+* There are comparison operations for the <data type>s, so you can tell whether
+  two values are the same, or one is greater than the other (this is the
+  concept of *ordering*).
 
-* There are built-in operators for the <data type>s, for example ``+`` is used 
-  to add to numbers together and produce another number (this is the concept 
+* There are built-in operators for the <data type>s, for example ``+`` is used
+  to add to numbers together and produce another number (this is the concept
   of *methods* that change values of certain data types).
 
-* There are cast operations so that values in one <data type> can be 
-  converted to another, or interchanged with host language variables (this is 
+* There are cast operations so that values in one <data type> can be
+  converted to another, or interchanged with host language variables (this is
   the concept of *cast methods and transforms*).
 
-With UDTs, you're on your own in all these cases. When you make a UDT, 
-you're going to have to remember that all those things won't be there, 
+With UDTs, you're on your own in all these cases. When you make a UDT,
+you're going to have to remember that all those things won't be there,
 unless you put them there yourself.
 
-However, when you do it, you'll end up with a <data type> that's just as 
-good as the predefined types. You'll be able to use your new UDT wherever 
+However, when you do it, you'll end up with a <data type> that's just as
+good as the predefined types. You'll be able to use your new UDT wherever
 you could use a predefined type before.
 
-A Schema may contain zero or more UDTs. An SQL UDT is a named, user-defined set 
-of valid values. UDTs are dependent on some Schema -- the <UDT name> must be 
-unique within the Schema the UDT belongs to (it may not be the same as any 
-<Domain name> in its Schema either) -- and are created, altered and dropped 
-using standard SQL statements. The Objects that may belong to a UDT are known 
-as Attributes; they depend on some UDT. 
+A Schema may contain zero or more UDTs. An SQL UDT is a named, user-defined set
+of valid values. UDTs are dependent on some Schema -- the <UDT name> must be
+unique within the Schema the UDT belongs to (it may not be the same as any
+<Domain name> in its Schema either) -- and are created, altered and dropped
+using standard SQL statements. The Objects that may belong to a UDT are known
+as Attributes; they depend on some UDT.
 
-A UDT can be either a distinct type -- a UDT that is based on a single 
-predefined <data type> -- or a structured type -- a UDT that is based on a list 
-of Attribute definitions. 
+A UDT can be either a distinct type -- a UDT that is based on a single
+predefined <data type> -- or a structured type -- a UDT that is based on a list
+of Attribute definitions.
 
 A UDT is defined by a descriptor that contains twelve pieces of information:
 
@@ -101,14 +103,14 @@ A UDT is defined by a descriptor that contains twelve pieces of information:
 
 4. The UDT's ordering category: either ``RELATIVE``, ``HASH`` or ``STATE``.
 
-5. The <specific routine designator> that identifies the UDT's ordering 
+5. The <specific routine designator> that identifies the UDT's ordering
    function.
 
-6. If the UDT is a direct subtype of one or more other UDTs, then the names 
+6. If the UDT is a direct subtype of one or more other UDTs, then the names
    of those UDTs.
 
-7. If the UDT is a distinct type, then the descriptor of the <data type> 
-   it's based on; otherwise an Attribute descriptor for each of the UDT's 
+7. If the UDT is a distinct type, then the descriptor of the <data type>
+   it's based on; otherwise an Attribute descriptor for each of the UDT's
    Attributes.
 
 8. The UDT's degree: the number of its Attributes.
@@ -119,14 +121,14 @@ A UDT is defined by a descriptor that contains twelve pieces of information:
 
 11. The UDT's Transform descriptor.
 
-12. If the UDT's definition includes a method signature list, a descriptor 
+12. If the UDT's definition includes a method signature list, a descriptor
     for each method signature named.
 
 To create a UDT, use the ``CREATE TYPE`` statement (either as a stand-alone SQL
-statement or within a ``CREATE SCHEMA`` statement). ``CREATE TYPE`` 
-specifies the enclosing Schema, names the UDT and identifies the UDT's set 
-of valid values. To destroy a UDT, use the ``DROP TYPE`` statement. None of 
-SQL3's UDT syntax is Core SQL, so if you want to restrict your code to Core 
+statement or within a ``CREATE SCHEMA`` statement). ``CREATE TYPE``
+specifies the enclosing Schema, names the UDT and identifies the UDT's set
+of valid values. To destroy a UDT, use the ``DROP TYPE`` statement. None of
+SQL3's UDT syntax is Core SQL, so if you want to restrict your code to Core
 SQL, don't use UDTs.
 
 *UDT Names*
@@ -139,18 +141,18 @@ A <UDT name> identifies a UDT. The required syntax for a <UDT name> is:
     <UDT name> ::=
     [ <Schema name>. ] unqualified name
 
-A <UDT name> is a <regular identifier> or a <delimited identifier> that is 
-unique (for all Domains and UDTs) within the Schema it belongs to. The <Schema 
-name> which qualifies a <UDT name> names the Schema that the UDT belongs to and 
-can either be explicitly stated, or a default will be supplied by your DBMS as 
-follows: 
+A <UDT name> is a <regular identifier> or a <delimited identifier> that is
+unique (for all Domains and UDTs) within the Schema it belongs to. The <Schema
+name> which qualifies a <UDT name> names the Schema that the UDT belongs to and
+can either be explicitly stated, or a default will be supplied by your DBMS as
+follows:
 
-* If a <UDT name> in a ``CREATE SCHEMA`` statement isn't qualified, the default 
+* If a <UDT name> in a ``CREATE SCHEMA`` statement isn't qualified, the default
   qualifier is the name of the Schema you're creating.
 
-* If the unqualified <UDT name> is found in any other SQL statement in a 
+* If the unqualified <UDT name> is found in any other SQL statement in a
   Module, the default qualifier is the name of the Schema identified in the
-  ``SCHEMA`` clause or ``AUTHORIZATION`` clause of the ``MODULE`` statement 
+  ``SCHEMA`` clause or ``AUTHORIZATION`` clause of the ``MODULE`` statement
   that defines that Module.
 
 UDT Example
@@ -167,26 +169,26 @@ Here's an example of a UDT definition:
     NOT FINAL                              -- this is a mandatory Finality Clause
     METHOD profit( ) RETURNS DECIMAL(9,2); -- profit is a method, defined later
 
-This ``CREATE TYPE`` statement results in a UDT named ``BOOK_UDT``. The 
-components of the UDT are three attributes (named ``TITLE``, ``BUYING_PRICE`` 
-and ``SELLING_PRICE``) and one method (named ``PROFIT``). 
+This ``CREATE TYPE`` statement results in a UDT named ``BOOK_UDT``. The
+components of the UDT are three attributes (named ``TITLE``, ``BUYING_PRICE``
+and ``SELLING_PRICE``) and one method (named ``PROFIT``).
 
 1. The three name-and-data-type pairs ``title CHAR(40)`` and ``buying_price
-   DECIMAL(9,2)`` and ``selling_price DECIMAL(9,2)`` are the UDT's Attribute 
+   DECIMAL(9,2)`` and ``selling_price DECIMAL(9,2)`` are the UDT's Attribute
    definitions.
 
 2. The words ``NOT FINAL`` matter only for subtyping, which we'll get to
-   later. Briefly, though, if a UDT definition doesn't include an ``UNDER`` 
+   later. Briefly, though, if a UDT definition doesn't include an ``UNDER``
    clause, the finality clause must specify ``NOT FINAL``.
 
-3. The clause ``METHOD profit () RETURNS DECIMAL (9,2)`` is a teaser. Like 
-   an Attribute, a "method" is a component of a UDT. However, this method -- 
-   ``PROFIT`` -- is actually a declaration that a function named ``PROFIT 
-   exists``. This function isn't defined further in the UDT definition -- there 
-   is a separate SQL statement for defining functions: ``CREATE METHOD``. All 
-   we can see at this stage is that ``PROFIT`` has a name and a (predefined) 
-   data type>, just as regular Attributes do. Some people would call ``PROFIT`` 
-   a "derived Attribute". 
+3. The clause ``METHOD profit () RETURNS DECIMAL (9,2)`` is a teaser. Like
+   an Attribute, a "method" is a component of a UDT. However, this method --
+   ``PROFIT`` -- is actually a declaration that a function named ``PROFIT
+   exists``. This function isn't defined further in the UDT definition -- there
+   is a separate SQL statement for defining functions: ``CREATE METHOD``. All
+   we can see at this stage is that ``PROFIT`` has a name and a (predefined)
+   data type>, just as regular Attributes do. Some people would call ``PROFIT``
+   a "derived Attribute".
 
 Columns Based on UDTs
 =====================
@@ -217,15 +219,15 @@ To understand the above compound statement, you'll need to look closely at the
 declaration and the four function calls that precede the ``INSERT`` statement.
 They are simple things, but the terminology is fancy.
 
-**First:** ``DECLARE u book_udt;`` is a declaration of a temporary variable 
-named ``u``. Nothing new about that (if you remember your PSM chapter), but it 
-shows that variables too can be based on UDTs instead of predefined <data 
-type>s. 
+**First:** ``DECLARE u book_udt;`` is a declaration of a temporary variable
+named ``u``. Nothing new about that (if you remember your PSM chapter), but it
+shows that variables too can be based on UDTs instead of predefined <data
+type>s.
 
-**Second:** ``u = book_udt();`` is a constructor function. The function we're 
-calling is named ``BOOK_UDT``, the same as the UDT. That's not a coincidence. 
-The DBMS's job is to create a constructor function automatically. When the 
-``CREATE TYPE book_udt1`` was executed, this SQL statement happened implicitly: 
+**Second:** ``u = book_udt();`` is a constructor function. The function we're
+calling is named ``BOOK_UDT``, the same as the UDT. That's not a coincidence.
+The DBMS's job is to create a constructor function automatically. When the
+``CREATE TYPE book_udt1`` was executed, this SQL statement happened implicitly:
 
 ::
 
@@ -234,17 +236,17 @@ The DBMS's job is to create a constructor function automatically. When the
    ...
    RETURN V
 
-In this ``CREATE FUNCTION`` statement, the ``RETURN V``, is a value of type 
-``BOOK_UDT1``, with all Attribute instance values equal to their default! What 
-does that mean? It means that when we call the ``BOOK_UDT1`` function, the 
-return is a "default value" of the ``BOOK_UDT1`` type. That's useful, so it's 
-good to know that the DBMS makes a constructor function for every UDT. 
+In this ``CREATE FUNCTION`` statement, the ``RETURN V``, is a value of type
+``BOOK_UDT1``, with all Attribute instance values equal to their default! What
+does that mean? It means that when we call the ``BOOK_UDT1`` function, the
+return is a "default value" of the ``BOOK_UDT1`` type. That's useful, so it's
+good to know that the DBMS makes a constructor function for every UDT.
 
-**Third:** ``u.title('The Compleat SQL');`` is a mutator function. The function 
-we're calling is named ``TITLE``, the same as the first Attribute in the UDT. 
-Once again, this is not a coincidence. The DBMS's job is to create a mutator 
-function automatically. When the ``CREATE TYPE book_udt1`` was executed, this 
-SQL statement also happened implicitly: 
+**Third:** ``u.title('The Compleat SQL');`` is a mutator function. The function
+we're calling is named ``TITLE``, the same as the first Attribute in the UDT.
+Once again, this is not a coincidence. The DBMS's job is to create a mutator
+function automatically. When the ``CREATE TYPE book_udt1`` was executed, this
+SQL statement also happened implicitly:
 
 ::
 
@@ -257,55 +259,55 @@ SQL statement also happened implicitly:
          CONTAINS SQL
          RETURN NULL ON NULL INPUT
 
-This statement defines a "method" (or "method function") because it is a 
-component of a UDT. To invoke the method, we just have to say "<udt 
-instance>.<method name> ( <new value> )" and the new value is a ``CHAR(40)`` 
-string, which is compatible with the Attribute's definition. The reason that 
-this method is called a mutator function is that it changes the value in the 
-object instance. So now the title in ``u`` is ``'The Compleat SQL'``. 
+This statement defines a "method" (or "method function") because it is a
+component of a UDT. To invoke the method, we just have to say "<udt
+instance>.<method name> ( <new value> )" and the new value is a ``CHAR(40)``
+string, which is compatible with the Attribute's definition. The reason that
+this method is called a mutator function is that it changes the value in the
+object instance. So now the title in ``u`` is ``'The Compleat SQL'``.
 
-You might wonder: why all the fuss? If the whole point is to set ``U.TITLE`` to 
-a value, why not just: 
+You might wonder: why all the fuss? If the whole point is to set ``U.TITLE`` to
+a value, why not just:
 
 ::
 
    SET u.title = 'The Compleat SQL';      /* not a good idea! */
 
-Using a ``SET`` statement like this would violate an object-oriented principle 
-called "encapsulation", according to which: the only access to Attributes is 
-via their functions (methods) -- so ``SET`` is not legal. If you're used to 
-Windows programming, you'll see the benefits of encapsulation: nothing can 
-access the storage except pre-approved routines which change if the storage 
-method changes. 
+Using a ``SET`` statement like this would violate an object-oriented principle
+called "encapsulation", according to which: the only access to Attributes is
+via their functions (methods) -- so ``SET`` is not legal. If you're used to
+Windows programming, you'll see the benefits of encapsulation: nothing can
+access the storage except pre-approved routines which change if the storage
+method changes.
 
-**Fourth and fifth:** ``u.buying_price(10.00;`` and ``u.selling_price(20.00);`` 
-are two more mutator functions. When the UDT was created, the DBMS made methods 
-for ``BUYING_PRICE`` and ``FOR SELLING_PRICE`` too, just as it must do for 
-every Attribute in a UDT. 
+**Fourth and fifth:** ``u.buying_price(10.00;`` and ``u.selling_price(20.00);``
+are two more mutator functions. When the UDT was created, the DBMS made methods
+for ``BUYING_PRICE`` and ``FOR SELLING_PRICE`` too, just as it must do for
+every Attribute in a UDT.
 
-The bottom line is: constructor functions are the ordinary way to make new 
-instances of UDTs; mutator functions are the ordinary way to change Attributes 
-in UDT instances. Using the constructor and the mutators, we have been able to 
-set up a fully-initialized UDT instance -- ``u`` -- with the contents we want. 
+The bottom line is: constructor functions are the ordinary way to make new
+instances of UDTs; mutator functions are the ordinary way to change Attributes
+in UDT instances. Using the constructor and the mutators, we have been able to
+set up a fully-initialized UDT instance -- ``u`` -- with the contents we want.
 
-**Sixth:** ``INSERT INTO T VALUES (u,1);`` is dénouement. Clearly, it puts a 
-value into Table ``T``. What the value looks like, we have no idea: it's 
-encapsulated. We do know, though, that what we put in was {``'The Compleat 
-SQL', 10.00, 20.00``}. Insertion phase complete. 
+**Sixth:** ``INSERT INTO T VALUES (u,1);`` is dénouement. Clearly, it puts a
+value into Table ``T``. What the value looks like, we have no idea: it's
+encapsulated. We do know, though, that what we put in was {``'The Compleat
+SQL', 10.00, 20.00``}. Insertion phase complete.
 
-Let us now get something back out of the UDT. You've probably guessed already 
-that we aren't going to just say: 
+Let us now get something back out of the UDT. You've probably guessed already
+that we aren't going to just say:
 
 ::
 
    SELECT book_column, serial_number
    FROM   T;
 
-To retrieve from a UDT, we need yet another function -- the opposite of a 
-mutator -- to get the Attribute values out of ``BOOK_COLUMN`` into a 
-representation that we can read. Such a function is called an *observer 
-function* and, once again, the DBMS makes observer functions implicitly at the 
-time that a UDT is created -- one for each Attribute, like this: 
+To retrieve from a UDT, we need yet another function -- the opposite of a
+mutator -- to get the Attribute values out of ``BOOK_COLUMN`` into a
+representation that we can read. Such a function is called an *observer
+function* and, once again, the DBMS makes observer functions implicitly at the
+time that a UDT is created -- one for each Attribute, like this:
 
 ::
 
@@ -327,18 +329,18 @@ Since the observer method exists to help us get values out, we can use them in
    FROM   T
    WHERE  serial_number > 0;
 
-In summary, these are the functions associated with our example ``UDT 
+In summary, these are the functions associated with our example ``UDT
 BOOK_UDT``:
 
 * One constructor function, named ``BOOK_UDT``.
 
-* Three mutator functions, named ``TITLE``, ``BUYING_PRICE`` and 
+* Three mutator functions, named ``TITLE``, ``BUYING_PRICE`` and
   ``SELLING_PRICE``.
 
-* Three observer functions, also named ``TITLE``, ``BUYING_PRICE`` and 
-  ``SELLING_PRICE``. (Actually the above is only for the "default case", we'll 
-  worry about options later.) As the examples indicated, constructors and 
-  mutators and observers are all we need for simple storage and retrieval 
+* Three observer functions, also named ``TITLE``, ``BUYING_PRICE`` and
+  ``SELLING_PRICE``. (Actually the above is only for the "default case", we'll
+  worry about options later.) As the examples indicated, constructors and
+  mutators and observers are all we need for simple storage and retrieval
   operations.
 
 *Routine Names and Signatures*
@@ -347,7 +349,7 @@ BOOK_UDT``:
 One of the strengths of the Object/Relational system is that all the functions
 have the same name as the Attribute they're associated with, which makes them
 easy to remember. But at first there's a little confusion too! How do we tell
-them apart? If you look closely at these three references, you'll see the 
+them apart? If you look closely at these three references, you'll see the
 differences:
 
 * ``title`` -- the name of an Attribute.
@@ -356,27 +358,27 @@ differences:
 
 * ``title ('The Compleat SQL')`` -- the name of a mutator method.
 
-The DBMS distinguishes between names the same way that you do. The first 
-distinction is easy: if it's got parentheses after it, then it must be a 
-routine name. The next distinction is that ``title()`` has no arguments, while 
-``title('The Compleat SQL')`` has one argument. That's the difference between 
-an observer and a mutator. Let's express this latter distinction as a general 
-set of rules. 
+The DBMS distinguishes between names the same way that you do. The first
+distinction is easy: if it's got parentheses after it, then it must be a
+routine name. The next distinction is that ``title()`` has no arguments, while
+``title('The Compleat SQL')`` has one argument. That's the difference between
+an observer and a mutator. Let's express this latter distinction as a general
+set of rules.
 
 **Rule 1**
 
-It is legal for two routines to be "in the same name class" -- that is, two 
+It is legal for two routines to be "in the same name class" -- that is, two
 routines with the same name may be in the same Schema.
 
 **Rule 2**
 
-Routines are distinguishable by their category. The four categories are 
+Routines are distinguishable by their category. The four categories are
 "procedures", "functions" and two types of "method".
 
 **Rule 3**
 
-Routines in the same category are distinguishable by the count of 
-parameters, and the declared type of those parameters, in their parameter 
+Routines in the same category are distinguishable by the count of
+parameters, and the declared type of those parameters, in their parameter
 list.
 
 Since the name alone isn't enough, we have to come up with a different term to
@@ -388,13 +390,13 @@ uses when it needs to figure out what routine you're really trying to call.
 Defining a Typed Table Based on a UDT
 =====================================
 
-It's one thing to base Columns on UDTs. It's quite another thing to base Tables 
-on UDTs. Tables based on UDTs are called "typed Tables" (or "referenceable 
-Tables"). They are also called "the two sided coin" -- because from one angle, 
-typed Tables look like relations but from another angle they look like 
-"instantiated classes" (to borrow a term from OO). 
+It's one thing to base Columns on UDTs. It's quite another thing to base Tables
+on UDTs. Tables based on UDTs are called "typed Tables" (or "referenceable
+Tables"). They are also called "the two sided coin" -- because from one angle,
+typed Tables look like relations but from another angle they look like
+"instantiated classes" (to borrow a term from OO).
 
-To make a typed Table, use the ``REF`` syntax: ``"CREATE TABLE <Table name> OF 
+To make a typed Table, use the ``REF`` syntax: ``"CREATE TABLE <Table name> OF
 <UDT name> ... REF IS <column name>"``. For example:
 
 ::
@@ -402,45 +404,45 @@ To make a typed Table, use the ``REF`` syntax: ``"CREATE TABLE <Table name> OF
    CREATE TABLE Book
       OF book_udt REF IS self_referencing_column;
 
-To execute this SQL statement, you must have the Privilege to create a Table -- 
-that is, you must be the Schema owner, and you must have a ``USAGE`` privilege 
-on the UDT. There are several options and there are some side effects, but let 
-us concentrate now on the OO significance: this instantiates the class. 
+To execute this SQL statement, you must have the Privilege to create a Table --
+that is, you must be the Schema owner, and you must have a ``USAGE`` privilege
+on the UDT. There are several options and there are some side effects, but let
+us concentrate now on the OO significance: this instantiates the class.
 
-As we said, "instantiated classes" are OO terminology. The OO equivalent for 
-"user-defined type" is "class". In pure OO languages, creating a class (with 
-its Attributes and methods) takes care of everything, since classes are by 
-default "instantiable" ("instantiable" is a short way to say "there can be 
-instances of the class, namely objects based on the class definition"). 
+As we said, "instantiated classes" are OO terminology. The OO equivalent for
+"user-defined type" is "class". In pure OO languages, creating a class (with
+its Attributes and methods) takes care of everything, since classes are by
+default "instantiable" ("instantiable" is a short way to say "there can be
+instances of the class, namely objects based on the class definition").
 
-This form of ``CREATE TABLE`` takes the Attribute definitions from a UDT and 
-transfers them to <Column definition>s in a Table. Since ``BOOK_UDT`` has three 
-Attributes -- ``TITLE``, ``BUYING_PRICE``, ``SELLING_PRICE`` -- the ``BOOK`` 
-Table will have four Columns -- <self-referencing column>, ``TITLE``, 
-``BUYING_PRICE``, ``SELLING_PRICE``. Of these, only the first Column, 
-<self-referencing column>, needs a bit of explanation. 
+This form of ``CREATE TABLE`` takes the Attribute definitions from a UDT and
+transfers them to <Column definition>s in a Table. Since ``BOOK_UDT`` has three
+Attributes -- ``TITLE``, ``BUYING_PRICE``, ``SELLING_PRICE`` -- the ``BOOK``
+Table will have four Columns -- <self-referencing column>, ``TITLE``,
+``BUYING_PRICE``, ``SELLING_PRICE``. Of these, only the first Column,
+<self-referencing column>, needs a bit of explanation.
 
-A self-referencing Column is the equivalent of what in object-oriented 
-terminology would be an "object identifier". All typed Tables have a 
-self-referencing Column; that's why typed Tables are sometimes called 
-"referenceable Tables". The point about this self-referencing Column is that it 
-uniquely identifies a single row. Now, the row in the ``BOOK`` Table is going 
-to be an instance of the "class" ``BOOK_UDT`` -- which means a row is an 
-object. So we'll be able to reference this object later, by referring to the 
-value in its self-referencing Column. The name of the self-referencing Column 
-is whatever we specify in the ``REF IS`` clause -- in this case, 
-``SELF_REFERENCING_COLUMN``. 
+A self-referencing Column is the equivalent of what in object-oriented
+terminology would be an "object identifier". All typed Tables have a
+self-referencing Column; that's why typed Tables are sometimes called
+"referenceable Tables". The point about this self-referencing Column is that it
+uniquely identifies a single row. Now, the row in the ``BOOK`` Table is going
+to be an instance of the "class" ``BOOK_UDT`` -- which means a row is an
+object. So we'll be able to reference this object later, by referring to the
+value in its self-referencing Column. The name of the self-referencing Column
+is whatever we specify in the ``REF IS`` clause -- in this case,
+``SELF_REFERENCING_COLUMN``.
 
-There are several options for generation of self-referencing Column values. 
-Theoretically the best option is to derive the values from the Table's primary 
-key. But in this phase of the discussion we'll just use the default option: 
-``VALUES ARE SYSTEM GENERATED``. In effect, with the default option, a 
-self-referencing column is an arbitrary row identifier. 
+There are several options for generation of self-referencing Column values.
+Theoretically the best option is to derive the values from the Table's primary
+key. But in this phase of the discussion we'll just use the default option:
+``VALUES ARE SYSTEM GENERATED``. In effect, with the default option, a
+self-referencing column is an arbitrary row identifier.
 
 *Treating a Typed Table as a Table*
 -----------------------------------
 
-This is the heads side of our two-sided coin. Table ``BOOK`` is just a Table. 
+This is the heads side of our two-sided coin. Table ``BOOK`` is just a Table.
 Therefore, all these operations are legal:
 
 ::
@@ -455,11 +457,11 @@ Therefore, all these operations are legal:
   FROM   Book
   WHERE  title LIKE '%SQL%';
 
-Notice that in the ``INSERT`` statement example, we did not trouble to 
-specify a new value for ``SELF-REFERENCING COLUMN``. That is because the 
+Notice that in the ``INSERT`` statement example, we did not trouble to
+specify a new value for ``SELF-REFERENCING COLUMN``. That is because the
 value is system-generated.
 
-Now here is another operation: let us make a new Table which "references" 
+Now here is another operation: let us make a new Table which "references"
 the ``BOOK`` Table:
 
 ::
@@ -473,19 +475,19 @@ the ``BOOK`` Table:
     FROM   Book
     WHERE  title = 'The Incompleat SQL';
 
-We described the ``REF`` <data type> in our chapter on <reference type>s, and 
-you can look up the details there for how ``REF`` is defined. Here, at last, is 
-an actual use for the ``REF`` <data type>. The new row in ``BOOK_CHAPTER`` will 
-contain a "reference" to a single row in ``BOOK``. This is awfully similar to 
-referencing a primary key row from a foreign key, and in fact the 
-``BOOK_CHAPTER``\'s ``BOOK_REF_COLUMN`` can be made to have the paraphernalia 
-of a foreign key, including ``ON DELETE`` or ``CASCADE`` options. 
+We described the ``REF`` <data type> in our chapter on <reference type>s, and
+you can look up the details there for how ``REF`` is defined. Here, at last, is
+an actual use for the ``REF`` <data type>. The new row in ``BOOK_CHAPTER`` will
+contain a "reference" to a single row in ``BOOK``. This is awfully similar to
+referencing a primary key row from a foreign key, and in fact the
+``BOOK_CHAPTER``\'s ``BOOK_REF_COLUMN`` can be made to have the paraphernalia
+of a foreign key, including ``ON DELETE`` or ``CASCADE`` options.
 
 *Treating a Typed Table as an Instantiable class*
 -------------------------------------------------
 
-This is the flip side of our two-sided coin. It is possible to refer to the 
-UDT's Attributes as they are stored (instanced) in the typed Table, using 
+This is the flip side of our two-sided coin. It is possible to refer to the
+UDT's Attributes as they are stored (instanced) in the typed Table, using
 references. For example:
 
 ::
@@ -494,53 +496,53 @@ references. For example:
 
 will invoke the ``PROFIT`` method on the underlying value in ``BOOK_UDT``.
 
-Further: if we have a "``REF (book)``" value to steer by, we can perform 
+Further: if we have a "``REF (book)``" value to steer by, we can perform
 "navigational" tricks. For example, this expression is legal:
 
 ::
 
    book_ref_column -> title
 
-The result is the value in the ``TITLE`` Column of ``BOOK``, for the row whose 
-self-referencing Column is the value in the ``BOOK_REF_COLUMN`` of 
+The result is the value in the ``TITLE`` Column of ``BOOK``, for the row whose
+self-referencing Column is the value in the ``BOOK_REF_COLUMN`` of
 ``BOOK_CHAPTER``.
 
-Now, getting deeply into the object-oriented business, we arrive at the 
-concepts of "subclasses" and "superclasses" -- or, since we're using UDTs, 
-"subtypes" and "supertypes". The concept is fairly easy to grasp if we remind 
-ourselves that we are merely modelling the real world, and in the real world 
-these statements are manifestly true: 
+Now, getting deeply into the object-oriented business, we arrive at the
+concepts of "subclasses" and "superclasses" -- or, since we're using UDTs,
+"subtypes" and "supertypes". The concept is fairly easy to grasp if we remind
+ourselves that we are merely modelling the real world, and in the real world
+these statements are manifestly true:
 
-* The ``BOOK_UDT`` type can be subdivided by topic -- say, ``SCIENCE`` or 
+* The ``BOOK_UDT`` type can be subdivided by topic -- say, ``SCIENCE`` or
   ``HISTORY``.
 
-* The ``HISTORY`` type can be further subdivided into ``ANCIENT`` and 
-  ``MODERN``, while the ``SCIENCE`` type can be further subdivided into 
-  ``PHYSICS`` and (following Lord Kelvin's famous dictum that "all science is 
-  either physics or stamp collecting") ``STAMP COLLECTING``. 
+* The ``HISTORY`` type can be further subdivided into ``ANCIENT`` and
+  ``MODERN``, while the ``SCIENCE`` type can be further subdivided into
+  ``PHYSICS`` and (following Lord Kelvin's famous dictum that "all science is
+  either physics or stamp collecting") ``STAMP COLLECTING``.
 
-In other words, we can think of a "family of types", of which the proud single 
-patriarch is ``BOOK_UDT`` (but we avoid the word patriarch and say "maximal 
-supertype" instead). ``HISTORY`` and ``SCIENCE`` are subtypes of ``BOOK_UDT``; 
-therefore, by definition, ``BOOK_UDT`` is the supertype of ``HISTORY`` and 
-``SCIENCE``. ``HISTORY``, in turn, is the supertype of ``ANCIENT`` and 
-``MODERN``, ... and so on. 
+In other words, we can think of a "family of types", of which the proud single
+patriarch is ``BOOK_UDT`` (but we avoid the word patriarch and say "maximal
+supertype" instead). ``HISTORY`` and ``SCIENCE`` are subtypes of ``BOOK_UDT``;
+therefore, by definition, ``BOOK_UDT`` is the supertype of ``HISTORY`` and
+``SCIENCE``. ``HISTORY``, in turn, is the supertype of ``ANCIENT`` and
+``MODERN``, ... and so on.
 
-The point of all this is: ``BOOK_UDT`` is a data type, so -- like any data type 
--- its specification includes a description of its representation and of the 
-operations that can be performed on it. That description is applicable as well 
-for ``HISTORY`` and for ``STAMP COLLECTING``, unless we explicitly say 
-otherwise: the subtype inherits the Attributes and methods of the supertype. 
+The point of all this is: ``BOOK_UDT`` is a data type, so -- like any data type
+-- its specification includes a description of its representation and of the
+operations that can be performed on it. That description is applicable as well
+for ``HISTORY`` and for ``STAMP COLLECTING``, unless we explicitly say
+otherwise: the subtype inherits the Attributes and methods of the supertype.
 
-We could, of course, reflect some subtyping concept using purely relational 
-operations (by joining a ``BOOK`` Table to a ``PHYSICS`` Table, for example). 
-But the advantage of object orientation is that such operations are implicit in 
-the definition. By declaring that ``a`` is a subtype of ``b``, you are saying 
-that ``a`` is automatically linked to ``b``, so the linking process is 
-practically invisible. 
+We could, of course, reflect some subtyping concept using purely relational
+operations (by joining a ``BOOK`` Table to a ``PHYSICS`` Table, for example).
+But the advantage of object orientation is that such operations are implicit in
+the definition. By declaring that ``a`` is a subtype of ``b``, you are saying
+that ``a`` is automatically linked to ``b``, so the linking process is
+practically invisible.
 
-To make the above discussion concrete, here are some SQL statements that make 
-subtypes. In these examples, the <keyword> ``UNDER`` means "as a subtype of". 
+To make the above discussion concrete, here are some SQL statements that make
+subtypes. In these examples, the <keyword> ``UNDER`` means "as a subtype of".
 
 ::
 
@@ -551,14 +553,14 @@ subtypes. In these examples, the <keyword> ``UNDER`` means "as a subtype of".
    CREATE TYPE physics UNDER science            NOT FINAL;
    CREATE TYPE stamp_collecting UNDER science   NOT FINAL;
 
-Admittedly, these new types lack personality. We've kept it that way so that 
-you can imagine for yourself what additional Attributes or methods you would 
-want to add to the subtypes, on top of the "inheritance" that they receive from 
-the supertypes. 
+Admittedly, these new types lack personality. We've kept it that way so that
+you can imagine for yourself what additional Attributes or methods you would
+want to add to the subtypes, on top of the "inheritance" that they receive from
+the supertypes.
 
-Finally, we can flip the coin over again and say: "if a type can have subtypes, 
-surely the instantiation of a type can have instantiations of subtypes." In 
-other words, Tables can have subtables: 
+Finally, we can flip the coin over again and say: "if a type can have subtypes,
+surely the instantiation of a type can have instantiations of subtypes." In
+other words, Tables can have subtables:
 
 ::
 
@@ -569,16 +571,16 @@ other words, Tables can have subtables:
    CREATE TABLE Physics UNDER Science;
    CREATE TABLE Stamp_collecting UNDER Science;
 
-Notice that the "subtables" and "supertables" defined are a family whose 
-relationships match the relationships of the "subtypes" and "supertypes" they 
-are based on. In fact, that is a requirement. 
+Notice that the "subtables" and "supertables" defined are a family whose
+relationships match the relationships of the "subtypes" and "supertypes" they
+are based on. In fact, that is a requirement.
 
 Here endeth the tutorial.
 
 CREATE TYPE Statement
 =====================
 
-The ``CREATE TYPE`` statement defines a UDT. The required syntax for the 
+The ``CREATE TYPE`` statement defines a UDT. The required syntax for the
 ``CREATE TYPE`` statement is:
 
 ::
@@ -633,20 +635,20 @@ The ``CREATE TYPE`` statement defines a UDT. The required syntax for the
           (SQL parameter declaration list)
           RETURNS <data type>
 
-``CREATE TYPE`` defines a new UDT: a named set of valid data values. A UDT 
+``CREATE TYPE`` defines a new UDT: a named set of valid data values. A UDT
 is owned by the Schema it belongs to.
 
-* The <UDT name> identifies the UDT and the Schema that it belongs to. A <UDT 
-  name> that includes an explicit <Schema name> qualifier belongs to the Schema 
-  named. A <UDT name> that does not include an explicit <Schema name> qualifier 
-  belongs to the SQL-session default Schema. The <UDT name> must be unique (for 
-  all Domains and UDTs) within the Schema that owns it. If ``CREATE TYPE`` is 
-  part of a ``CREATE SCHEMA`` statement, the <UDT name>, if explicitly 
-  qualified, must include the <Schema name> of the Schema being created; 
-  that is, it isn't possible to create a UDT belonging to a different Schema 
-  from within ``CREATE SCHEMA``. 
+* The <UDT name> identifies the UDT and the Schema that it belongs to. A <UDT
+  name> that includes an explicit <Schema name> qualifier belongs to the Schema
+  named. A <UDT name> that does not include an explicit <Schema name> qualifier
+  belongs to the SQL-session default Schema. The <UDT name> must be unique (for
+  all Domains and UDTs) within the Schema that owns it. If ``CREATE TYPE`` is
+  part of a ``CREATE SCHEMA`` statement, the <UDT name>, if explicitly
+  qualified, must include the <Schema name> of the Schema being created;
+  that is, it isn't possible to create a UDT belonging to a different Schema
+  from within ``CREATE SCHEMA``.
 
-There are actually three variants of ``CREATE TYPE``, used in distinct ways: 
+There are actually three variants of ``CREATE TYPE``, used in distinct ways:
 
 +----------------------------------+------------------------------+-----------------------------+
 | **Making structured types**      | **Making structured types**  | **Making distinct types**   |
@@ -677,19 +679,19 @@ If you use a subtype clause -- for example:
 
    CREATE TYPE a UNDER b ...
 
-you are making a new subtype under an existing supertype. The supertype must 
-exist, it must be a structured type UDT that was defined as ``NOT FINAL`` and 
-you must have the ``UNDER`` Privilege on it. Notice that there can be only one 
-supertype; this means that SQL, like Java, has a "single inheritance" rule. 
-Notice too that you can have both a subtype clause and an Attribute definition 
-list in the same ``CREATE TYPE`` statement; this means that the subtype can 
-have both inherited Attributes (Attributes taken from the supertype) and 
-original Attributes (Attributes taken from the new definition, which follow the 
-inherited Attributes). 
+you are making a new subtype under an existing supertype. The supertype must
+exist, it must be a structured type UDT that was defined as ``NOT FINAL`` and
+you must have the ``UNDER`` Privilege on it. Notice that there can be only one
+supertype; this means that SQL, like Java, has a "single inheritance" rule.
+Notice too that you can have both a subtype clause and an Attribute definition
+list in the same ``CREATE TYPE`` statement; this means that the subtype can
+have both inherited Attributes (Attributes taken from the supertype) and
+original Attributes (Attributes taken from the new definition, which follow the
+inherited Attributes).
 
-If the representation is "... ``AS`` <Attribute list> ...", then each Attribute 
-definition must look very much like a <Column definition> looks in a ``CREATE 
-TABLE`` statement -- for example: 
+If the representation is "... ``AS`` <Attribute list> ...", then each Attribute
+definition must look very much like a <Column definition> looks in a ``CREATE
+TABLE`` statement -- for example:
 
 
 
@@ -698,53 +700,53 @@ TABLE`` statement -- for example:
    attribute_1 CHAR(1000) CHARACTER SET ISO8BIT,
    attribute_2 TIME WITH TIME ZONE DEFAULT '12:00:00'
 
-Constraints (such as ``NOT NULL``) are illegal, though. An <Attribute name> is 
-an <identifier>; all <Attribute name>s must be unique within their UDT. The 
-Attribute's <data type> may be a UDT, but cyclic references are illegal. 
+Constraints (such as ``NOT NULL``) are illegal, though. An <Attribute name> is
+an <identifier>; all <Attribute name>s must be unique within their UDT. The
+Attribute's <data type> may be a UDT, but cyclic references are illegal.
 
-The Standard is contradictory about the instantiable clause. It's safe to 
-assume that "instantiable", as in all OO languages, means "can be instantiated" 
-(a "non-instantiable" or "abstract" UDT would have no instances but could have 
-instantiable subtypes). Use of typed Tables is only possible if the type is 
-intantiable. 
+The Standard is contradictory about the instantiable clause. It's safe to
+assume that "instantiable", as in all OO languages, means "can be instantiated"
+(a "non-instantiable" or "abstract" UDT would have no instances but could have
+instantiable subtypes). Use of typed Tables is only possible if the type is
+intantiable.
 
-The Standard is also contradictory about the finality clause. It probably means 
-(as in Java) that the new UDT may have no proper subtypes. That is, no further 
-UDT may be created ``UNDER`` it. (There is a belief that the clause is for 
-distinguishing distinct types from structured types. We don't believe that. We 
-repeat that a distinct type s a UDT defined with "``AS`` <predefined type>", 
-all other UDTs are structured types.) If the ``CREATE TYPE`` statement contains 
-any Attribute definitions, then ``NOT FINAL`` is mandatory. Otherwise either 
-``FINAL`` or ``NOT FINAL`` is mandatory. 
+The Standard is also contradictory about the finality clause. It probably means
+(as in Java) that the new UDT may have no proper subtypes. That is, no further
+UDT may be created ``UNDER`` it. (There is a belief that the clause is for
+distinguishing distinct types from structured types. We don't believe that. We
+repeat that a distinct type s a UDT defined with "``AS`` <predefined type>",
+all other UDTs are structured types.) If the ``CREATE TYPE`` statement contains
+any Attribute definitions, then ``NOT FINAL`` is mandatory. Otherwise either
+``FINAL`` or ``NOT FINAL`` is mandatory.
 
-The reference specification is either "user-generated" (``REF USING``), 
-"derived" (``REF`` <Attribute list>) or "system-generated" (``REF IS SYSTEM 
-GENERATED``). With the default -- ``REF IS SYSTEM GENERATED`` -- there is no 
-further specification because values are implementation-dependent. With the 
-main option -- ``REF USING`` -- there is a further specification: the 
-<Attribute name> list. Because (as in pure relational systems) a row's 
-uniqueness should depend on Column values, the <Attribute name>s here would be 
-an indirect list of a "key value". 
+The reference specification is either "user-generated" (``REF USING``),
+"derived" (``REF`` <Attribute list>) or "system-generated" (``REF IS SYSTEM
+GENERATED``). With the default -- ``REF IS SYSTEM GENERATED`` -- there is no
+further specification because values are implementation-dependent. With the
+main option -- ``REF USING`` -- there is a further specification: the
+<Attribute name> list. Because (as in pure relational systems) a row's
+uniqueness should depend on Column values, the <Attribute name>s here would be
+an indirect list of a "key value".
 
-The cast option is legal only for distinct types. The cast's source and target 
-<data type>s are the <predefined type> specified earlier in the ``CREATE TYPE`` 
-statement and the name of the UDT, respectively. 
+The cast option is legal only for distinct types. The cast's source and target
+<data type>s are the <predefined type> specified earlier in the ``CREATE TYPE``
+statement and the name of the UDT, respectively.
 
-A UDT's methods are defined in pretty well the same way as functions; indeed a 
-method is a function, albeit a function which cannot live without its UDT and 
-which is called in a slightly different way than a regular function. The 
-default method characteristics are ``LANGUAGE SQL``, ``PARAMETER STYLE SQL``, 
-``NOT DETERMINISTIC``, ``CONTAINS SQL``, ``NOT NULL CALL``. (Note: Although the 
-Standard says that ``NOT DETERMINISTIC`` is the default, it's hard to believe 
-that this is the true intent.) The difference between an "overriding" and an 
-"original" method is that an overriding method "overrides" an already-existing 
-method with the same name, in some supertype. Method signatures must be 
-distinct. Remember that, as noted in the tutorial section of this chapter, 
-structured UDTs have implicitly-created methods: one constructor method for the 
-UDT as a whole, *n* mutator methods (one for each Attribute), and *n* observer 
-methods (one for each Attribute). As for distinct types: apparently no 
-implicitly-created methods exist for them, but there may be a "transform" 
-function for casting to/from host languages. 
+A UDT's methods are defined in pretty well the same way as functions; indeed a
+method is a function, albeit a function which cannot live without its UDT and
+which is called in a slightly different way than a regular function. The
+default method characteristics are ``LANGUAGE SQL``, ``PARAMETER STYLE SQL``,
+``NOT DETERMINISTIC``, ``CONTAINS SQL``, ``NOT NULL CALL``. (Note: Although the
+Standard says that ``NOT DETERMINISTIC`` is the default, it's hard to believe
+that this is the true intent.) The difference between an "overriding" and an
+"original" method is that an overriding method "overrides" an already-existing
+method with the same name, in some supertype. Method signatures must be
+distinct. Remember that, as noted in the tutorial section of this chapter,
+structured UDTs have implicitly-created methods: one constructor method for the
+UDT as a whole, *n* mutator methods (one for each Attribute), and *n* observer
+methods (one for each Attribute). As for distinct types: apparently no
+implicitly-created methods exist for them, but there may be a "transform"
+function for casting to/from host languages.
 
 *Distinct Types*
 ----------------
@@ -755,11 +757,11 @@ The simplest way to make a UDT is with:
 
    CREATE TYPE <UDT name> AS <predefined data type> FINAL;
 
-which -- since it has no Attribute list -- is not a specification of a 
-"structured type" with all the OO trimmings. Instead, UDTs made this way are 
-called "distinct types". The main idea behind distinct types is that they 
-constitute enforceable domains. For example, suppose we define two currency 
-data types: 
+which -- since it has no Attribute list -- is not a specification of a
+"structured type" with all the OO trimmings. Instead, UDTs made this way are
+called "distinct types". The main idea behind distinct types is that they
+constitute enforceable domains. For example, suppose we define two currency
+data types:
 
 ::
 
@@ -767,24 +769,24 @@ data types:
 
    CREATE TYPE mark AS DECIMAL(8,2) FINAL;
 
-If we now attempt to pass a ``euro`` value to a ``mark`` target, we will fail 
--- the distinct type provides us with a simple form of type checking that we 
-cannot achieve using an SQL Domain. 
+If we now attempt to pass a ``euro`` value to a ``mark`` target, we will fail
+-- the distinct type provides us with a simple form of type checking that we
+cannot achieve using an SQL Domain.
 
-Distinct types have methods, just like structured types. However, they are 
-limited in various ways. Usually, when we make generalized comments about 
-object-orientation analogies -- such as "UDTs are classes" -- we have 
+Distinct types have methods, just like structured types. However, they are
+limited in various ways. Usually, when we make generalized comments about
+object-orientation analogies -- such as "UDTs are classes" -- we have
 structured types in mind, not distinct types.
 
 CREATE TABLE Statement
 ======================
 
-We've already shown you the ``CREATE TABLE`` statement in our chapter on 
-Tables. However, there are two options to add to that description now, for 
-Object/Relational Tables. 
+We've already shown you the ``CREATE TABLE`` statement in our chapter on
+Tables. However, there are two options to add to that description now, for
+Object/Relational Tables.
 
-The first option has to do with the creation of typed Tables. Here's the 
-syntax: 
+The first option has to do with the creation of typed Tables. Here's the
+syntax:
 
 ::
 
@@ -801,20 +803,20 @@ follow when you use this syntax:
 
 * <UDT name> must specify a structured UDT.
 
-* The optional ``REF`` clause may appear within the Table element list (that 
-  is, inside the parentheses along with the Column and Constraint definitions). 
-  The <self-referencing Column name> must be a valid and distinct <identifier>. 
-  The three options associated with "``REF IS ...``" are (like ``CREATE 
-  TYPE``\'s ``REF`` clause) either "user-generated", "derived" or 
-  "system-generated". With the default -- ``SYSTEM GENERATED`` -- the Column 
-  values are implementation-dependent. With the main option -- ``DERIVED`` -- 
-  Column values come from the Table's primary key. A typed Table always has one 
-  self-referencing Column, and its position within the Table is fixed: it is 
-  always the first Column in the Table. The "``REF IS ...``" clause only 
-  specifies a few details about the self-referencing Column. Note: typed Tables 
-  are known (sometimes) as "referenceable Tables" and (rarely) as "object 
-  UDTs". The second option has to do with the creation of subtables. Here's the 
-  syntax: 
+* The optional ``REF`` clause may appear within the Table element list (that
+  is, inside the parentheses along with the Column and Constraint definitions).
+  The <self-referencing Column name> must be a valid and distinct <identifier>.
+  The three options associated with "``REF IS ...``" are (like ``CREATE
+  TYPE``\'s ``REF`` clause) either "user-generated", "derived" or
+  "system-generated". With the default -- ``SYSTEM GENERATED`` -- the Column
+  values are implementation-dependent. With the main option -- ``DERIVED`` --
+  Column values come from the Table's primary key. A typed Table always has one
+  self-referencing Column, and its position within the Table is fixed: it is
+  always the first Column in the Table. The "``REF IS ...``" clause only
+  specifies a few details about the self-referencing Column. Note: typed Tables
+  are known (sometimes) as "referenceable Tables" and (rarely) as "object
+  UDTs". The second option has to do with the creation of subtables. Here's the
+  syntax:
 
   ::
 
@@ -830,24 +832,24 @@ follow when you use this syntax:
 
 * Both the subtable and the supertable must be typed Tables.
 
-* The subtable/supertable relationship must mirror the subtype/supertype 
-  relationship. For example: if ``ty1`` is a subtype of ``ty2``, and ``ta1`` is 
-  a typed Table based on ``ty1``, and ``ta2`` is a typed Table based on 
-  ``ty2``, then it is legal to create ``ta1 UNDER ta2`` -- but it is not legal 
-  to create ``ta2 UNDER ta1``. 
+* The subtable/supertable relationship must mirror the subtype/supertype
+  relationship. For example: if ``ty1`` is a subtype of ``ty2``, and ``ta1`` is
+  a typed Table based on ``ty1``, and ``ta2`` is a typed Table based on
+  ``ty2``, then it is legal to create ``ta1 UNDER ta2`` -- but it is not legal
+  to create ``ta2 UNDER ta1``.
 
 CREATE CAST Statement
 =====================
 
-With UDTs, you'll need some way of assigning UDT values to predefined <data 
-type> targets, or vice versa. Further, if you have two distinct UDTs -- say 
-UDT1 and UDT2 -- then you'll also need some way to assign values based on UDT1 
-to UDT2 targets, or vice versa. This might all be complicated by the fact that 
-subtypes contain their supertypes' Attributes, which should imply a degree of 
-mutual assignability. In sum, you need the ability to "cast" a UDT to or from 
-another data type. The solution is to create a user-defined cast for the chosen 
-<data type>s, with the ``CREATE CAST`` statement. The required syntax for the 
-``CREATE CAST`` statement is: 
+With UDTs, you'll need some way of assigning UDT values to predefined <data
+type> targets, or vice versa. Further, if you have two distinct UDTs -- say
+UDT1 and UDT2 -- then you'll also need some way to assign values based on UDT1
+to UDT2 targets, or vice versa. This might all be complicated by the fact that
+subtypes contain their supertypes' Attributes, which should imply a degree of
+mutual assignability. In sum, you need the ability to "cast" a UDT to or from
+another data type. The solution is to create a user-defined cast for the chosen
+<data type>s, with the ``CREATE CAST`` statement. The required syntax for the
+``CREATE CAST`` statement is:
 
 ::
 
@@ -855,19 +857,19 @@ another data type. The solution is to create a user-defined cast for the chosen
     WITH <specific routine designator>
     [ AS ASSIGNMENT ]
 
-A UDT value is assignable to a UDT target only if the source value is a subtype 
-of the target UDT. There can be only one user-defined cast for any given 
-combination of source and target types. Either <source type> or <target type> 
-must be either UDT or ``REF``, but the other operand can be any <data type>. To 
-execute ``CREATE CAST``, you must be the owner of both the cast function 
-identified by <specific routine designator>) and the <target type> (if it is a 
-UDT). 
+A UDT value is assignable to a UDT target only if the source value is a subtype
+of the target UDT. There can be only one user-defined cast for any given
+combination of source and target types. Either <source type> or <target type>
+must be either UDT or ``REF``, but the other operand can be any <data type>. To
+execute ``CREATE CAST``, you must be the owner of both the cast function
+identified by <specific routine designator>) and the <target type> (if it is a
+UDT).
 
-The <specific routine designator> is usually a signature -- for example, 
-"``FUNCTION f (SMALLINT)``" can be a <specific routine designator>. It is also 
-possible to identify a routine using a specific name, which is a unique, 
-possibly mangled, name that is usually assigned by the DBMS. The cast function 
-identified by the <specific routine designator> must have the general form: 
+The <specific routine designator> is usually a signature -- for example,
+"``FUNCTION f (SMALLINT)``" can be a <specific routine designator>. It is also
+possible to identify a routine using a specific name, which is a unique,
+possibly mangled, name that is usually assigned by the DBMS. The cast function
+identified by the <specific routine designator> must have the general form:
 
 ::
 
@@ -876,9 +878,9 @@ identified by the <specific routine designator> must have the general form:
    ... { NO SQL | CONTAINS SQL }
    ...
 
-``AS ASSIGNMENT`` (which is not the default) means that the cast is "implicitly 
-invocable" during assignment operations. That is, if ``x`` is ``UDT_1``, and 
-there is an implicitly-invocable cast, then this is a legal assignment: 
+``AS ASSIGNMENT`` (which is not the default) means that the cast is "implicitly
+invocable" during assignment operations. That is, if ``x`` is ``UDT_1``, and
+there is an implicitly-invocable cast, then this is a legal assignment:
 
 ::
 
@@ -890,39 +892,39 @@ Otherwise, this is a legal assignment:
 
    x = CAST ('F' AS UDT_1)
 
-[Obscure Rule] An assignment might involve a choice between several possible 
-"implicitly invocable" cast functions. The DBMS picks the one that fits these 
-criteria: 
+[Obscure Rule] An assignment might involve a choice between several possible
+"implicitly invocable" cast functions. The DBMS picks the one that fits these
+criteria:
 
-* It's an implicitly-invocable cast function -- i.e.: it was mentioned with 
+* It's an implicitly-invocable cast function -- i.e.: it was mentioned with
   ``AS ASSIGNABLE``.
 
 * The cast function's result <data type> is the target's declared type.
 
-* The cast function has one parameter, and that parameter has a "declared 
-  type", and that declared type is in the "type precedence list" of the 
-  declared type of the source value. If there are two cast functions which 
-  meet all these requirements, the DBMS picks the one whose declared type is 
+* The cast function has one parameter, and that parameter has a "declared
+  type", and that declared type is in the "type precedence list" of the
+  declared type of the source value. If there are two cast functions which
+  meet all these requirements, the DBMS picks the one whose declared type is
   highest in the "type precedence list".
 
 .. TIP::
 
-   If you decide to make a user-defined cast for "a to b", be reciprocal: 
-   make a user-defined cast for "b to a" as well. Users expect all casts to 
+   If you decide to make a user-defined cast for "a to b", be reciprocal:
+   make a user-defined cast for "b to a" as well. Users expect all casts to
    be two-way.
 
 .. TIP::
 
-   For hierarchy's sake: if ``A1`` is a supertype of ``A2``, and ``B1`` is a 
-   supertype of ``B2``, then make casts from ``A1`` to ``B1`` and from 
-   ``A2`` to ``B2`` -- not ``A1`` to ``B2`` nor ``A2`` to ``B1``. That is, 
+   For hierarchy's sake: if ``A1`` is a supertype of ``A2``, and ``B1`` is a
+   supertype of ``B2``, then make casts from ``A1`` to ``B1`` and from
+   ``A2`` to ``B2`` -- not ``A1`` to ``B2`` nor ``A2`` to ``B1``. That is,
    cast from super to super and from sub to sub.
 
-Here is a user-defined cast for the ``BOOK_UDT`` type which we used in earlier 
-examples. The UDT has three Attributes (``title CHAR(40)``, ``buying_price 
-DECIMAL(9,2)``, ``selling_price DECIMAL(9,2)``). Since each Attribute's type is 
-either ``CHAR`` or castable to ``CHAR``, we'll make a function which simply 
-concatenates each Attribute into one big character string. Here's how: 
+Here is a user-defined cast for the ``BOOK_UDT`` type which we used in earlier
+examples. The UDT has three Attributes (``title CHAR(40)``, ``buying_price
+DECIMAL(9,2)``, ``selling_price DECIMAL(9,2)``). Since each Attribute's type is
+either ``CHAR`` or castable to ``CHAR``, we'll make a function which simply
+concatenates each Attribute into one big character string. Here's how:
 
 ::
 
@@ -952,10 +954,10 @@ Now that we have a cast, we can use ``BOOK_UDT`` in a ``CAST`` expression:
   SELECT CAST(book_udt AS CHAR(60))
   FROM   Books;
 
-Thus, we can design our own external representation of a UDT, without 
+Thus, we can design our own external representation of a UDT, without
 worrying about its internal representation.
 
-For distinct type UDTs only, the DBMS automatically creates two casts. For 
+For distinct type UDTs only, the DBMS automatically creates two casts. For
 example, if you make this UDT:
 
 ::
@@ -969,15 +971,15 @@ the DBMS will make these two casts for it:
    CREATE CAST (longitude AS REAL) ... AS ASSIGNMENT;
    CREATE CAST (REAL AS longitude) ... AS ASSIGNMENT;
 
-Now, suppose you have a variable ``lo`` of type ``LONGITUDE``. Because of 
-the automatic cast, it's legal to cast a <literal> to ``LONGITUDE``, for 
+Now, suppose you have a variable ``lo`` of type ``LONGITUDE``. Because of
+the automatic cast, it's legal to cast a <literal> to ``LONGITUDE``, for
 example:
 
 ::
 
     SET lo = CAST (33.59 AS longitude);
 
-Not only that, though! The casts are ``AS ASSIGNMENT`` casts, so this SQL 
+Not only that, though! The casts are ``AS ASSIGNMENT`` casts, so this SQL
 statement is also legal:
 
 ::
@@ -993,20 +995,20 @@ The reason that ``SET lo = 33.59;`` is legal is that there is an implicit cast
 
 .. TIP::
 
-   Implicitly invocable casts are convenient but error-prone. If you don't 
-   want to allow loosely-typed phrases like ``money_column = 5.00``, you 
-   should ``DROP`` the cast that the DBMS created and then explicitly make 
+   Implicitly invocable casts are convenient but error-prone. If you don't
+   want to allow loosely-typed phrases like ``money_column = 5.00``, you
+   should ``DROP`` the cast that the DBMS created and then explicitly make
    it again -- but without specifying ``AS ASSIGNMENT`` in the definition.
 
 CREATE ORDERING Statement
 =========================
 
-For UDT values, you'll need some way of knowing that "udt-value-1 is greater 
-than udt-value-2" -- or less, or equal. Otherwise you'll be unable to use UDTs 
-in search conditions, or in ``ORDER BY`` clauses, or in ``GROUP BY`` clauses, 
-or after the word ``DISTINCT``. The solution is to create an ordering for the 
-UDT with the ``CREATE ORDERING`` statement. The required syntax for the 
-``CREATE ORDERING`` statement is: 
+For UDT values, you'll need some way of knowing that "udt-value-1 is greater
+than udt-value-2" -- or less, or equal. Otherwise you'll be unable to use UDTs
+in search conditions, or in ``ORDER BY`` clauses, or in ``GROUP BY`` clauses,
+or after the word ``DISTINCT``. The solution is to create an ordering for the
+UDT with the ``CREATE ORDERING`` statement. The required syntax for the
+``CREATE ORDERING`` statement is:
 
 ::
 
@@ -1019,47 +1021,47 @@ UDT with the ``CREATE ORDERING`` statement. The required syntax for the
        HASH WITH <specific routine designator> |
        STATE [ <specific name> ]
 
-A UDT value is comparable to another UDT value only if both UDTs are in the 
-same subtype family. There can be only one ordering for a UDT. To execute 
-``CREATE ORDERING``, you must be the owner of both the UDT and routine named in 
-the <ordering category>. Since UDTs in the same type family are related, all 
-orderings for UDTs within the same type family must all be defined either with 
-``EQUALS ONLY BY`` or with ``ORDER FULL BY``. 
+A UDT value is comparable to another UDT value only if both UDTs are in the
+same subtype family. There can be only one ordering for a UDT. To execute
+``CREATE ORDERING``, you must be the owner of both the UDT and routine named in
+the <ordering category>. Since UDTs in the same type family are related, all
+orderings for UDTs within the same type family must all be defined either with
+``EQUALS ONLY BY`` or with ``ORDER FULL BY``.
 
-A <specific routine designator> is usually a signature. For example, ``FUNCTION 
-f (SMALLINT)`` can be a <specific routine designator>. It is also possible to 
-identify a routine using a <specific name>: an additional routine name, used to 
-uniquely identify a routine. A routine's <specific name> is usually assigned by 
-the DBMS. The ordering routine must be ``DETERMINISTIC`` and must not possibly 
-modify SQL-data. 
+A <specific routine designator> is usually a signature. For example, ``FUNCTION
+f (SMALLINT)`` can be a <specific routine designator>. It is also possible to
+identify a routine using a <specific name>: an additional routine name, used to
+uniquely identify a routine. A routine's <specific name> is usually assigned by
+the DBMS. The ordering routine must be ``DETERMINISTIC`` and must not possibly
+modify SQL-data.
 
-The <ordering category> "``RELATIVE WITH`` <specific routine designator>" is 
-legal only for maximal supertypes (i.e.: types that have no proper supertypes 
-of their own). ``RELATIVE WITH`` functions have two parameters (both are UDT 
-types) and return an ``INTEGER``. 
+The <ordering category> "``RELATIVE WITH`` <specific routine designator>" is
+legal only for maximal supertypes (i.e.: types that have no proper supertypes
+of their own). ``RELATIVE WITH`` functions have two parameters (both are UDT
+types) and return an ``INTEGER``.
 
-The <ordering category> "``HASH WITH`` <specific routine designator>" is legal 
-for subtypes, but only if their supertypes are also defined with ``HASH WITH`` 
-orderings. Typically, the <specific routine designator> named will identify an 
-observer method for one of the UDT's Attributes. ``HASH WITH`` functions have 
-one parameter (its type is UDT) and return a predefined <data type>. 
+The <ordering category> "``HASH WITH`` <specific routine designator>" is legal
+for subtypes, but only if their supertypes are also defined with ``HASH WITH``
+orderings. Typically, the <specific routine designator> named will identify an
+observer method for one of the UDT's Attributes. ``HASH WITH`` functions have
+one parameter (its type is UDT) and return a predefined <data type>.
 
-The <ordering category> ``STATE`` is legal only for maximal supertypes. If you 
-specify ``STATE``, the DBMS implicitly creates a function named ``EQUALS``. It 
-is the duty of the ``EQUALS`` function to return ``TRUE`` if all Attribute 
-values are equal. 
+The <ordering category> ``STATE`` is legal only for maximal supertypes. If you
+specify ``STATE``, the DBMS implicitly creates a function named ``EQUALS``. It
+is the duty of the ``EQUALS`` function to return ``TRUE`` if all Attribute
+values are equal.
 
-Because the ordering routine is user-defined, it's impossible to say exactly 
-what the various ordering categories imply. The following is a generalization: 
+Because the ordering routine is user-defined, it's impossible to say exactly
+what the various ordering categories imply. The following is a generalization:
 
-* An ``EQUALS`` function returns ``TRUE`` if all values are equal; otherwise it 
+* An ``EQUALS`` function returns ``TRUE`` if all values are equal; otherwise it
   returns ``FALSE``. It never returns ``UNKNOWN``.
 
-* A ``RELATIVE`` function returns an integer value less than zero for less than 
-  values, returns zero for equal values and returns an integer greater than 
+* A ``RELATIVE`` function returns an integer value less than zero for less than
+  values, returns zero for equal values and returns an integer greater than
   zero for greater than values.
 
-* A ``HASH`` function returns an absolute ordering within the predefined <data 
+* A ``HASH`` function returns an absolute ordering within the predefined <data
   type>.
 
 Here's an example of ``CREATE ORDERING``:
@@ -1070,7 +1072,7 @@ Here's an example of ``CREATE ORDERING``:
    ORDER FULL BY HASH WITH
       FUNCTION title (book_udt);   /* observer function for title Attribute */
 
-There is no need to create an ordering for a distinct type. As with casts, 
+There is no need to create an ordering for a distinct type. As with casts,
 the DBMS implicitly does the following when ``CREATE TYPE`` is executed:
 
 ::
@@ -1079,14 +1081,14 @@ the DBMS implicitly does the following when ``CREATE TYPE`` is executed:
    ORDER FULL BY HASH WITH
       FUNCTION <Schema name>.<cast-to-source identifier> (<UDT name>);
 
-Comparisons of distinct types work exactly the same way as comparisons of 
+Comparisons of distinct types work exactly the same way as comparisons of
 the predefined <data type>s they are based on.
 
 .. TIP::
 
-   When you create a maximal supertype, make sure to execute a ``CREATE 
-   ORDERING`` statement for that type. When you create a subtype, the matter is 
-   less urgent because subtypes inherit from their supertypes. 
+   When you create a maximal supertype, make sure to execute a ``CREATE
+   ORDERING`` statement for that type. When you create a subtype, the matter is
+   less urgent because subtypes inherit from their supertypes.
 
 Other Processes for Object/Relational Users
 ===========================================
@@ -1100,7 +1102,7 @@ here, in the hope that you'll find the details to be intuitive.
 *ALTER TYPE Statement*
 ----------------------
 
-The ``ALTER TYPE`` statement lets you change the definition of a UDT. The 
+The ``ALTER TYPE`` statement lets you change the definition of a UDT. The
 required syntax for the ``ALTER TYPE`` statement is:
 
 ::
@@ -1114,8 +1116,8 @@ required syntax for the ``ALTER TYPE`` statement is:
 *CREATE METHOD Statement*
 -------------------------
 
-The ``CREATE METHOD`` statement lets you make a new method -- it's actually 
-a special form of the ``CREATE FUNCTION`` statement. The required syntax 
+The ``CREATE METHOD`` statement lets you make a new method -- it's actually
+a special form of the ``CREATE FUNCTION`` statement. The required syntax
 for the ``CREATE METHOD`` statement is:
 
 ::
@@ -1127,11 +1129,11 @@ for the ``CREATE METHOD`` statement is:
     [ SPECIFIC <specific name> ]
     <routine body>
 
-(See our chapter on procedures for a definition of <routine body>.) 
+(See our chapter on procedures for a definition of <routine body>.)
 
-A method is a function which is associated with a UDT. Methods and functions 
-can look quite different, even when they're the same thing. Consider these two 
-examples: 
+A method is a function which is associated with a UDT. Methods and functions
+can look quite different, even when they're the same thing. Consider these two
+examples:
 
 ::
 
@@ -1140,17 +1142,17 @@ examples:
     RETURNS FLOAT                        RETURNS FLOAT
                                          FOR book_udt
 
-These examples -- shorn of unnecessary detail -- illustrate a confusing fact: 
-the function and the method are the same thing! When you want to list a 
-method's parameters, you should "augment" the parameter list by adding one 
-parameter, called the "self" parameter, in ordinal position 1. 
+These examples -- shorn of unnecessary detail -- illustrate a confusing fact:
+the function and the method are the same thing! When you want to list a
+method's parameters, you should "augment" the parameter list by adding one
+parameter, called the "self" parameter, in ordinal position 1.
 
 *CREATE TRANSFORM Statement*
 ----------------------------
 
-The ``CREATE TRANSFORM`` statement lets you make a method that will be used in 
-casting for host languages. The required syntax for the ``CREATE TRANSFORM`` 
-statement is: 
+The ``CREATE TRANSFORM`` statement lets you make a method that will be used in
+casting for host languages. The required syntax for the ``CREATE TRANSFORM``
+statement is:
 
 ::
 
@@ -1162,22 +1164,22 @@ statement is:
        TO SQL WITH <specific routine designator> |
        FROM SQL WITH <specific routine designator>
 
-A ``TRANSFORM`` is an SQL-invoked function that is automatically invoked when 
-you transfer UDT values to and from a host language program. It identifies one 
-or two functions -- each identified by a <group name> (the name is either an 
-<identifier> of the <keyword> ``DEFAULT``). 
+A ``TRANSFORM`` is an SQL-invoked function that is automatically invoked when
+you transfer UDT values to and from a host language program. It identifies one
+or two functions -- each identified by a <group name> (the name is either an
+<identifier> of the <keyword> ``DEFAULT``).
 
-The ``TRANSFORM``\'s ``TO SQL`` function casts a predefined <data type> value 
-to a UDT value and gets invoked whenever a UDT value is passed to the DBMS by a 
-host language program or external routine. The ``TRANSFORM``\'s ``FROM SQL`` 
-function casts a UDT value to a predefined <data type> value and gets invoked 
-whenever a UDT value is passed from the DBMS to a host language program or 
-external routine. 
+The ``TRANSFORM``\'s ``TO SQL`` function casts a predefined <data type> value
+to a UDT value and gets invoked whenever a UDT value is passed to the DBMS by a
+host language program or external routine. The ``TRANSFORM``\'s ``FROM SQL``
+function casts a UDT value to a predefined <data type> value and gets invoked
+whenever a UDT value is passed from the DBMS to a host language program or
+external routine.
 
 *DROP CAST Statement*
 ---------------------
 
-The ``DROP CAST`` statement lets you destroy a user-defined cast. The 
+The ``DROP CAST`` statement lets you destroy a user-defined cast. The
 required syntax for the ``DROP CAST`` statement is:
 
 ::
@@ -1187,7 +1189,7 @@ required syntax for the ``DROP CAST`` statement is:
 *DROP ORDERING Statement*
 -------------------------
 
-The ``DROP ORDERING`` statement lets you destroy an ordering for a UDT. The 
+The ``DROP ORDERING`` statement lets you destroy an ordering for a UDT. The
 required syntax for the ``DROP ORDERING`` statement is:
 
 ::
@@ -1197,7 +1199,7 @@ required syntax for the ``DROP ORDERING`` statement is:
 *DROP TRANSFORM Statement*
 --------------------------
 
-The ``DROP TRANSFORM`` statement lets you destroy a transform. The required 
+The ``DROP TRANSFORM`` statement lets you destroy a transform. The required
 syntax for the ``DROP TRANSFORM`` statement is:
 
 ::
@@ -1207,7 +1209,7 @@ syntax for the ``DROP TRANSFORM`` statement is:
 *DROP TYPE Statement*
 ---------------------
 
-The ``DROP TYPE`` statement lets you destroy a UDT. The required syntax for the 
+The ``DROP TYPE`` statement lets you destroy a UDT. The required syntax for the
 ``DROP TYPE`` statement is:
 
 ::
@@ -1217,7 +1219,7 @@ The ``DROP TYPE`` statement lets you destroy a UDT. The required syntax for the
 *NEW Statement*
 ---------------
 
-The ``NEW`` statement lets you invoke a method on a newly-constructed value 
+The ``NEW`` statement lets you invoke a method on a newly-constructed value
 of a structured type. The required syntax for the ``NEW`` statement is:
 
 ::
@@ -1227,9 +1229,9 @@ of a structured type. The required syntax for the ``NEW`` statement is:
 *TREAT Statement*
 -----------------
 
-The ``TREAT`` statement lets you modify the declared type of a structured type 
-expression to a type of one of its supertypes. The required syntax for the 
-``TREAT`` statement is: 
+The ``TREAT`` statement lets you modify the declared type of a structured type
+expression to a type of one of its supertypes. The required syntax for the
+``TREAT`` statement is:
 
 ::
 
@@ -1238,7 +1240,7 @@ expression to a type of one of its supertypes. The required syntax for the
 *DEREF Function*
 ----------------
 
-The ``DEREF`` function lets you obtain the data value referenced by a <reference 
+The ``DEREF`` function lets you obtain the data value referenced by a <reference
 type>. The required syntax is:
 
 ::
@@ -1286,76 +1288,76 @@ family). The required syntax is as follows
 Is object/relational really object-oriented?
 ============================================
 
-Is O/R really OO? Lets go through the features that are considered to be 
-standard parts of an object-oriented specification and see whether SQL3 
-delivers them. (In this list, "UDT" means "UDTs which are structured types".) 
+Is O/R really OO? Lets go through the features that are considered to be
+standard parts of an object-oriented specification and see whether SQL3
+delivers them. (In this list, "UDT" means "UDTs which are structured types".)
 
 **Classes**
 
-UDTs are classes. SQL3 vocabulary may include words like "type family" where 
-most languages' vocabulary would have "class family", but the essential 
-functionality is the same. 
+UDTs are classes. SQL3 vocabulary may include words like "type family" where
+most languages' vocabulary would have "class family", but the essential
+functionality is the same.
 
 **Encapsulation**
 
-SQL3 keeps data representation separate from data access, but does not allow 
-for PRIVATE and PUBLIC Attribute definitions -- those are matters for ``GRANT`` 
-and ``REVOKE`` to handle. 
+SQL3 keeps data representation separate from data access, but does not allow
+for PRIVATE and PUBLIC Attribute definitions -- those are matters for ``GRANT``
+and ``REVOKE`` to handle.
 
 **Extensibility**
 
-It is possible to put together packages consisting of new type families, 
-methods and representations. Such packages exist today, although to a large 
-extent -- for efficiency reasons -- the methods are external functions written 
-in some other language. 
+It is possible to put together packages consisting of new type families,
+methods and representations. Such packages exist today, although to a large
+extent -- for efficiency reasons -- the methods are external functions written
+in some other language.
 
 **Inheritance**
 
-A UDT may be defined under another UDT. Subtypes inherit the methods and 
-Attributes of their supertypes. Inheritance is single, as in most pure 
-object-oriented languages. 
+A UDT may be defined under another UDT. Subtypes inherit the methods and
+Attributes of their supertypes. Inheritance is single, as in most pure
+object-oriented languages.
 
 **Instantiation**
 
-SQL3's UDTs may be used in place of predefined <data type>s in SQL-data 
-statements. Rows in typed Tables may be treated as objects, complete with 
-object identifiers. 
+SQL3's UDTs may be used in place of predefined <data type>s in SQL-data
+statements. Rows in typed Tables may be treated as objects, complete with
+object identifiers.
 
 **Introspection**
 
-SQL already has a clean way to find out what a database's structural components 
-are: ``INFORMATION_SCHEMA``. It should be no big deal to put wrappers around 
-SQL statements that ``SELECT`` from ``INFORMATION_SCHEMA``. Unfortunately, it 
-is more likely that wrappers will instead be put around the unwieldy CLI 
-Catalog functions (see our chapter on CLI Catalog functions). 
+SQL already has a clean way to find out what a database's structural components
+are: ``INFORMATION_SCHEMA``. It should be no big deal to put wrappers around
+SQL statements that ``SELECT`` from ``INFORMATION_SCHEMA``. Unfortunately, it
+is more likely that wrappers will instead be put around the unwieldy CLI
+Catalog functions (see our chapter on CLI Catalog functions).
 
 **Polymorphism**
 
-Multiple methods in a type family may have the same name. The DBMS will choose 
-the specific method based on the signature. This is Java-like. 
+Multiple methods in a type family may have the same name. The DBMS will choose
+the specific method based on the signature. This is Java-like.
 
-It should be admitted that, like any hybrid, SQL3 will look bad to purists on 
-both sides. The relational theorists will note that SQL3's new features -- 
-especially self-referencing columns -- allow for "pointer-chasing" demons which 
-we thought were buried along with pre-SQL DBMSs. The object oriented 
-aficionados may decry the ease with which encapsulation can be broken, at least 
-in appearance, by recourse to SQL-92 manipulation methods. From both 
-directions, SQL3 will get flak as a chimera -- a monster with a lion's head on 
-a goat's body with a serpent's tail -- which certainly betrays its origins as 
-an animal designed by a committee. 
+It should be admitted that, like any hybrid, SQL3 will look bad to purists on
+both sides. The relational theorists will note that SQL3's new features --
+especially self-referencing columns -- allow for "pointer-chasing" demons which
+we thought were buried along with pre-SQL DBMSs. The object oriented
+aficionados may decry the ease with which encapsulation can be broken, at least
+in appearance, by recourse to SQL-92 manipulation methods. From both
+directions, SQL3 will get flak as a chimera -- a monster with a lion's head on
+a goat's body with a serpent's tail -- which certainly betrays its origins as
+an animal designed by a committee.
 
-All such criticisms are beside the point, though. SQL3 was put together to meet 
-certain needs which are urgent in the current market environment: 
+All such criticisms are beside the point, though. SQL3 was put together to meet
+certain needs which are urgent in the current market environment:
 
 * To meld with object-oriented host languages, especially Java.
 
 * To allow for multi-media extensions.
 
-* To pre-empt the chaos which would result from non-standard vendor 
+* To pre-empt the chaos which would result from non-standard vendor
   definitions, or competition from pure OO DBMSs.
 
-Given these goals, Object/Relational SQL3 is a reasonable development. We 
-now wait to see whether users will find that it truly meets these urgent 
+Given these goals, Object/Relational SQL3 is a reasonable development. We
+now wait to see whether users will find that it truly meets these urgent
 needs.
 
 Dialects
@@ -1363,37 +1365,37 @@ Dialects
 
 .. |tm| unicode:: U+2122
 
-Some SQL vendors have already introduced Object/Relational features. We give 
+Some SQL vendors have already introduced Object/Relational features. We give
 especial note to:
 
 **UniSQL**
 
-A smaller group, which gained note in 1992 for being the first to introduce an 
-Object/Relational SQL (though some O/R features can be traced all the way back 
-to 1980s versions of DB2 and Ingres). 
+A smaller group, which gained note in 1992 for being the first to introduce an
+Object/Relational SQL (though some O/R features can be traced all the way back
+to 1980s versions of DB2 and Ingres).
 
 **IBM**
 
-Offers "relational extenders", which are packages containing UDTs, user-defined 
-functions, triggers and constraints. At the moment, IBM's "universal database" 
-is probably the implementation which is closest to the SQL3 Object/Relational 
-spec. 
+Offers "relational extenders", which are packages containing UDTs, user-defined
+functions, triggers and constraints. At the moment, IBM's "universal database"
+is probably the implementation which is closest to the SQL3 Object/Relational
+spec.
 
 **Informix**
 
-Bought Illustra (one of the Object/Relational pioneers) and since then has won 
-some praise for its "DataBlades"|tm| plug-ins, which are described as 
-data-type extensions -- that is, Informix emphasizes the utility of defining 
-your own data types, rather than the purported benefits of OO. 
+Bought Illustra (one of the Object/Relational pioneers) and since then has won
+some praise for its "DataBlades"|tm| plug-ins, which are described as
+data-type extensions -- that is, Informix emphasizes the utility of defining
+your own data types, rather than the purported benefits of OO.
 
 **Oracle**
 
-Oracle8's "cartridges" are another name for what we might call "class 
-libraries" in pure OO contexts. So far, most cartridges have been multimedia 
-packages, for example "Video cartridges" and "Spatial cartridges". For 
-performance reasons, Oracle's Object/Relational features have not been popular 
-among its users, till recently. 
+Oracle8's "cartridges" are another name for what we might call "class
+libraries" in pure OO contexts. So far, most cartridges have been multimedia
+packages, for example "Video cartridges" and "Spatial cartridges". For
+performance reasons, Oracle's Object/Relational features have not been popular
+among its users, till recently.
 
-And finally, watch Sun. The world is waiting to see the impact of 
-"JavaBlend"|tm| which purportedly will merge Java with SQL3's 
-Object/Relational extensions. 
+And finally, watch Sun. The world is waiting to see the impact of
+"JavaBlend"|tm| which purportedly will merge Java with SQL3's
+Object/Relational extensions.

--- a/docs/chapters/28.rst
+++ b/docs/chapters/28.rst
@@ -4,10 +4,12 @@
 Chapter 28 -- Introduction to SQL-data operations
 =================================================
 
-In this chapter, we'll describe some common SQL constructs. We'll be using 
-these constructs in the following chapters, to describe how operations on SQL- 
-data work. [Obscure Rule] applies to everything we talk about here, but the 
-definitions are a necessary evil for understanding some of what lies ahead. 
+.. include:: ../_include/note.rst
+
+In this chapter, we'll describe some common SQL constructs. We'll be using
+these constructs in the following chapters, to describe how operations on SQL-
+data work. [Obscure Rule] applies to everything we talk about here, but the
+definitions are a necessary evil for understanding some of what lies ahead.
 
 .. rubric:: Table of Contents
 
@@ -17,9 +19,9 @@ definitions are a necessary evil for understanding some of what lies ahead.
 <value specification>
 =====================
 
-A <value specification> is a scalar expression that specifies either a 
-<literal>, a host language variable parameter or an SQL parameter as a source 
-for a data value. The required syntax for a <value specification> is: 
+A <value specification> is a scalar expression that specifies either a
+<literal>, a host language variable parameter or an SQL parameter as a source
+for a data value. The required syntax for a <value specification> is:
 
 ::
 
@@ -44,84 +46,84 @@ for a data value. The required syntax for a <value specification> is:
        <host parameter name> |
        <SQL parameter reference>
 
-A <value specification> specifies a value that is not selected from a Table -- 
-that is, a <value specification> is either the value represented by a 
-<literal>, the value represented by a host language variable or the value 
-represented by an SQL parameter. A simple <value specification> is either a 
-<literal>, the value of a host language variable or the value of an SQL 
-parameter: it may not be the null value. If a <simple value specification> does 
-evaluate to ``NULL``, the SQL statement that contains it will fail: your DBMS 
-will return the ``SQLSTATE error 22004 "data exception-null value not 
-allowed"``. 
+A <value specification> specifies a value that is not selected from a Table --
+that is, a <value specification> is either the value represented by a
+<literal>, the value represented by a host language variable or the value
+represented by an SQL parameter. A simple <value specification> is either a
+<literal>, the value of a host language variable or the value of an SQL
+parameter: it may not be the null value. If a <simple value specification> does
+evaluate to ``NULL``, the SQL statement that contains it will fail: your DBMS
+will return the ``SQLSTATE error 22004 "data exception-null value not
+allowed"``.
 
-A host parameter specification identifies a host parameter (or a host parameter 
-and its indicator) in an SQL-client Module. If the indicator for a host 
-parameter is set to a negative number, that means the value represented by the 
-host parameter is ``NULL``. If the indicator is set to any other number, that 
-means the value represented by the host parameter is the current value of that 
-host parameter. The required syntax for a <host parameter name> is: 
+A host parameter specification identifies a host parameter (or a host parameter
+and its indicator) in an SQL-client Module. If the indicator for a host
+parameter is set to a negative number, that means the value represented by the
+host parameter is ``NULL``. If the indicator is set to any other number, that
+means the value represented by the host parameter is the current value of that
+host parameter. The required syntax for a <host parameter name> is:
 
 ::
 
     <host parameter name> ::=
     :<identifier>
 
-A <host parameter name> is a <regular identifier> or a <delimited identifier> 
-preceded by a colon (for example, ``:param_name``) -- it identifies a host 
-language parameter, so the name you choose must also, of course, be a valid 
-parameter name in that host language. Each <host parameter name> must be 
-defined in the SQL-client Module that you use it in. The indicator for a host 
-parameter has to be an integer type. We'll talk more about host parameters and 
-variables in our chapters on binding styles. 
+A <host parameter name> is a <regular identifier> or a <delimited identifier>
+preceded by a colon (for example, ``:param_name``) -- it identifies a host
+language parameter, so the name you choose must also, of course, be a valid
+parameter name in that host language. Each <host parameter name> must be
+defined in the SQL-client Module that you use it in. The indicator for a host
+parameter has to be an integer type. We'll talk more about host parameters and
+variables in our chapters on binding styles.
 
-An <SQL parameter reference> identifies a parameter of an SQL-invoked routine, 
-so it can be the name of a function that returns only one value (for example, 
-``CURRENT_ROLE``) or an <SQL parameter name>. (For the syntax of an <SQL 
-parameter name>, see our chapter on SQL-invoked routines.) The value 
-represented by an <SQL parameter reference> is the current value of that SQL 
-parameter. 
+An <SQL parameter reference> identifies a parameter of an SQL-invoked routine,
+so it can be the name of a function that returns only one value (for example,
+``CURRENT_ROLE``) or an <SQL parameter name>. (For the syntax of an <SQL
+parameter name>, see our chapter on SQL-invoked routines.) The value
+represented by an <SQL parameter reference> is the current value of that SQL
+parameter.
 
-An <element reference> identifies an element of an array; see out chapter on 
-<collection type>s. The value represented by an <element reference> is the 
-current value of that element in that particular array. 
+An <element reference> identifies an element of an array; see out chapter on
+<collection type>s. The value represented by an <element reference> is the
+current value of that element in that particular array.
 
-``CURRENT_ROLE``, ``CURRENT_USER``, ``SESSION_USER``, ``SYSTEM_USER`` and 
-``USER`` all identify an <AuthorizationID>; see our chapter on that SQL Object. 
-The value represented by any of these functions is the current value returned 
-by that function: each returns an ``SQL_TEXT`` character string whose value 
-represents an <AuthorizationID>. 
+``CURRENT_ROLE``, ``CURRENT_USER``, ``SESSION_USER``, ``SYSTEM_USER`` and
+``USER`` all identify an <AuthorizationID>; see our chapter on that SQL Object.
+The value represented by any of these functions is the current value returned
+by that function: each returns an ``SQL_TEXT`` character string whose value
+represents an <AuthorizationID>.
 
-``CURRENT_PATH`` identifies a <Schema name> list that helps your DBMS track 
-routines. In the list, both the <Schema name>s and their qualifying <Catalog 
-name>s are <delimited identifier>s and multiple <Schema name>s are separated by 
-commas. 
+``CURRENT_PATH`` identifies a <Schema name> list that helps your DBMS track
+routines. In the list, both the <Schema name>s and their qualifying <Catalog
+name>s are <delimited identifier>s and multiple <Schema name>s are separated by
+commas.
 
-[NON-PORTABLE] The result of ``CURRENT_PATH`` is non-standard because the SQL 
-Standard requires implementors to define whether the result string is fixed 
-length or variable length and the result string's fixed length or maximum 
-length (as applicable). 
+[NON-PORTABLE] The result of ``CURRENT_PATH`` is non-standard because the SQL
+Standard requires implementors to define whether the result string is fixed
+length or variable length and the result string's fixed length or maximum
+length (as applicable).
 
-[OCELOT Implementation] The OCELOT DBMS that comes with this book has 
-``CURRENT_PATH`` return a variable length ``SQL_TEXT`` string. The result has a 
-maximum length of 128 octets. 
+[OCELOT Implementation] The OCELOT DBMS that comes with this book has
+``CURRENT_PATH`` return a variable length ``SQL_TEXT`` string. The result has a
+maximum length of 128 octets.
 
-``VALUE`` identifies an instance of a data value and can only be used in a 
-Domain definition; see our chapter on Domains. 
+``VALUE`` identifies an instance of a data value and can only be used in a
+Domain definition; see our chapter on Domains.
 
-[Obscure Rule] If the <data type> of a <value specification> is character 
-string, the character string it represents has a coercibility attribute of 
-``COERCIBLE``. 
+[Obscure Rule] If the <data type> of a <value specification> is character
+string, the character string it represents has a coercibility attribute of
+``COERCIBLE``.
 
-If you want to restrict your code to Core SQL, don't use an <element reference> 
-or ``CURRENT_PATH`` to specify a value. 
+If you want to restrict your code to Core SQL, don't use an <element reference>
+or ``CURRENT_PATH`` to specify a value.
 
 <value expression>
 ==================
 
-A <value expression> is a scalar expression that specifies a data value. In 
-this book, we most often use the term ``scalar_expression`` to show you where a 
-<value expression> is allowed in SQL syntax. The required syntax for a <value 
-expression> is: 
+A <value expression> is a scalar expression that specifies a data value. In
+this book, we most often use the term ``scalar_expression`` to show you where a
+<value expression> is allowed in SQL syntax. The required syntax for a <value
+expression> is:
 
 ::
 
@@ -136,17 +138,17 @@ expression> is:
     <reference value expression> |
     <collection value expression> |
 
-A <value expression> specifies a value that may or may not be selected from a 
-Table -- that is, it may be a <value specification> or it may be the result of 
-an expression on SQL-data that returns a single number, character string, bit 
-string, ``BLOB``, date, time, timestamp, interval, Boolean value, UDT value, 
-row of data, ``REF`` value or array. The <data type> of a <value expression> is 
-determined by the <data type> of the value it evaluates to. 
+A <value expression> specifies a value that may or may not be selected from a
+Table -- that is, it may be a <value specification> or it may be the result of
+an expression on SQL-data that returns a single number, character string, bit
+string, ``BLOB``, date, time, timestamp, interval, Boolean value, UDT value,
+row of data, ``REF`` value or array. The <data type> of a <value expression> is
+determined by the <data type> of the value it evaluates to.
 
-The following SQL constructs all qualify as <value expression>s; each can 
-optionally include a Collation specification (i.e.: ``COLLATE`` <Collation 
-name>) to force a collating sequence for the value represented by the <value 
-expression>, provided that value's <data type> is character string: 
+The following SQL constructs all qualify as <value expression>s; each can
+optionally include a Collation specification (i.e.: ``COLLATE`` <Collation
+name>) to force a collating sequence for the value represented by the <value
+expression>, provided that value's <data type> is character string:
 
 * A <Column reference>: represents the value of that Column.
 
@@ -156,7 +158,7 @@ expression>, provided that value's <data type> is character string:
 
 * A ``CASE`` expression: represents the value returned by that expression.
 
-* A ``CAST`` specification: represents the value as ``CAST`` to the target 
+* A ``CAST`` specification: represents the value as ``CAST`` to the target
   <data type>.
 
 * A <subtype treatment>: represents the value as modified.
@@ -169,18 +171,18 @@ expression>, provided that value's <data type> is character string:
 
 * A <Field reference>: represents the value of that Field of a particular row.
 
-* A <method invocation> and a <method reference>: represents the value 
+* A <method invocation> and a <method reference>: represents the value
   returned by that method.
 
-If you want to restrict your code to Core SQL, don't use a <value expression> 
-that evaluates to a Boolean value, an array, an interval or a ``REF`` value, 
-don't use a <subtype treatment> to specify a value and don't use the 
-``COLLATE`` clause to force a collating sequence for any value. 
+If you want to restrict your code to Core SQL, don't use a <value expression>
+that evaluates to a Boolean value, an array, an interval or a ``REF`` value,
+don't use a <subtype treatment> to specify a value and don't use the
+``COLLATE`` clause to force a collating sequence for any value.
 
 <row value constructor>
 =======================
 
-A <row value constructor> defines an ordered set of values that make up one 
+A <row value constructor> defines an ordered set of values that make up one
 row of data. The required syntax for a <row value constructor> is:
 
 ::
@@ -190,16 +192,16 @@ row of data. The required syntax for a <row value constructor> is:
     (<value expression> [ {,<value expression>} ... ]) |
     <row subquery> }
 
-A <row value constructor> constructs a row of data values in one of three 
+A <row value constructor> constructs a row of data values in one of three
 possible ways:
 
-1. By evaluating a single <value expression>, for example, the <character 
-   string literal> ``'GOODBYE'``. In this case, the <value expression> may 
-   not be enclosed in parentheses. This rule is explicitly stated in the SQL 
-   Standard to resolve a syntactic ambiguity: in certain circumstances, the 
+1. By evaluating a single <value expression>, for example, the <character
+   string literal> ``'GOODBYE'``. In this case, the <value expression> may
+   not be enclosed in parentheses. This rule is explicitly stated in the SQL
+   Standard to resolve a syntactic ambiguity: in certain circumstances, the
    syntax: (<value expression>) is permitted.
 
-2. By evaluating two or more comma-delimited <value expression>s enclosed in 
+2. By evaluating two or more comma-delimited <value expression>s enclosed in
    parentheses, for example: (``'GOODBYE',10``).
 
 3. By evaluating a <row subquery>, for example:
@@ -208,26 +210,26 @@ possible ways:
 
    ... (SELECT column_2, column_5 FROM Table_2)
 
-The <data type>s of the Column(s) of a <row value constructor> are the <data 
-type>s of the <value expression>(s) or the Column(s) of the <row subquery> that 
-make up the <row value constructor>. If a <row value constructor> is derived 
-from a <row subquery>, then the degree (i.e.: the number of Columns) of the 
-<row value constructor> is the degree of the Table that results from the 
-evaluation of the <row subquery>; otherwise, the degree of the <row value 
-constructor> is the number of <value expression>s that make up the <row value 
-constructor>. 
+The <data type>s of the Column(s) of a <row value constructor> are the <data
+type>s of the <value expression>(s) or the Column(s) of the <row subquery> that
+make up the <row value constructor>. If a <row value constructor> is derived
+from a <row subquery>, then the degree (i.e.: the number of Columns) of the
+<row value constructor> is the degree of the Table that results from the
+evaluation of the <row subquery>; otherwise, the degree of the <row value
+constructor> is the number of <value expression>s that make up the <row value
+constructor>.
 
-In this case, if the number of rows returned by the <row subquery> is zero, the 
-result is a single row containing null values for every Column of the <row 
-subquery>. If the number of rows returned by the subquery is one, the result is 
+In this case, if the number of rows returned by the <row subquery> is zero, the
+result is a single row containing null values for every Column of the <row
+subquery>. If the number of rows returned by the subquery is one, the result is
 that single row. (Note: a <row subquery> may not return more than one row.)
 
 <target specification>
 ======================
 
-A <target specification> is a scalar expression that specifies a host language 
-variable parameter, an SQL parameter or a Column as the target for a data 
-value. The required syntax for a <target specification> is: 
+A <target specification> is a scalar expression that specifies a host language
+variable parameter, an SQL parameter or a Column as the target for a data
+value. The required syntax for a <target specification> is:
 
 ::
 
@@ -236,10 +238,10 @@ value. The required syntax for a <target specification> is:
     <SQL parameter name> |
     <Column reference>
 
-A <target specification> specifies a place to put a value. Most often, this 
-will be a <Column reference> (as in an ``INSERT`` statement), but you can also 
-assign values to an output SQL parameter (see our chapter on SQL-invoked 
-routines) or to a variable in a host language program (see our chapters on 
-binding styles). A <simple target specification> is either a host language 
-variable, an output SQL parameter or a "known not nullable" Column: it may not 
+A <target specification> specifies a place to put a value. Most often, this
+will be a <Column reference> (as in an ``INSERT`` statement), but you can also
+assign values to an output SQL parameter (see our chapter on SQL-invoked
+routines) or to a variable in a host language program (see our chapters on
+binding styles). A <simple target specification> is either a host language
+variable, an output SQL parameter or a "known not nullable" Column: it may not
 be the null value.

--- a/docs/chapters/29.rst
+++ b/docs/chapters/29.rst
@@ -4,6 +4,8 @@
 Chapter 29 -- Simple Search Conditions
 ======================================
 
+.. include:: ../_include/note.rst
+
 We've come at last to the point where we can begin showing you the most
 important aspect of SQL -- how to query your "database". In this chapter,
 we'll begin by describing simple search conditions.

--- a/docs/chapters/30.rst
+++ b/docs/chapters/30.rst
@@ -4,32 +4,34 @@
 Chapter 30 -- Searching with Joins
 ==================================
 
-It's France in the 1600s. Rene Descartes is playing cards with Madame du Barry. 
-The game is War. Each player has a deck. Rene plays a card from the top of his 
-deck. Madame du Barry plays a card from the top of her deck. If Rene's card has 
-a higher value then Madame's, he wins the trick. If his card has a lower value, 
-Madame wins the trick. In the case of a tie, each player throws down another 
-card. They repeat this until one player has all the tricks, or until Rene and 
-Madame think of something more interesting to do (it's France in the 1600s). 
+.. include:: ../_include/note.rst
 
-In set theory, each trick is an ordered two-element pair. There are (52*52) 
-possible first-round combinations. To honor Mr Descartes, we call the set of 
-all possible tricks the *Cartesian product* of the two original (deck) sets. 
-Two valuable insights arise from playing the game: 
+It's France in the 1600s. Rene Descartes is playing cards with Madame du Barry.
+The game is War. Each player has a deck. Rene plays a card from the top of his
+deck. Madame du Barry plays a card from the top of her deck. If Rene's card has
+a higher value then Madame's, he wins the trick. If his card has a lower value,
+Madame wins the trick. In the case of a tie, each player throws down another
+card. They repeat this until one player has all the tricks, or until Rene and
+Madame think of something more interesting to do (it's France in the 1600s).
 
-1. Insight: What matters is the values on the cards. There are no threads 
-   connecting the queens in Rene's deck to the queens in Madame's deck. There 
-   are no notes on each card saying "I match the *n*\th card from the top in the 
-   other deck". There are, in other words, no pointers -- in the real world, we 
-   match based on values. 
+In set theory, each trick is an ordered two-element pair. There are (52*52)
+possible first-round combinations. To honor Mr Descartes, we call the set of
+all possible tricks the *Cartesian product* of the two original (deck) sets.
+Two valuable insights arise from playing the game:
 
-2. Insight: Slow, tedious meaninglessness. We recognize that there is always 
-   conceptually a Cartesian product, but we would like as quickly as possible 
-   to filter out the only interesting cases -- the ties (the 52*4 cases where 
-   the cards' face values are equal). 
+1. Insight: What matters is the values on the cards. There are no threads
+   connecting the queens in Rene's deck to the queens in Madame's deck. There
+   are no notes on each card saying "I match the *n*\th card from the top in the
+   other deck". There are, in other words, no pointers -- in the real world, we
+   match based on values.
 
-The first insight is the basis of relational-database theory. The second is 
-a warning that we want to minimize the undesirable consequences of joined 
+2. Insight: Slow, tedious meaninglessness. We recognize that there is always
+   conceptually a Cartesian product, but we would like as quickly as possible
+   to filter out the only interesting cases -- the ties (the 52*4 cases where
+   the cards' face values are equal).
+
+The first insight is the basis of relational-database theory. The second is
+a warning that we want to minimize the undesirable consequences of joined
 Tables.
 
 .. rubric:: Table of Contents
@@ -40,9 +42,9 @@ Tables.
 Joined Tables
 =============
 
-The SQL definition for a joined Table is: a Table derived from a Cartesian 
-product, an inner join, an outer join or a union join. The required syntax for 
-a joined Table is: 
+The SQL definition for a joined Table is: a Table derived from a Cartesian
+product, an inner join, an outer join or a union join. The required syntax for
+a joined Table is:
 
 ::
 
@@ -61,12 +63,12 @@ a joined Table is:
        ON <search condition> |
        USING (join <Column name> [ {,join <Column name>} ... ])
 
-Basically, a joined Table is the result of some expression that represents an 
-explicit join of two Tables, each of which is identified by a <Table reference> 
-(the <Table reference> could itself be a joined Table, but is usually just a 
-<Table name> or a Table identified by a <Correlation name>, and we'll use only 
-that form for now). We'll use a library database with these Tables in all the 
-examples of joins that follow. Here's our data: 
+Basically, a joined Table is the result of some expression that represents an
+explicit join of two Tables, each of which is identified by a <Table reference>
+(the <Table reference> could itself be a joined Table, but is usually just a
+<Table name> or a Table identified by a <Correlation name>, and we'll use only
+that form for now). We'll use a library database with these Tables in all the
+examples of joins that follow. Here's our data:
 
 **BORROWERS**
 
@@ -112,18 +114,18 @@ examples of joins that follow. Here's our data:
 | ``NULL``          | 4           | Friday                       |
 +-------------------+-------------+------------------------------+
 
-Our example database illustrates a very common Humans --> Transactions --> 
-Objects framework, which appears in many businesses -- (Customers --> Sales --> 
-Products), (Clients --> Deposits_Withdrawals --> Accounts), (Workers --> Shifts 
---> Tasks) -- so think of your own analogies for each example of a join 
-situation that follows. 
+Our example database illustrates a very common Humans --> Transactions -->
+Objects framework, which appears in many businesses -- (Customers --> Sales -->
+Products), (Clients --> Deposits_Withdrawals --> Accounts), (Workers --> Shifts
+--> Tasks) -- so think of your own analogies for each example of a join
+situation that follows.
 
 *Cartesian-Filter Join*
 -----------------------
 
 "List titles for all Books checked out on April 27."
 
-Our answer to this question -- the first of several answers -- will use the 
+Our answer to this question -- the first of several answers -- will use the
 traditional syntax, which is legal in all versions of SQL:
 
 ::
@@ -133,34 +135,34 @@ traditional syntax, which is legal in all versions of SQL:
    WHERE  checkout_date = DATE '1999-04-27' AND
           Books.book_id = Checkouts.book_id;
 
-In this ``SELECT`` statement, the words "``FROM Books, Checkouts``" tell the 
-DBMS we want a Cartesian join of ``BOOKS`` and ``CHECKOUTS``. That gives us 
-four ``BOOKS/CHECKOUTS`` pairs. But the ``WHERE`` conditions filter out the 
-unwanted pairs and leave us with only one. 
+In this ``SELECT`` statement, the words "``FROM Books, Checkouts``" tell the
+DBMS we want a Cartesian join of ``BOOKS`` and ``CHECKOUTS``. That gives us
+four ``BOOKS/CHECKOUTS`` pairs. But the ``WHERE`` conditions filter out the
+unwanted pairs and leave us with only one.
 
-When we think of both the ``WHERE`` clause conditions as "filters" that winnow 
-the results from an imagined Cartesian ``BOOKS+CHECKOUTS`` Table, the two 
-conditions both appear to be doing similar tasks. It appears natural that both 
-conditions should be in the ``WHERE`` clause. Now, here is a niggle: it's not 
-real. You are supposed to conceptualize that a Cartesian product is formed and 
-then filtered, but -- since the number of rows in a Cartesian product is always 
-the number of rows in each individual Table multiplied by each other -- its 
-size rises geometrically as database size rises, so the DBMS will avoid it and 
-quietly use a navigational trick instead ("first find a ``CHECKOUTS`` row where 
-``CHECKOUT_DATE =`` April 27, then take the ``BOOK_ID`` of that checkout and 
-find ``BOOK_ID`` within ``BOOKS ...``"). 
+When we think of both the ``WHERE`` clause conditions as "filters" that winnow
+the results from an imagined Cartesian ``BOOKS+CHECKOUTS`` Table, the two
+conditions both appear to be doing similar tasks. It appears natural that both
+conditions should be in the ``WHERE`` clause. Now, here is a niggle: it's not
+real. You are supposed to conceptualize that a Cartesian product is formed and
+then filtered, but -- since the number of rows in a Cartesian product is always
+the number of rows in each individual Table multiplied by each other -- its
+size rises geometrically as database size rises, so the DBMS will avoid it and
+quietly use a navigational trick instead ("first find a ``CHECKOUTS`` row where
+``CHECKOUT_DATE =`` April 27, then take the ``BOOK_ID`` of that checkout and
+find ``BOOK_ID`` within ``BOOKS ...``").
 
-Efficiency of evaluation isn't the subject of this chapter, though. Right now 
-we're only concerned with the fact that Cartesian products are a simplifying 
-myth. Unfortunately, to programmers aware of the myth, it is obvious that the 
-two conditions in the ``WHERE`` clause are not really the same sort of thing. 
-One is a typical filter, but the other is a glue directive to the DBMS. It's 
-not really a ``WHERE`` sort of condition at all. 
+Efficiency of evaluation isn't the subject of this chapter, though. Right now
+we're only concerned with the fact that Cartesian products are a simplifying
+myth. Unfortunately, to programmers aware of the myth, it is obvious that the
+two conditions in the ``WHERE`` clause are not really the same sort of thing.
+One is a typical filter, but the other is a glue directive to the DBMS. It's
+not really a ``WHERE`` sort of condition at all.
 
 *Cartesian-Filter Join II -- CROSS JOIN*
 ----------------------------------------
-As shown in our syntax diagram earlier, we could use the <keyword>s ``CROSS 
-JOIN`` instead of a comma in the ``FROM`` clause to get the same result: 
+As shown in our syntax diagram earlier, we could use the <keyword>s ``CROSS
+JOIN`` instead of a comma in the ``FROM`` clause to get the same result:
 
 ::
 
@@ -169,15 +171,15 @@ JOIN`` instead of a comma in the ``FROM`` clause to get the same result:
    WHERE  checkout_date = DATE '1999-04-27' AND
           Books.book_id = Checkouts.book_id;
 
-This is synonymous with the "``... FROM Books, Checkouts ...``" query (``CROSS 
-JOIN`` just means "Cartesian product"), and it's too bad we didn't use English 
-words instead of commas in the first place, but ``CROSS JOIN`` is relatively 
-new (a SQL-92 introduction). 
+This is synonymous with the "``... FROM Books, Checkouts ...``" query (``CROSS
+JOIN`` just means "Cartesian product"), and it's too bad we didn't use English
+words instead of commas in the first place, but ``CROSS JOIN`` is relatively
+new (a SQL-92 introduction).
 
 *JOIN ... USING*
 ----------------
 
-We're still asking: "List titles for all Books checked out on April 27". 
+We're still asking: "List titles for all Books checked out on April 27".
 This time we will use the modern syntax:
 
 ::
@@ -186,24 +188,24 @@ This time we will use the modern syntax:
    FROM   Books INNER JOIN Checkouts USING (book_id)
    WHERE  checkout_date = DATE '1999-04-27';
 
-For some years to come, the conventional syntax for joins (our first example) 
-will still be the most popular. However, modern syntax (of which ``JOIN ... 
-USING`` is the best example) is now seen frequently in tutorials and magazine 
-articles, especially when Microsoft Access is the subject. In modern syntax, we 
-acknowledge that joining conditions might look better in a clause of their own. 
-The clause "``USING (book_id)``" replaces the traditional "``WHERE ... 
-Books.book_id = Checkouts.book_id``". Thus, ``BOOK_ID`` is a reference to both 
-``BOOK_ID`` Columns -- the one in the ``BOOKS`` Table and the one in the 
-``CHECKOUTS`` Table. It's not a piece of luck, you know, that we used the same 
-<Column name> in both Tables -- you should always use the same <Column name> 
-when you anticipate joining over a pair of Columns. 
+For some years to come, the conventional syntax for joins (our first example)
+will still be the most popular. However, modern syntax (of which ``JOIN ...
+USING`` is the best example) is now seen frequently in tutorials and magazine
+articles, especially when Microsoft Access is the subject. In modern syntax, we
+acknowledge that joining conditions might look better in a clause of their own.
+The clause "``USING (book_id)``" replaces the traditional "``WHERE ...
+Books.book_id = Checkouts.book_id``". Thus, ``BOOK_ID`` is a reference to both
+``BOOK_ID`` Columns -- the one in the ``BOOKS`` Table and the one in the
+``CHECKOUTS`` Table. It's not a piece of luck, you know, that we used the same
+<Column name> in both Tables -- you should always use the same <Column name>
+when you anticipate joining over a pair of Columns.
 
 *NATURAL JOIN*
 --------------
 
-The ultimate simplification of ``JOIN ... USING`` is to throw out the <Column 
-name>s entirely, and specify "wherever <Column name>s are the same in both 
-Tables, join on them". Here's how: 
+The ultimate simplification of ``JOIN ... USING`` is to throw out the <Column
+name>s entirely, and specify "wherever <Column name>s are the same in both
+Tables, join on them". Here's how:
 
 ::
 
@@ -211,22 +213,22 @@ Tables, join on them". Here's how:
    FROM   Books NATURAL JOIN Checkouts
    WHERE  checkout_date = DATE '1999-04-27';
 
-A natural join is a join over matching Columns (Columns which have the same 
-name in the Tables being joined). This is the ultimate step. It hides the join 
-process from the user who gets the result. Perhaps, one could even change the 
-join <Column name>s, or add new Columns, without having to change all 
-``SELECT`` statements which refer to the joined Tables. On the other hand, 
-users of ``NATURAL JOIN`` have to be careful that all joinable Columns really 
-do have the same name, and that all non-joinable Columns don't. The 
-casual-looking "``Books NATURAL JOIN Checkouts``" is only possible when 
-database naming conventions are formal and enforced. 
+A natural join is a join over matching Columns (Columns which have the same
+name in the Tables being joined). This is the ultimate step. It hides the join
+process from the user who gets the result. Perhaps, one could even change the
+join <Column name>s, or add new Columns, without having to change all
+``SELECT`` statements which refer to the joined Tables. On the other hand,
+users of ``NATURAL JOIN`` have to be careful that all joinable Columns really
+do have the same name, and that all non-joinable Columns don't. The
+casual-looking "``Books NATURAL JOIN Checkouts``" is only possible when
+database naming conventions are formal and enforced.
 
-In some places, the custom is to use ``NATURAL JOIN`` for only one class of 
-situations: where one is joining a Table with a ``FOREIGN KEY`` Constraint to 
-the Table that the foreign key ``REFERENCES``. Such a join is, due to the way 
-that primary/foreign keys work, always a "one-to-many" join (that is: there 
-will always be only one row in ``TABLE_1`` which is joined with between zero 
-and infinity rows in ``TABLE_2``). 
+In some places, the custom is to use ``NATURAL JOIN`` for only one class of
+situations: where one is joining a Table with a ``FOREIGN KEY`` Constraint to
+the Table that the foreign key ``REFERENCES``. Such a join is, due to the way
+that primary/foreign keys work, always a "one-to-many" join (that is: there
+will always be only one row in ``TABLE_1`` which is joined with between zero
+and infinity rows in ``TABLE_2``).
 
 *JOIN ... ON*
 -------------
@@ -240,32 +242,32 @@ There is one more way to "List titles for books checked out on April 27":
            ON (Books.book_id = Checkouts.book_id)
    WHERE  checkout_date = DATE '1999-04-27';
 
-With this syntax, the ``ON`` clause introduces a conditional expression for a 
-join: it contains a conditional expression just like a ``WHERE`` clause does. 
-Legally, you could take all the conditions out of the ``WHERE`` clause and put 
-them in the ``ON`` clause, but that would flout the principle of the exercise, 
-which is: "``ON`` clauses should have joining conditions, ``WHERE`` clauses 
-should have filtering conditions". Earlier we discussed why this syntax just 
-looks better, to some people, than the conventional syntax. Later we'll discuss 
-one situation where you *must* use ``ON`` rather than ``WHERE``, but the 
-current example is not one of those situations. The more immediate question is: 
-why would we ever want to use ``ON`` rather than ``USING``? The immediate reply 
-is: well, ``USING`` is only possible when you're joining over two Columns with 
-the same name and when the relator is implicitly equality (``=``). Joins can, 
-of course, also be related using the other SQL comparison operators too. 
+With this syntax, the ``ON`` clause introduces a conditional expression for a
+join: it contains a conditional expression just like a ``WHERE`` clause does.
+Legally, you could take all the conditions out of the ``WHERE`` clause and put
+them in the ``ON`` clause, but that would flout the principle of the exercise,
+which is: "``ON`` clauses should have joining conditions, ``WHERE`` clauses
+should have filtering conditions". Earlier we discussed why this syntax just
+looks better, to some people, than the conventional syntax. Later we'll discuss
+one situation where you *must* use ``ON`` rather than ``WHERE``, but the
+current example is not one of those situations. The more immediate question is:
+why would we ever want to use ``ON`` rather than ``USING``? The immediate reply
+is: well, ``USING`` is only possible when you're joining over two Columns with
+the same name and when the relator is implicitly equality (``=``). Joins can,
+of course, also be related using the other SQL comparison operators too.
 
 *Self-Joins*
 ------------
 
-Here's a new question: "List parents with their children." 
+Here's a new question: "List parents with their children."
 
-Among our library's borrowers are several children. Their parents also have 
-cards (it's one of the conditions of membership for child borrowers). That is, 
-there is a relationship between different rows of the same Table. When we have 
-a query that bases itself on an intra-Table relationship, we must join the 
-Table with itself -- this is called a *self-join* and is one of the rare cases 
-where SQL provides no alternative means of answering the query. Here's an 
-example: 
+Among our library's borrowers are several children. Their parents also have
+cards (it's one of the conditions of membership for child borrowers). That is,
+there is a relationship between different rows of the same Table. When we have
+a query that bases itself on an intra-Table relationship, we must join the
+Table with itself -- this is called a *self-join* and is one of the rare cases
+where SQL provides no alternative means of answering the query. Here's an
+example:
 
 ::
 
@@ -275,7 +277,7 @@ example:
           Borrowers AS Children
    WHERE  Parents.name = Children.parent;
 
-The result is: 
+The result is:
 
 +----------+----------+
 | ``NAME`` | ``NAME`` |
@@ -287,19 +289,19 @@ The result is:
 | Christa  | Jaclyn   |
 +----------+----------+
 
-In a self-join, by definition, all the Columns in the first Table have the same 
-names as the Columns in the second Table. So we can't ``SELECT name ...`` or 
-even ``SELECT Borrowers.name ...`` -- such expressions are ambiguous. This is a 
-case where we absolutely must use a <Correlation name> to explicitly identify 
-each Table, and each Column of a particular Table. Here, we've given one copy 
-of the ``BORROWERS`` Table the <Correlation name> ``PARENTS``, and the other 
-the <Correlation name> ``CHILDREN``, so as to be able to distinguish between 
-them. 
+In a self-join, by definition, all the Columns in the first Table have the same
+names as the Columns in the second Table. So we can't ``SELECT name ...`` or
+even ``SELECT Borrowers.name ...`` -- such expressions are ambiguous. This is a
+case where we absolutely must use a <Correlation name> to explicitly identify
+each Table, and each Column of a particular Table. Here, we've given one copy
+of the ``BORROWERS`` Table the <Correlation name> ``PARENTS``, and the other
+the <Correlation name> ``CHILDREN``, so as to be able to distinguish between
+them.
 
 *Theta-Joins*
 -------------
 
-A *theta-join* is any Cartesian product that's filtered by a condition which 
+A *theta-join* is any Cartesian product that's filtered by a condition which
 compares values from both Tables. That is, the general theta-join form is:
 
 ::
@@ -312,24 +314,24 @@ where the relator is almost always "``=``", as in this example:
 
    Sellers.seller_name = Sales.seller_name
 
-This special case of theta-join -- where the relation is equality -- is 
-called an *equijoin*. Although all relators are legal, the other kinds of 
+This special case of theta-join -- where the relation is equality -- is
+called an *equijoin*. Although all relators are legal, the other kinds of
 theta-join are, in fact, rare.
 
-In a typical programming life, you'll never encounter a lone theta-join (or if 
-you do, you're looking at some sort of an error). The common cases are always 
-double theta-joins. Here is an example: 
+In a typical programming life, you'll never encounter a lone theta-join (or if
+you do, you're looking at some sort of an error). The common cases are always
+double theta-joins. Here is an example:
 
 Double Theta: > Combined with Equijoin
 ______________________________________
 
-"List identification numbers of borrowers who took out books on two 
+"List identification numbers of borrowers who took out books on two
 different days."
 
-To answer this request, we need to use a greater than operator, so this is an 
-example of a general theta-join -- but it's also an equijoin. Here are two ways 
-of doing it (the first example uses the ``WHERE`` clause to set the conditions 
-and the second example uses the ``ON`` clause for the same purpose): 
+To answer this request, we need to use a greater than operator, so this is an
+example of a general theta-join -- but it's also an equijoin. Here are two ways
+of doing it (the first example uses the ``WHERE`` clause to set the conditions
+and the second example uses the ``ON`` clause for the same purpose):
 
 ::
 
@@ -345,7 +347,7 @@ and the second example uses the ``ON`` clause for the same purpose):
    ON   (Firsts.borrower_id = Seconds.borrower_id) AND
         (Firsts.date > Seconds.date);
 
-(Remember that the <keyword> ``AS`` is optional when you're defining a 
+(Remember that the <keyword> ``AS`` is optional when you're defining a
 <Correlation name>.) The result is:
 
 +-----------------+
@@ -356,18 +358,18 @@ and the second example uses the ``ON`` clause for the same purpose):
 
 .. TIP::
 
-   For queries containing the word "different", consider whether a ``>`` 
-   will do. Queries with ``>`` are often a bit faster than queries with 
+   For queries containing the word "different", consider whether a ``>``
+   will do. Queries with ``>`` are often a bit faster than queries with
    ``<>``.
 
-The double theta-join is, in practice, often associated with a self-join. 
-Sometimes the relators are ``<=`` and ``>=`` (for instance, when we join over a 
+The double theta-join is, in practice, often associated with a self-join.
+Sometimes the relators are ``<=`` and ``>=`` (for instance, when we join over a
 floating-point number).
 
 *Bad Joins*
 -----------
 
-"List all the borrowers whose names appear in a book title, and the book 
+"List all the borrowers whose names appear in a book title, and the book
 titles."
 
 ::
@@ -378,22 +380,22 @@ titles."
 
 The result is no rows found.
 
-It might please 'Paige' to find her name on a book: 'The book of Paige ...'. 
-The syntax is technically legal. The reasons that we use this as a bad join 
+It might please 'Paige' to find her name on a book: 'The book of Paige ...'.
+The syntax is technically legal. The reasons that we use this as a bad join
 example are:
 
-* The Domain of ``BORROWERS.NAME`` is not the same as the Domain of 
-  ``BOOKS.TITLE``, and there are no Columns common to ``BORROWERS`` and 
-  ``BOOKS`` which would qualify for a ``NATURAL JOIN``. Together, these two 
-  observations are always signs that a query is frivolous, if not downright 
-  erroneous. 
+* The Domain of ``BORROWERS.NAME`` is not the same as the Domain of
+  ``BOOKS.TITLE``, and there are no Columns common to ``BORROWERS`` and
+  ``BOOKS`` which would qualify for a ``NATURAL JOIN``. Together, these two
+  observations are always signs that a query is frivolous, if not downright
+  erroneous.
 
-* The joining expression contains a scalar, and has both Columns on the 
-  same side of the relator. Together, these two characteristics will choke 
+* The joining expression contains a scalar, and has both Columns on the
+  same side of the relator. Together, these two characteristics will choke
   every DBMS currently in existence.
 
-Allow the query, of course. But, for critical and common situations, use 
-only simple expressions, on related Tables, over similar Columns. Odd syntax 
+Allow the query, of course. But, for critical and common situations, use
+only simple expressions, on related Tables, over similar Columns. Odd syntax
 is bad syntax.
 
 *Joins with Multiple Tables*
@@ -401,7 +403,7 @@ is bad syntax.
 
 "List titles and borrowers for books taken out on April 27."
 
-The answer is straightforward -- once you know two-Table joins you can also 
+The answer is straightforward -- once you know two-Table joins you can also
 do three-Table joins:
 
 ::
@@ -420,17 +422,17 @@ The result is:
 | Paige    | The Borrowers |
 +----------+---------------+
 
-It should be possible in a 3-way join to follow a chain of links as a reading 
-exercise. In this case, if we start with the first Table (``BORROWERS``), we 
-can see that it's possible to go from there to ``CHECKOUTS`` (using the 
-``BORROWER_ID`` Column), and from ``CHECKOUTS`` to ``BOOKS`` (using the 
-``BOOK_ID`` Column). If there is no chain, think hard: maybe the query "goes 
-Cartesian" during some intermediate stage. 
+It should be possible in a 3-way join to follow a chain of links as a reading
+exercise. In this case, if we start with the first Table (``BORROWERS``), we
+can see that it's possible to go from there to ``CHECKOUTS`` (using the
+``BORROWER_ID`` Column), and from ``CHECKOUTS`` to ``BOOKS`` (using the
+``BOOK_ID`` Column). If there is no chain, think hard: maybe the query "goes
+Cartesian" during some intermediate stage.
 
 .. CAUTION::
 
-   The next query looks like it does the same thing. In fact, though, it is 
-   an example of the most common mistake that can happen with multi-Table 
+   The next query looks like it does the same thing. In fact, though, it is
+   an example of the most common mistake that can happen with multi-Table
    joins:
 
    ::
@@ -446,27 +448,27 @@ Cartesian" during some intermediate stage.
                     FROM   Checkouts
                     WHERE checkout_date = DATE '1999-04-27');
 
-   The error is in the assumption that "if A is linked to B and C is linked to 
-   B, then C is linked to A". That sounds like fundamental arithmetic (the Law 
-   Of Transitivity) -- but it's wrong in this case because B is not a value -- 
-   it is a set of values -- and the ``IN`` predicate means "... linked to any 
-   one of (B) ...". When writing a multi-Table join, an intermediate link 
-   should be true "for all", not just "for any". 
+   The error is in the assumption that "if A is linked to B and C is linked to
+   B, then C is linked to A". That sounds like fundamental arithmetic (the Law
+   Of Transitivity) -- but it's wrong in this case because B is not a value --
+   it is a set of values -- and the ``IN`` predicate means "... linked to any
+   one of (B) ...". When writing a multi-Table join, an intermediate link
+   should be true "for all", not just "for any".
 
-What about 4-Table, 5-Table, 6-Table joins? Yes, as long as you remember that 
-adding a new Table adds time to your query geometrically. Eventually you will 
-run into a fixed limit for every DBMS. To conform with the US government's 
-requirements (FIPS 127-2), an "intermediate level" SQL DBMS must be able to 
-join at least 10 Tables. If you find yourself needing more than that, you might 
-want to consider either *(a)* splitting up your query using temporary Tables or 
-*(b)* combining two Tables into one ("denormalizing"). 
+What about 4-Table, 5-Table, 6-Table joins? Yes, as long as you remember that
+adding a new Table adds time to your query geometrically. Eventually you will
+run into a fixed limit for every DBMS. To conform with the US government's
+requirements (FIPS 127-2), an "intermediate level" SQL DBMS must be able to
+join at least 10 Tables. If you find yourself needing more than that, you might
+want to consider either *(a)* splitting up your query using temporary Tables or
+*(b)* combining two Tables into one ("denormalizing").
 
 *Avoiding Duplicates*
 ---------------------
 
 "List names of borrowers who have taken out books."
 
-To get the result, you can use any join syntax you like, provided you 
+To get the result, you can use any join syntax you like, provided you
 include ``DISTINCT`` in your select list. Here's an example:
 
 ::
@@ -485,19 +487,19 @@ The result is:
 | Hayley   |
 +----------+
 
-Without ``DISTINCT``, we would see 'Hayley' twice in the result, because Hayley 
-took out two books. Any join can cause duplication unless both sides of the 
-join are unique keys. So we are tempted to say: "always use ``DISTINCT`` when 
-you join" ... but that would be a false tip. True, you want to eliminate 
-duplicates caused in this case by the join, but what if there are two Hayleys? 
-That is, do you want to eliminate duplicates which were not caused by the join? 
-Some people would answer "yes I do", and would add "duplicate information isn't 
-real information anyway". We'll contrive an example, then: *(a)* we want to 
-hand out name cards to borrowers who took books out, so this list is going to a 
-printer and *(b)* assume that there are two different 'Hayley's, one of whom 
-took out two books. If we form a query using ``DISTINCT``, we'll get too few 
-'Hayley' cards -- but if we don't use ``DISTINCT`` we'll get too many 'Hayley' 
-cards. For such situations, the real tip is: use a subquery, like this: 
+Without ``DISTINCT``, we would see 'Hayley' twice in the result, because Hayley
+took out two books. Any join can cause duplication unless both sides of the
+join are unique keys. So we are tempted to say: "always use ``DISTINCT`` when
+you join" ... but that would be a false tip. True, you want to eliminate
+duplicates caused in this case by the join, but what if there are two Hayleys?
+That is, do you want to eliminate duplicates which were not caused by the join?
+Some people would answer "yes I do", and would add "duplicate information isn't
+real information anyway". We'll contrive an example, then: *(a)* we want to
+hand out name cards to borrowers who took books out, so this list is going to a
+printer and *(b)* assume that there are two different 'Hayley's, one of whom
+took out two books. If we form a query using ``DISTINCT``, we'll get too few
+'Hayley' cards -- but if we don't use ``DISTINCT`` we'll get too many 'Hayley'
+cards. For such situations, the real tip is: use a subquery, like this:
 
 ::
 
@@ -505,23 +507,23 @@ cards. For such situations, the real tip is: use a subquery, like this:
    FROM   Borrowers
    WHERE  borrower_id IN (SELECT borrower_id FROM Checkouts);
 
-This query neither generates nor eliminates duplicates, so would be better. 
+This query neither generates nor eliminates duplicates, so would be better.
 We'll talk more about subqueries in a later chapter.
 
-Amusing story: There once was a vendor who secretly converted all subqueries 
-into joins (the transform is fairly easy), and that vendor's DBMS produced 
-spurious duplicate rows when subqueries were used. Instead of admitting this, 
-that vendor's employees wrote an "SQL textbook" informing the public that false 
-duplicates were a necessary evil of Standard SQL! The vendor is still around 
-and sells thousands of copies a month. 
+Amusing story: There once was a vendor who secretly converted all subqueries
+into joins (the transform is fairly easy), and that vendor's DBMS produced
+spurious duplicate rows when subqueries were used. Instead of admitting this,
+that vendor's employees wrote an "SQL textbook" informing the public that false
+duplicates were a necessary evil of Standard SQL! The vendor is still around
+and sells thousands of copies a month.
 
 *OUTER JOIN*
 ------------
 
-"List all books, along with the dates they were checked out and who borrowed 
-them (if they're out)." 
+"List all books, along with the dates they were checked out and who borrowed
+them (if they're out)."
 
-This query will give us the ``NATURAL JOIN`` of the ``BOOKS`` and 
+This query will give us the ``NATURAL JOIN`` of the ``BOOKS`` and
 ``CHECKOUTS`` Tables:
 
 ::
@@ -543,10 +545,10 @@ The result is:
 | The Hobbit                   | 1999-04-29        | 2               |
 +------------------------------+-------------------+-----------------+
 
-There is one book missing from the list. At this point, most people will say 
-"What about 'Friday'? I realize it's not in the ``CHECKOUTS`` Table, but that 
-very fact is important to me. It seems your join will always lose information 
-unless both Tables have the same set of matching keys." 
+There is one book missing from the list. At this point, most people will say
+"What about 'Friday'? I realize it's not in the ``CHECKOUTS`` Table, but that
+very fact is important to me. It seems your join will always lose information
+unless both Tables have the same set of matching keys."
 
 True -- but there is a way around this. Let's give 'Friday' a checkout:
 
@@ -568,29 +570,29 @@ Now, when we do the ``NATURAL JOIN`` again, we get this result:
 | Friday                       | ``NULL``          | ``NULL``        |
 +------------------------------+-------------------+-----------------+
 
-... and that's your answer. (Incidentally we inserted ``NULL`` in the 
-``BORROWER_ID`` Column because the book wasn't really checked out, so no 
+... and that's your answer. (Incidentally we inserted ``NULL`` in the
+``BORROWER_ID`` Column because the book wasn't really checked out, so no
 one's ID could apply.)
 
-"So, to band-aid your broken join you invent an ad-hoc ``CHECKOUTS`` row 
+"So, to band-aid your broken join you invent an ad-hoc ``CHECKOUTS`` row
 that matches. I can imagine what your idea of a general solution would be."
 
-Exactly. The general solution would be imaginary rows. In fact, we don't 
-really have to insert them all, we can just pretend they're there -- and 
+Exactly. The general solution would be imaginary rows. In fact, we don't
+really have to insert them all, we can just pretend they're there -- and
 call what we're doing an ``OUTER JOIN``.
 
 "Okay."
 
-But is it really okay? It's true that the ``OUTER JOIN`` has answered the 
-example question: an ``OUTER JOIN`` will answer any question of the form 
-"give me the join of Table A and Table B without losing information from 
-Table A." So, sure it's okay, as long as we keep in mind that there's a 
-band-aid involved. In particular -- what is this ``NULL``? Certainly it 
-does not mean ``UNKNOWN``. Remember, we're not uncertain what the 
-``BORROWER_ID`` is; on the contrary, we know perfectly well that there 
-is no ``BORROWER_ID`` for 'Friday'. 
+But is it really okay? It's true that the ``OUTER JOIN`` has answered the
+example question: an ``OUTER JOIN`` will answer any question of the form
+"give me the join of Table A and Table B without losing information from
+Table A." So, sure it's okay, as long as we keep in mind that there's a
+band-aid involved. In particular -- what is this ``NULL``? Certainly it
+does not mean ``UNKNOWN``. Remember, we're not uncertain what the
+``BORROWER_ID`` is; on the contrary, we know perfectly well that there
+is no ``BORROWER_ID`` for 'Friday'.
 
-SQL actually provides us with "official" syntax to express an ``OUTER JOIN`` 
+SQL actually provides us with "official" syntax to express an ``OUTER JOIN``
 request:
 
 ::
@@ -598,69 +600,69 @@ request:
    SELECT Books.title, Books.checkout_date, Checkouts.borrower_id
    FROM   Checkouts RIGHT OUTER JOIN Books USING (book_id);
 
-Our example is a "right" outer join because, although we have everything 
-in the right (second) Table (which is ``BOOKS``), there are implied 
-``NULL``\s in the left (first) Table (which is ``CHECKOUTS``). In such 
-cases, the <keyword> ``RIGHT`` is mandatory (although the <keyword> 
-``OUTER`` is optional). You must always use ``RIGHT [OUTER] JOIN`` in 
-conjunction with a ``USING`` clause or an ``ON`` clause -- though a 
-query can certainly also include a ``WHERE`` clause, it should not 
-contain the joining conditions. 
+Our example is a "right" outer join because, although we have everything
+in the right (second) Table (which is ``BOOKS``), there are implied
+``NULL``\s in the left (first) Table (which is ``CHECKOUTS``). In such
+cases, the <keyword> ``RIGHT`` is mandatory (although the <keyword>
+``OUTER`` is optional). You must always use ``RIGHT [OUTER] JOIN`` in
+conjunction with a ``USING`` clause or an ``ON`` clause -- though a
+query can certainly also include a ``WHERE`` clause, it should not
+contain the joining conditions.
 
-Since there are ``RIGHT [OUTER] JOIN``\s, there ought to be ``LEFT 
-[OUTER] JOIN``\s too, and indeed there are. For instance, we could have 
-made our query this way: 
+Since there are ``RIGHT [OUTER] JOIN``\s, there ought to be ``LEFT
+[OUTER] JOIN``\s too, and indeed there are. For instance, we could have
+made our query this way:
 
 ::
 
    SELECT Books.title, Books.checkout_date, Checkouts.borrower_id
    FROM   Books LEFT OUTER JOIN Checkouts USING (book_id);
 
-There is also a ``FULL [OUTER] JOIN``, for situations when there might be 
+There is also a ``FULL [OUTER] JOIN``, for situations when there might be
 missing information from both joined Tables. This is rarely used.
 
-To summarize: the basic idea behind an ``OUTER JOIN`` is that, where an 
-``INNER JOIN`` would lose rows because there is no row in one of the 
-joined Tables that matches a row in the other Table, an ``OUTER JOIN`` 
-includes such rows -- with a ``NULL`` in the Column positions that would 
-show values from some matching row, if a matching row existed. An 
-``INNER JOIN`` loses non-matching rows; an ``OUTER JOIN`` preserves 
-them. For two Tables, a ``LEFT OUTER JOIN`` preserves non-matching rows 
-from the first Table, a ``RIGHT OUTER JOIN`` preserves non-matching rows 
-from the second Table and a ``FULL OUTER JOIN`` preserves non-matching 
-rows from both Tables. 
+To summarize: the basic idea behind an ``OUTER JOIN`` is that, where an
+``INNER JOIN`` would lose rows because there is no row in one of the
+joined Tables that matches a row in the other Table, an ``OUTER JOIN``
+includes such rows -- with a ``NULL`` in the Column positions that would
+show values from some matching row, if a matching row existed. An
+``INNER JOIN`` loses non-matching rows; an ``OUTER JOIN`` preserves
+them. For two Tables, a ``LEFT OUTER JOIN`` preserves non-matching rows
+from the first Table, a ``RIGHT OUTER JOIN`` preserves non-matching rows
+from the second Table and a ``FULL OUTER JOIN`` preserves non-matching
+rows from both Tables.
 
-Consider using ``OUTER JOIN`` if you worry that ``INNER JOIN`` would 
-lose information that is really valuable. But if you use them a lot, 
-that's too often. There are severe consequences to using outer joins 
-unnecessarily: 
+Consider using ``OUTER JOIN`` if you worry that ``INNER JOIN`` would
+lose information that is really valuable. But if you use them a lot,
+that's too often. There are severe consequences to using outer joins
+unnecessarily:
 
 ``Outer Join`` **Downside #1 -- Performance** Inner joins are always faster.
 
-``Outer Join`` **Downside #2 -- Syntax** Although all the major vendors are 
-now able to handle the SQL-92 Standard syntax for outer joins, there is a 
+``Outer Join`` **Downside #2 -- Syntax** Although all the major vendors are
+now able to handle the SQL-92 Standard syntax for outer joins, there is a
 bewildering variety of "outer join" syntaxes still in existence.
 
-``Outer Join`` **Downside #3 -- Three-way-join confusion** Let's face 
-it, we're not bright enough to figure out what "``Table_1 LEFT JOIN 
-Table_2 RIGHT JOIN Table_3``" means. And it appears that not all vendors 
-are bright either. Trying multiple outer joins with different DBMSs will 
-give different results. 
+``Outer Join`` **Downside #3 -- Three-way-join confusion** Let's face
+it, we're not bright enough to figure out what "``Table_1 LEFT JOIN
+Table_2 RIGHT JOIN Table_3``" means. And it appears that not all vendors
+are bright either. Trying multiple outer joins with different DBMSs will
+give different results.
 
-``Outer Join`` **Downside #4 -- Nullability** You can't think "Column X was 
-defined as ``NOT NULL`` so it will never be ``NULL``" -- any Column can be 
+``Outer Join`` **Downside #4 -- Nullability** You can't think "Column X was
+defined as ``NOT NULL`` so it will never be ``NULL``" -- any Column can be
 ``NULL`` if it's in an ``OUTER JOIN``.
 
-``Outer Join`` **Downside #5 -- Confused** ``NULL`` We can't tell whether a 
+``Outer Join`` **Downside #5 -- Confused** ``NULL`` We can't tell whether a
 ``NULL`` is due to an ``OUTER JOIN`` or was always there.
 
 *UNION JOIN*
 ------------
 
-A ``UNION JOIN`` constructs a result Table that includes every Column of both 
-Tables and every row of both Tables. Every Column position that has no value 
-because it wasn't part of one or the other Table you're joining, gets a null 
-value. Here's an example: 
+A ``UNION JOIN`` constructs a result Table that includes every Column of both
+Tables and every row of both Tables. Every Column position that has no value
+because it wasn't part of one or the other Table you're joining, gets a null
+value. Here's an example:
 
 ::
 
@@ -686,63 +688,63 @@ The result is:
 | ``NULL``        | ``NULL``    | ``NULL``          | 4           | Friday                          |
 +-----------------+-------------+-------------------+-------------+---------------------------------+
 
-Joined Tables aren't updatable in SQL-92. Usually, this means that a View which 
-is based on a query that joins multiple Tables can't be the object of a 
-``DELETE``, ``INSERT`` or ``UPDATE`` statement. 
+Joined Tables aren't updatable in SQL-92. Usually, this means that a View which
+is based on a query that joins multiple Tables can't be the object of a
+``DELETE``, ``INSERT`` or ``UPDATE`` statement.
 
-But such Views might be updatable in SQL3. For example, a ``UNION JOIN`` is 
-useful in SQL3 because it allows you to change the joined data. Consider a 
-situation where you want to ``INSERT`` a row into a ``UNION JOIN`` of two 
-Tables, where the first Table has five Columns and the second Table has six 
-Columns (so the ``UNION JOIN`` has 11 Columns). There are three possible 
-situations: 
+But such Views might be updatable in SQL3. For example, a ``UNION JOIN`` is
+useful in SQL3 because it allows you to change the joined data. Consider a
+situation where you want to ``INSERT`` a row into a ``UNION JOIN`` of two
+Tables, where the first Table has five Columns and the second Table has six
+Columns (so the ``UNION JOIN`` has 11 Columns). There are three possible
+situations:
 
-1. If the first 5 Columns of the new row are all ``NULL`` and any of the last 
-   six Columns are a non-null value, then the ``INSERT`` operation strips off 
-   the first 5 ``NULL``\s and puts the remaining new row into the second Table. 
+1. If the first 5 Columns of the new row are all ``NULL`` and any of the last
+   six Columns are a non-null value, then the ``INSERT`` operation strips off
+   the first 5 ``NULL``\s and puts the remaining new row into the second Table.
 
-2. If any of the first 5 Columns of the new row are a non-null value and all of 
-   the last six Columns are ``NULL``, then the ``INSERT`` operation strips off 
-   the last six ``NULL``\s and puts the remaining new row into the first Table. 
+2. If any of the first 5 Columns of the new row are a non-null value and all of
+   the last six Columns are ``NULL``, then the ``INSERT`` operation strips off
+   the last six ``NULL``\s and puts the remaining new row into the first Table.
 
-3. If any of the first 5 Columns of the new row are a non-null value and any of 
-   the last six Columns are also a non-null value, then the ``INSERT`` 
-   operation will fail: your DBMS will return the ``SQLSTATE error 22014 "data 
-   exception-invalid update value."`` 
+3. If any of the first 5 Columns of the new row are a non-null value and any of
+   the last six Columns are also a non-null value, then the ``INSERT``
+   operation will fail: your DBMS will return the ``SQLSTATE error 22014 "data
+   exception-invalid update value."``
 
-Now consider a situation where you want to ``DELETE`` a row from the same 
+Now consider a situation where you want to ``DELETE`` a row from the same
 ``UNION JOIN``. This time, there are two possible situations:
 
-1. If the row you want to ``DELETE`` was derived from the first Table (that is, 
-   the row contains only ``NULL``\s for every Column derived from the second 
-   Table), then the ``DELETE`` operation will remove that row from the first 
-   Table. 
+1. If the row you want to ``DELETE`` was derived from the first Table (that is,
+   the row contains only ``NULL``\s for every Column derived from the second
+   Table), then the ``DELETE`` operation will remove that row from the first
+   Table.
 
-2. If the row you want to ``DELETE`` was derived from the second Table, then 
-   the ``DELETE`` operation will remove that row from the second Table. 
+2. If the row you want to ``DELETE`` was derived from the second Table, then
+   the ``DELETE`` operation will remove that row from the second Table.
 
-Finally, consider a situation where you want to ``UPDATE`` a row from the 
+Finally, consider a situation where you want to ``UPDATE`` a row from the
 same ``UNION JOIN``. Once again, there are three possible situations:
 
-1. If the row you want to ``UPDATE`` was derived from the first Table (and so 
-   the last six Columns of the row are ``NULL``), then the ``UPDATE`` operation 
-   will change that row in the first Table. 
+1. If the row you want to ``UPDATE`` was derived from the first Table (and so
+   the last six Columns of the row are ``NULL``), then the ``UPDATE`` operation
+   will change that row in the first Table.
 
-2. If the row you want to ``UPDATE`` was derived from the second Table (and so 
-   the first five Columns of the row are ``NULL``), then the ``UPDATE`` 
-   operation will change that row in the second Table. 
+2. If the row you want to ``UPDATE`` was derived from the second Table (and so
+   the first five Columns of the row are ``NULL``), then the ``UPDATE``
+   operation will change that row in the second Table.
 
-3. If any of the first 5 Columns of the row you want to change are a non-null 
-   value and any of the last six Columns are also a non-null value, then the 
-   ``UPDATE`` operation will fail: your DBMS will return the ``SQLSTATE error 
-   22014 "data exception-invalid update value."`` 
+3. If any of the first 5 Columns of the row you want to change are a non-null
+   value and any of the last six Columns are also a non-null value, then the
+   ``UPDATE`` operation will fail: your DBMS will return the ``SQLSTATE error
+   22014 "data exception-invalid update value."``
 
 Syntax Rules
 ============
 
-Now that we've shown you an example of each type of join, here's a list of the 
-formal syntax rules you'll have to follow when forming a join expression. 
-First, we'll repeat the join syntax itself: 
+Now that we've shown you an example of each type of join, here's a list of the
+formal syntax rules you'll have to follow when forming a join expression.
+First, we'll repeat the join syntax itself:
 
 ::
 
@@ -761,59 +763,59 @@ First, we'll repeat the join syntax itself:
        ON <search condition> |
        USING (join <Column name> [ {,join <Column name>} ... ])
 
-You can't join over ``BLOB``\s, ``CLOB``\s, ``NCLOB``\s or ``ARRAY``\s, so 
-don't name any Column with one of these <data type>s in a ``USING`` clause and 
-don't expect a ``NATURAL JOIN`` to join over such Columns either. 
+You can't join over ``BLOB``\s, ``CLOB``\s, ``NCLOB``\s or ``ARRAY``\s, so
+don't name any Column with one of these <data type>s in a ``USING`` clause and
+don't expect a ``NATURAL JOIN`` to join over such Columns either.
 
-If your join expression specifies ``NATURAL``, it may not include either an 
-``ON`` clause or a ``USING`` clause: your DBMS will just search out the Columns 
-with the same name and equal values in each Table. The common Columns must have 
-mutually comparable <data type>s. For each pair of common Columns, only one 
-Column will appear in the result. Because of this, when your SQL statement 
-includes the join operator ``NATURAL``, you may never qualify the common 
-<Column name>(s) anywhere in the SQL statement. 
+If your join expression specifies ``NATURAL``, it may not include either an
+``ON`` clause or a ``USING`` clause: your DBMS will just search out the Columns
+with the same name and equal values in each Table. The common Columns must have
+mutually comparable <data type>s. For each pair of common Columns, only one
+Column will appear in the result. Because of this, when your SQL statement
+includes the join operator ``NATURAL``, you may never qualify the common
+<Column name>(s) anywhere in the SQL statement.
 
-If your join expression specifies ``UNION``, it may not also specify 
-``NATURAL``, nor may it include an ``ON`` clause or a ``USING`` clause: your 
-DBMS will merely join every Column in each Table together, for all rows in both 
-Tables. 
+If your join expression specifies ``UNION``, it may not also specify
+``NATURAL``, nor may it include an ``ON`` clause or a ``USING`` clause: your
+DBMS will merely join every Column in each Table together, for all rows in both
+Tables.
 
-If your join expression doesn't specify either ``NATURAL`` or ``UNION``, then 
-it must include either an ``ON`` clause or a ``USING`` clause, to tell your 
-DBMS what the join conditions are. The ``USING`` clause provides the 
-unqualified name of the common Column (or a list of names, if the Tables have 
-multiple common Columns). Once again, for each pair of common Columns, only one 
-Column will appear in the result, so any <Column name> that appears in a 
-``USING`` clause may never be qualified within the SQL statement that contains 
-that ``USING`` clause. The ``ON`` clause provides the condition that must be 
-met for joining the Tables so, within an SQL statement, common <Column name>s 
-that appear in an ``ON`` clause may be qualified throughout that SQL statement. 
+If your join expression doesn't specify either ``NATURAL`` or ``UNION``, then
+it must include either an ``ON`` clause or a ``USING`` clause, to tell your
+DBMS what the join conditions are. The ``USING`` clause provides the
+unqualified name of the common Column (or a list of names, if the Tables have
+multiple common Columns). Once again, for each pair of common Columns, only one
+Column will appear in the result, so any <Column name> that appears in a
+``USING`` clause may never be qualified within the SQL statement that contains
+that ``USING`` clause. The ``ON`` clause provides the condition that must be
+met for joining the Tables so, within an SQL statement, common <Column name>s
+that appear in an ``ON`` clause may be qualified throughout that SQL statement.
 
-If your join expression is "``Table_1 NATURAL JOIN Table_2``", the effect is 
-the same as if you specified "``Table_1 NATURAL INNER JOIN Table_2``" -- so 
+If your join expression is "``Table_1 NATURAL JOIN Table_2``", the effect is
+the same as if you specified "``Table_1 NATURAL INNER JOIN Table_2``" -- so
 non-matching rows won't be part of the result Table.
 
-If you want to restrict your code to Core SQL, don't use ``CROSS JOIN``, 
-don't use ``UNION JOIN``, don't use ``NATURAL`` for any type of join and 
+If you want to restrict your code to Core SQL, don't use ``CROSS JOIN``,
+don't use ``UNION JOIN``, don't use ``NATURAL`` for any type of join and
 don't use ``FULL [OUTER] JOIN``.
 
 *Retrieval Using Joins*
 -----------------------
 
-The ability to join a Table to others is one of the most powerful features of 
-SQL. Here's some more examples of joins, using the sample database we defined 
-in our chapter on simple search conditions. Remember that, to join Tables, the 
-select list must contain the unambiguous names of the desired Columns, and the 
-``ON``, ``USING`` or ``WHERE`` clause must specify the conditions which define 
-the relationship between them. (The relationship is usually equality, but it 
-need not be.) Also, of course, the Columns that specify the required join 
-relationship must have comparable <data-type>s; that is, they must either both 
-be numeric or both be character strings or both be dates, and so on. They do 
-not always have to have the same name, but it is helpful in reading the query 
-if they do. 
+The ability to join a Table to others is one of the most powerful features of
+SQL. Here's some more examples of joins, using the sample database we defined
+in our chapter on simple search conditions. Remember that, to join Tables, the
+select list must contain the unambiguous names of the desired Columns, and the
+``ON``, ``USING`` or ``WHERE`` clause must specify the conditions which define
+the relationship between them. (The relationship is usually equality, but it
+need not be.) Also, of course, the Columns that specify the required join
+relationship must have comparable <data-type>s; that is, they must either both
+be numeric or both be character strings or both be dates, and so on. They do
+not always have to have the same name, but it is helpful in reading the query
+if they do.
 
-To find all information available on all employees (retrieve a join of all 
-Columns) the following SQL statement are equivalent: 
+To find all information available on all employees (retrieve a join of all
+Columns) the following SQL statement are equivalent:
 
 ::
 
@@ -834,12 +836,12 @@ Columns) the following SQL statement are equivalent:
    SELECT *
    FROM   Employee JOIN Payroll USING(Employee.empnum=Payroll.empnum);
 
-The result is the entire ``EMPLOYEE`` Table joined with the entire ``PAYROLL`` 
-Table over their matching employee numbers; ten rows and ten columns in all. 
-Note the <Column reference>s for the ``EMPNUM`` Column, to avoid ambiguity. To 
-eliminate duplicate Columns from the result, specific <Column reference>s 
-(rather than "``*``") must be put in the select list, as in these two 
-equivalent SQL statements: 
+The result is the entire ``EMPLOYEE`` Table joined with the entire ``PAYROLL``
+Table over their matching employee numbers; ten rows and ten columns in all.
+Note the <Column reference>s for the ``EMPNUM`` Column, to avoid ambiguity. To
+eliminate duplicate Columns from the result, specific <Column reference>s
+(rather than "``*``") must be put in the select list, as in these two
+equivalent SQL statements:
 
 ::
 
@@ -859,7 +861,7 @@ The result is:
 | 1          | A        | KOO         | 6.00     | 10TH FLOOR    |
 +------------+----------+-------------+----------+---------------+
 
-To find an employee's manager (retrieve one equivalent Column from multiple 
+To find an employee's manager (retrieve one equivalent Column from multiple
 Tables):
 
 ::
@@ -876,7 +878,7 @@ The result is:
 | TURNER      | JONES B     |
 +-------------+-------------+
 
-To find the pay rates and locations of all department A employees (join 
+To find the pay rates and locations of all department A employees (join
 values fulfilling multiple conditions from multiple Tables):
 
 ::
@@ -884,10 +886,10 @@ values fulfilling multiple conditions from multiple Tables):
    SELECT Employee.*,Payroll.*
    FROM   Employee NATURAL JOIN Payroll ON dept='A';
 
-The result is the ``EMPLOYEE`` Table joined with the ``PAYROLL`` Table, for 
+The result is the ``EMPLOYEE`` Table joined with the ``PAYROLL`` Table, for
 all rows where the ``DEPT`` Column contains an "A" in both Tables.
 
-To find the department and payroll data for employee 35, here are two 
+To find the department and payroll data for employee 35, here are two
 equivalent SQL statements:
 
 ::
@@ -910,20 +912,20 @@ The result is:
 | 35         | OLSEN       | E        | GREEN E     | 9.00     |
 +------------+-------------+----------+-------------+----------+
 
-Outer join results Tables are produced exactly the same way as inner join 
-results are -- with the exception that, in an outer join, rows are retrieved 
-even when data in one of the Tables has no match in the other. 
+Outer join results Tables are produced exactly the same way as inner join
+results are -- with the exception that, in an outer join, rows are retrieved
+even when data in one of the Tables has no match in the other.
 
-If a row in the first Table named has no match in the second Table, and the 
-outer join type is either a ``LEFT JOIN`` or a ``FULL JOIN``, then a dummy row 
-appears for the second Table. If a row in the second Table named has no match 
-in the first Table, and the outer join type is either a ``RIGHT JOIN`` or a 
-``FULL JOIN``, then a dummy row appears for the first Table. In both cases, the 
-Columns in a dummy row are all equal to their ``DEFAULT`` values. 
+If a row in the first Table named has no match in the second Table, and the
+outer join type is either a ``LEFT JOIN`` or a ``FULL JOIN``, then a dummy row
+appears for the second Table. If a row in the second Table named has no match
+in the first Table, and the outer join type is either a ``RIGHT JOIN`` or a
+``FULL JOIN``, then a dummy row appears for the first Table. In both cases, the
+Columns in a dummy row are all equal to their ``DEFAULT`` values.
 
-For example, suppose ``TABLE_1`` has one Column and four rows, containing the 
-values {``1,2,3,5``} and ``TABLE_2`` has one Column and four rows, containing 
-the values {``2,4,5,7``}. An inner join query on the Tables would be: 
+For example, suppose ``TABLE_1`` has one Column and four rows, containing the
+values {``1,2,3,5``} and ``TABLE_2`` has one Column and four rows, containing
+the values {``2,4,5,7``}. An inner join query on the Tables would be:
 
 ::
 
@@ -965,7 +967,7 @@ The result is:
 | 5             | 5             |
 +---------------+---------------+
 
-The values in the first (left) Table that have no match are matched with a 
+The values in the first (left) Table that have no match are matched with a
 ``NULL`` (or default) value.
 
 A right outer join query on the Tables would be:
@@ -990,7 +992,7 @@ The result is:
 | ``NULL``      | 7             |
 +---------------+---------------+
 
-The values in the second (right) Table that have no match are matched with a 
+The values in the second (right) Table that have no match are matched with a
 ``NULL`` (or default) value.
 
 A full outer join query on the Tables would be:
@@ -1019,17 +1021,17 @@ The result is:
 | ``NULL``      | 7             |
 +---------------+---------------+
 
-The values in either Table that have no match are matched with a ``NULL`` 
+The values in either Table that have no match are matched with a ``NULL``
 (or default) value.
 
 Dialects
 ========
 
-Since "modern" syntax is relatively new to SQL, various products support 
+Since "modern" syntax is relatively new to SQL, various products support
 different syntax for the types of joins we've illustrated here. For example:
 
-* Oracle uses "``WHERE Table_1.column (+) = Table_2.column``" for a ``LEFT 
+* Oracle uses "``WHERE Table_1.column (+) = Table_2.column``" for a ``LEFT
   OUTER JOIN``.
 
-* For Microsoft SQL Server, the search condition for an ``OUTER JOIN`` must 
+* For Microsoft SQL Server, the search condition for an ``OUTER JOIN`` must
   be an equals condition.

--- a/docs/chapters/31.rst
+++ b/docs/chapters/31.rst
@@ -4,29 +4,31 @@
 Chapter 31 -- Searching with Subqueries
 =======================================
 
-A subquery is a parenthesized query enclosed within some outer SQL 
-statement. Most queries are ``SELECT``\s, so this means that a subquery usually 
-takes the form (``SELECT ...``), nested somewhere inside an expression. 
-Queries return result sets, or Tables, and the values in such Tables can be 
-used when the syntax of the outer expression calls for a value of the 
+.. include:: ../_include/note.rst
+
+A subquery is a parenthesized query enclosed within some outer SQL
+statement. Most queries are ``SELECT``\s, so this means that a subquery usually
+takes the form (``SELECT ...``), nested somewhere inside an expression.
+Queries return result sets, or Tables, and the values in such Tables can be
+used when the syntax of the outer expression calls for a value of the
 appropriate <data type>.
 
-Subqueries make an SQL statement look structured, and indeed it was the 
-presence of subqueries that gave the original SQL its distinctive look (the 
-letters SQL used to stand for "Structured Query Language"). Nowadays subqueries 
-are less essential because there other ways (particularly joins and 
-``UNION/EXCEPT/INTERSECT`` operators) to reach the same ends. Nevertheless, 
-they are important because they provide these benefits: 
+Subqueries make an SQL statement look structured, and indeed it was the
+presence of subqueries that gave the original SQL its distinctive look (the
+letters SQL used to stand for "Structured Query Language"). Nowadays subqueries
+are less essential because there other ways (particularly joins and
+``UNION/EXCEPT/INTERSECT`` operators) to reach the same ends. Nevertheless,
+they are important because they provide these benefits:
 
-* SQL statements with subqueries are readable. Most people, especially if they 
-  are familiar with the role of subordinate clauses in English, can figure that 
-  a subquery-containing SQL statement can be read "from the inside out" -- that 
-  is, they can focus on the subquery's workings first, and then on the separate 
-  analysis of the outer statement. Statements with joins, by contrast, must be 
-  read all at once. 
+* SQL statements with subqueries are readable. Most people, especially if they
+  are familiar with the role of subordinate clauses in English, can figure that
+  a subquery-containing SQL statement can be read "from the inside out" -- that
+  is, they can focus on the subquery's workings first, and then on the separate
+  analysis of the outer statement. Statements with joins, by contrast, must be
+  read all at once.
 
-* Certain types of problems can be stated more concisely, and more efficiently, 
-  with subqueries. 
+* Certain types of problems can be stated more concisely, and more efficiently,
+  with subqueries.
 
 .. rubric:: Table of Contents
 
@@ -36,18 +38,18 @@ they are important because they provide these benefits:
 Subquery Syntax
 ===============
 
-A subquery is used to specify either a value (the scalar subquery, which 
-returns one value), a row (the row subquery, which returns one row), or a Table 
-(the Table subquery, which returns a result Table). The required syntax for a 
-subquery is: 
+A subquery is used to specify either a value (the scalar subquery, which
+returns one value), a row (the row subquery, which returns one row), or a Table
+(the Table subquery, which returns a result Table). The required syntax for a
+subquery is:
 
 ::
 
     <subquery> ::=
 	( <query experession> )
 
-That is, a subquery is a parenthesized <query experession> -- and the <query 
-expression> is usually a ``SELECT`` statement. Here's an example: 
+That is, a subquery is a parenthesized <query experession> -- and the <query
+expression> is usually a ``SELECT`` statement. Here's an example:
 
 ::
 
@@ -59,81 +61,81 @@ expression> is usually a ``SELECT`` statement. Here's an example:
 	 FROM Table_2
 	 WHERE Table_2.column_1 = 5);
 
-There are some restrictions regarding where subqueries can be used and what 
-they may contain. In early SQL days, the restrictions were quite strict. For 
-instance, the subquery had to be on the right side of a comparison operator 
-within a ``WHERE`` clause, as in the above example. Nowadays, the restrictions 
-for an SQL subquery, in a fully-conformant DBMS environment, are mild: 
+There are some restrictions regarding where subqueries can be used and what
+they may contain. In early SQL days, the restrictions were quite strict. For
+instance, the subquery had to be on the right side of a comparison operator
+within a ``WHERE`` clause, as in the above example. Nowadays, the restrictions
+for an SQL subquery, in a fully-conformant DBMS environment, are mild:
 
 * There can be no ``ORDER BY`` clause inside the subquery.
 
-* The subquery's select list may not include any reference to a value that 
+* The subquery's select list may not include any reference to a value that
   evaluates to a ``BLOB``, ``CLOB``, ``NCLOB`` or ``ARRAY``.
 
-* A subquery may not be immediately enclosed within a set function, for 
+* A subquery may not be immediately enclosed within a set function, for
   example:
-  
+
   ::
-  
-      ... AVG((SELECT column_1 FROM Table_1)) ... 
-  
+
+      ... AVG((SELECT column_1 FROM Table_1)) ...
+
   is not legal syntax.
 
-It is legal to nest subqueries within subqueries. The maximum level of nesting 
-depends on your implementation, since the Standard doesn't specify the number 
-of levels of nesting that must be supported. 
+It is legal to nest subqueries within subqueries. The maximum level of nesting
+depends on your implementation, since the Standard doesn't specify the number
+of levels of nesting that must be supported.
 
-We said earlier that there are three types of subquery. They are distinguished 
-from each other, not by their form -- the general form of a subquery is always 
-just "(<query expression>)" -- but by the shape of their result: how many 
-Columns and rows do they return? 
+We said earlier that there are three types of subquery. They are distinguished
+from each other, not by their form -- the general form of a subquery is always
+just "(<query expression>)" -- but by the shape of their result: how many
+Columns and rows do they return?
 
-* If a subquery can return exactly one Column and one row, it is a *scalar 
+* If a subquery can return exactly one Column and one row, it is a *scalar
   subquery*. The subquery:
 
   ::
 
       ... (SELECT MAX(Table_1.column_1) FROM Table_1) ...
 
-  would fit the bill, but usually it's not so easy to simply glance at a 
+  would fit the bill, but usually it's not so easy to simply glance at a
   query and realize that it will return only one Column and one row.
 
-* If a subquery can return more than one Column, but still exactly one row, it 
-  is a row subquery. A *row subquery* is just a generalized derivation of a 
-  scalar subquery, used in some comparisons. Row subqueries are the 
-  least-frequently-seen type of subquery. 
+* If a subquery can return more than one Column, but still exactly one row, it
+  is a row subquery. A *row subquery* is just a generalized derivation of a
+  scalar subquery, used in some comparisons. Row subqueries are the
+  least-frequently-seen type of subquery.
 
-* If a subquery can return more than one Column and more than one row, it is a 
-  Table subquery. A *Table subquery* is another type of <Table reference> and 
-  can be used in an SQL statement wherever a <Table name> can be used -- which 
-  isn't very often! However, there are some special search operators which are 
-  specifically designed to work with Table subqueries. Discussion of those 
-  search operators is an important part of this chapter. 
+* If a subquery can return more than one Column and more than one row, it is a
+  Table subquery. A *Table subquery* is another type of <Table reference> and
+  can be used in an SQL statement wherever a <Table name> can be used -- which
+  isn't very often! However, there are some special search operators which are
+  specifically designed to work with Table subqueries. Discussion of those
+  search operators is an important part of this chapter.
 
-Thus, the distinction between subquery types depends on the size of the select 
-list, and the number of rows returned. The three types of subquery are not 
-utterly separate: a scalar subquery's definition is subsumed by a row 
-subquery's definition, which is subsumed by a Table subquery's definition. (In 
-fact, a one-Column Table subquery is such a common thing that some people 
-regard it as a separate type, which they call a "Column subquery".) 
-Nevertheless, the potential distinction should be kept in mind. It's easy to 
-get confused by assuming that everything which applies for one type, applies 
-for the others as well. We will discuss scalar subqueries, row subqueries and 
-Table subqueries separately. 
+Thus, the distinction between subquery types depends on the size of the select
+list, and the number of rows returned. The three types of subquery are not
+utterly separate: a scalar subquery's definition is subsumed by a row
+subquery's definition, which is subsumed by a Table subquery's definition. (In
+fact, a one-Column Table subquery is such a common thing that some people
+regard it as a separate type, which they call a "Column subquery".)
+Nevertheless, the potential distinction should be kept in mind. It's easy to
+get confused by assuming that everything which applies for one type, applies
+for the others as well. We will discuss scalar subqueries, row subqueries and
+Table subqueries separately.
 
 Scalar Subqueries
 =================
 
-In general terms, a scalar subquery resembles a scalar function. Remember that 
-a scalar function returns a single value, given an argument which is some sort 
-of expression -- well, a scalar subquery returns a single value, given an 
-argument which is a <query expression>. Since that value must be a scalar 
-value, a few aspects of scalar subqueries are simply logical consequences of 
-their definitions: 
+In general terms, a scalar subquery resembles a scalar function. Remember that
+a scalar function returns a single value, given an argument which is some sort
+of expression -- well, a scalar subquery returns a single value, given an
+argument which is a <query expression>. Since that value must be a scalar
+value, a few aspects of scalar subqueries are simply logical consequences of
+their definitions:
 
-* The <data type>, Collation, length and all other significant attributes of 
-  the value are inherited from the attributes of the selected Column. For 
-  example, the result of the subquery: 
+* The <data type>, Collation, length and all other significant attributes of
+  the value are inherited from the attributes of the selected Column. For
+  example, the result of the subquery:
 
   ::
 
@@ -141,29 +143,29 @@ their definitions:
 
   has a <data type> of ``CHAR(3)``.
 
-* It is an error if, at runtime, the DBMS discovers that a scalar subquery 
-  returns more than one row. If this is the case, the entire SQL statement will 
-  fail: your DBMS will return the ``SQLSTATE error 21000 "cardinality 
-  violation"``. 
+* It is an error if, at runtime, the DBMS discovers that a scalar subquery
+  returns more than one row. If this is the case, the entire SQL statement will
+  fail: your DBMS will return the ``SQLSTATE error 21000 "cardinality
+  violation"``.
 
-One thing that does *not* follow from the definition, and in fact surprises 
-some analysts, is the value returned when a scalar subquery returns zero rows. 
-In this case, the result is ``NULL``. For example, consider this SQL statement: 
+One thing that does *not* follow from the definition, and in fact surprises
+some analysts, is the value returned when a scalar subquery returns zero rows.
+In this case, the result is ``NULL``. For example, consider this SQL statement:
 
 ::
 
     UPDATE Table_1 SET
 	   column_1 = (SELECT column_1 FROM Table_2 WHERE 1 = 2);
 
-Since 1 is never equal to 2, the search condition in this subquery example will 
-always be ``FALSE`` -- so the subquery result is an empty set. In this case, 
-the ``UPDATE`` operation assigns a null value to ``COLUMN_1`` in ``TABLE_1``. 
-This is a case where ``NULL`` obviously does not mean "unknown" or "not 
-applicable" -- it means "not there" -- but no great harm results. 
+Since 1 is never equal to 2, the search condition in this subquery example will
+always be ``FALSE`` -- so the subquery result is an empty set. In this case,
+the ``UPDATE`` operation assigns a null value to ``COLUMN_1`` in ``TABLE_1``.
+This is a case where ``NULL`` obviously does not mean "unknown" or "not
+applicable" -- it means "not there" -- but no great harm results.
 
-Here are some examples of scalar subqueries. You can tell that these must be 
-scalar subqueries -- not row subqueries or Table subqueries -- because they are 
-being used in places where only scalar values are legal. 
+Here are some examples of scalar subqueries. You can tell that these must be
+scalar subqueries -- not row subqueries or Table subqueries -- because they are
+being used in places where only scalar values are legal.
 
 ::
 
@@ -186,38 +188,38 @@ being used in places where only scalar values are legal.
     INSERT INTO Table_1
     VALUES (1 + (SELECT column_1 FROM Table_2));
 
-Our third example of a scalar subquery shows its use in a ``WHERE`` clause. 
-This is a traditional and common usage, as it used to be the only place a 
-subquery could appear. These general observations apply if you're including a 
-scalar subquery in a comparison: 
+Our third example of a scalar subquery shows its use in a ``WHERE`` clause.
+This is a traditional and common usage, as it used to be the only place a
+subquery could appear. These general observations apply if you're including a
+scalar subquery in a comparison:
 
-* The "comparison" operator is not limited to the traditional operators: it can 
-  be pretty well any predicate, including ``LIKE`` or ``BETWEEN``. 
+* The "comparison" operator is not limited to the traditional operators: it can
+  be pretty well any predicate, including ``LIKE`` or ``BETWEEN``.
 
-* The subquery can be on either side of the comparison operator. There can even 
-  be subqueries on both sides of the comparison operator. 
+* The subquery can be on either side of the comparison operator. There can even
+  be subqueries on both sides of the comparison operator.
 
-* The subquery can be in an expression, along with arithmetic or scalar 
-  function operators. 
+* The subquery can be in an expression, along with arithmetic or scalar
+  function operators.
 
-* The subquery result will depend on the number of rows returned: one row is 
-  normal and gives a known result, two or more rows results in a "cardinality 
-  violation" error and zero rows results in the comparison predicate returning 
-  ``UNKNOWN``, because the subquery result value is ``NULL``. We've repeated 
-  these general observations here because we want to emphasize that such 
-  observations apply only to scalar subqueries. None of them will apply when we 
-  discuss comparisons that involve Table subqueries. 
+* The subquery result will depend on the number of rows returned: one row is
+  normal and gives a known result, two or more rows results in a "cardinality
+  violation" error and zero rows results in the comparison predicate returning
+  ``UNKNOWN``, because the subquery result value is ``NULL``. We've repeated
+  these general observations here because we want to emphasize that such
+  observations apply only to scalar subqueries. None of them will apply when we
+  discuss comparisons that involve Table subqueries.
 
 Row Subqueries
 ==============
 
-Row subqueries are similar to scalar subqueries in the one fundamental respect: 
-they may not return more than one row. If a row subquery returns two or more 
-rows, the entire SQL statement will fail: your DBMS will return the ``SQLSTATE 
-error 21000 "cardinality violation"``. 
+Row subqueries are similar to scalar subqueries in the one fundamental respect:
+they may not return more than one row. If a row subquery returns two or more
+rows, the entire SQL statement will fail: your DBMS will return the ``SQLSTATE
+error 21000 "cardinality violation"``.
 
-Row subqueries offer a slight convenience for comparison operations. For 
-example, we can say: 
+Row subqueries offer a slight convenience for comparison operations. For
+example, we can say:
 
 ::
 
@@ -225,44 +227,44 @@ example, we can say:
     FROM Table_1
     WHERE (column_1,'X') = (SELECT column_1,column_2 FROM Table_2);
 
-That is, we can compare two Column values using a single equals operator. This 
-is more concise, and probably more efficient, than comparing twice with scalar 
-subqueries, as in this equivalent example: 
+That is, we can compare two Column values using a single equals operator. This
+is more concise, and probably more efficient, than comparing twice with scalar
+subqueries, as in this equivalent example:
 
 ::
 
     SELECT *
     FROM Table_1
-    WHERE Table_1.column_1 = (SELECT Table_2.column_1 FROM Table_2) AND 
+    WHERE Table_1.column_1 = (SELECT Table_2.column_1 FROM Table_2) AND
           'X' = (SELECT Table_2.column_2 FROM Table_2);
 
-A row subquery, then, is a form of row value expression -- an expression that 
-evaluates to one row. This construct can be used with every SQL predicate, not 
-just basic comparison. 
+A row subquery, then, is a form of row value expression -- an expression that
+evaluates to one row. This construct can be used with every SQL predicate, not
+just basic comparison.
 
 Table Subqueries
 ================
 
-We now switch from talking about "one-row" subqueries, to talking about 
-"multi-row" subqueries, or Table subqueries. This means, almost exclusively, 
+We now switch from talking about "one-row" subqueries, to talking about
+"multi-row" subqueries, or Table subqueries. This means, almost exclusively,
 subqueries that are used in comparison operations.
 
-Quite often, a Table subquery looks like a scalar subquery, because -- almost 
-always -- a single Column makes up the subquery's select list. You can 
-distinguish a Table subquery from context, though: it will always be preceded 
-by a special for-Table-subqueries-only operator, either 
-<comparison_operator>\ ``ALL``, <comparison_operator>\ ``ANY`` (or its synonym, 
-<comparison_operator>\ ``SOME``), ``IN``, ``EXISTS``, or ``UNIQUE``. 
+Quite often, a Table subquery looks like a scalar subquery, because -- almost
+always -- a single Column makes up the subquery's select list. You can
+distinguish a Table subquery from context, though: it will always be preceded
+by a special for-Table-subqueries-only operator, either
+<comparison_operator>\ ``ALL``, <comparison_operator>\ ``ANY`` (or its synonym,
+<comparison_operator>\ ``SOME``), ``IN``, ``EXISTS``, or ``UNIQUE``.
 
 *Correlated Subqueries*
 -----------------------
 
-A correlated subquery is a subquery that contains references to the values in 
-Tables that are referred to in the outer statement (that is, the SQL statement 
-that the subquery is nested in). These references are, in standard terminology, 
-"outer references". One tends to find outer references in Table subqueries, 
-although in theory there is nothing to restrict them to that role. Here's an 
-example (for now, concentrate only on the syntax we're showing): 
+A correlated subquery is a subquery that contains references to the values in
+Tables that are referred to in the outer statement (that is, the SQL statement
+that the subquery is nested in). These references are, in standard terminology,
+"outer references". One tends to find outer references in Table subqueries,
+although in theory there is nothing to restrict them to that role. Here's an
+example (for now, concentrate only on the syntax we're showing):
 
 ::
 
@@ -275,23 +277,23 @@ example (for now, concentrate only on the syntax we're showing):
 
 There are two things to note in this example:
 
-**First:** The subquery's ``WHERE`` clause refers to ``Table_1.column_2``, but 
-``TABLE_1`` is not mentioned in the subquery's ``FROM`` clause. Instead, 
-``TABLE_1`` is named in the outer query's ``FROM`` clause -- this is the outer 
-reference. 
+**First:** The subquery's ``WHERE`` clause refers to ``Table_1.column_2``, but
+``TABLE_1`` is not mentioned in the subquery's ``FROM`` clause. Instead,
+``TABLE_1`` is named in the outer query's ``FROM`` clause -- this is the outer
+reference.
 
-**Second:** Besides ``Table_1.column_2``, the subquery's ``WHERE`` clause has 
-another Column named ``COLUMN_2``. This reference is to the ``COLUMN_2`` that 
-belongs to ``TABLE_2``. We could have used the <Column reference>\ 
-``TABLE_2.COLUMN_2`` for clarity, but this isn't necessary. By default, a 
-<Column name> applies to the Table(s) in the nearest ``FROM`` clause -- there 
-is a scoping rule that says: look in the local subquery first for resolution of 
-<Column reference>s, then look outward, progressing if necessary through 
-several levels of nesting, till the outermost query is reached. 
+**Second:** Besides ``Table_1.column_2``, the subquery's ``WHERE`` clause has
+another Column named ``COLUMN_2``. This reference is to the ``COLUMN_2`` that
+belongs to ``TABLE_2``. We could have used the <Column reference>\
+``TABLE_2.COLUMN_2`` for clarity, but this isn't necessary. By default, a
+<Column name> applies to the Table(s) in the nearest ``FROM`` clause -- there
+is a scoping rule that says: look in the local subquery first for resolution of
+<Column reference>s, then look outward, progressing if necessary through
+several levels of nesting, till the outermost query is reached.
 
-Occasionally, the <Table names>s are the same in the subquery and in the outer 
-statement. When this happens, it's the subquery analog of the self-join and so 
-you'll need to define <Correlation name>s for the Tables. Here's an example: 
+Occasionally, the <Table names>s are the same in the subquery and in the outer
+statement. When this happens, it's the subquery analog of the self-join and so
+you'll need to define <Correlation name>s for the Tables. Here's an example:
 
 ::
 
@@ -302,19 +304,19 @@ you'll need to define <Correlation name>s for the Tables. Here's an example:
            FROM Table_1 AS T_one_b
            WHERE T_one_b.column_2 = T_one_a.column_2);
 
-Whenever a subquery contains an outer reference, it is correlated with the 
-outer statement. That means your DBMS can't evaluate the subquery without 
-feeding it values from outside the subquery. Correlation can be messy, and 
+Whenever a subquery contains an outer reference, it is correlated with the
+outer statement. That means your DBMS can't evaluate the subquery without
+feeding it values from outside the subquery. Correlation can be messy, and
 some DBMSs handle it poorly. But sometimes there's no alternative.
 
 Quantified Comparisons
 ======================
 
-In our chapters on the various <data type>s, we showed you which of them could 
-be used in an expression that compared a value of that <data type> with the 
-collection of values returned by a Table subquery. Here's a more detailed 
-explanation of quantified comparisons using the quantifiers ``ALL``, ``SOME``, 
-``ANY``. 
+In our chapters on the various <data type>s, we showed you which of them could
+be used in an expression that compared a value of that <data type> with the
+collection of values returned by a Table subquery. Here's a more detailed
+explanation of quantified comparisons using the quantifiers ``ALL``, ``SOME``,
+``ANY``.
 
 *ALL*
 -----
@@ -325,14 +327,14 @@ The required syntax for an ``ALL`` quantified comparison is:
 
     scalar_expression comparison_operator ALL
 
-Here, ``scalar_expression`` may be any expression that evaluates to a single 
-value and ``comparison_operator`` may be any one of: = or > or < or >= or <= or 
-<>. ``ALL`` returns ``TRUE`` if the Table subquery returns zero rows or if the 
-comparison operator returns ``TRUE`` for every row returned by the Table 
-subquery. ``ALL`` returns ``FALSE`` if the comparison operator returns 
-``FALSE`` for at least one row returned by the Table subquery. Suppose that 
-``TABLE_1`` has one Column, defined as ``DECIMAL(6,2)``. Here's what will 
-happen, for different values in the rows of ``TABLE_1``, for this expression: 
+Here, ``scalar_expression`` may be any expression that evaluates to a single
+value and ``comparison_operator`` may be any one of: = or > or < or >= or <= or
+<>. ``ALL`` returns ``TRUE`` if the Table subquery returns zero rows or if the
+comparison operator returns ``TRUE`` for every row returned by the Table
+subquery. ``ALL`` returns ``FALSE`` if the comparison operator returns
+``FALSE`` for at least one row returned by the Table subquery. Suppose that
+``TABLE_1`` has one Column, defined as ``DECIMAL(6,2)``. Here's what will
+happen, for different values in the rows of ``TABLE_1``, for this expression:
 
 ::
 
@@ -340,22 +342,22 @@ happen, for different values in the rows of ``TABLE_1``, for this expression:
           (SELECT column_1 FROM Table_1) ...
 
 * If ``TABLE_1`` contains the values {``100.00, 200.00, 300.00``}, the
-  expression is ``TRUE``: all of ``TABLE_1``\'s values are less than 
+  expression is ``TRUE``: all of ``TABLE_1``\'s values are less than
   ``1000.00``.
 
-* If ``TABLE_1`` contains the values {``100.00, 2000.00, 300.00``}, the 
-  expression is ``FALSE``: one of ``TABLE_1``\'s values is greater than 
-  ``1000.00``. 
+* If ``TABLE_1`` contains the values {``100.00, 2000.00, 300.00``}, the
+  expression is ``FALSE``: one of ``TABLE_1``\'s values is greater than
+  ``1000.00``.
 
-* If ``TABLE_1`` contains the values {``1000.00, 200.00, 300.00``}, the 
-  expression is ``FALSE`` too: one of ``TABLE_1``\'s values is equal to 
-  ``1000.00``. 
+* If ``TABLE_1`` contains the values {``1000.00, 200.00, 300.00``}, the
+  expression is ``FALSE`` too: one of ``TABLE_1``\'s values is equal to
+  ``1000.00``.
 
-* If ``TABLE_1`` contains no values, the expression is ``TRUE``: when the set 
-  is empty, ``ALL`` is ``TRUE``. 
+* If ``TABLE_1`` contains no values, the expression is ``TRUE``: when the set
+  is empty, ``ALL`` is ``TRUE``.
 
-* If ``TABLE_1`` contains the values {``100.00, NULL, 300.00``}, the expression 
-  is ``UNKNOWN``: when ``NULL``\s are involved, ``ALL`` is ``UNKNOWN``. 
+* If ``TABLE_1`` contains the values {``100.00, NULL, 300.00``}, the expression
+  is ``UNKNOWN``: when ``NULL``\s are involved, ``ALL`` is ``UNKNOWN``.
 
 *ANY or SOME*
 -------------
@@ -368,67 +370,67 @@ comparison is:
     scalar_expression comparison_operator ANY <Table subquery> |
     scalar_expression comparison_operator SOME <Table subquery>
 
-Once again, ``scalar_expression`` may be any expression that evaluates to a 
-single value and ``comparison_operator`` may be any one of: = or > or < or >= 
-or <= or <>. ``SOME`` and ``ANY`` are synonyms. They return ``TRUE`` if the 
-comparison operator returns ``TRUE`` for at least one row returned by the Table 
-subquery. They return ``FALSE`` if the Table subquery returns zero rows or if 
-the comparison operator returns ``FALSE`` for every row returned by the Table 
-subquery. Suppose, once again, that ``TABLE_1`` has one Column, defined as 
-``DECIMAL(6,2)``. Here's what will happen, for different values in the rows of 
-``TABLE_1``, for this expression: 
+Once again, ``scalar_expression`` may be any expression that evaluates to a
+single value and ``comparison_operator`` may be any one of: = or > or < or >=
+or <= or <>. ``SOME`` and ``ANY`` are synonyms. They return ``TRUE`` if the
+comparison operator returns ``TRUE`` for at least one row returned by the Table
+subquery. They return ``FALSE`` if the Table subquery returns zero rows or if
+the comparison operator returns ``FALSE`` for every row returned by the Table
+subquery. Suppose, once again, that ``TABLE_1`` has one Column, defined as
+``DECIMAL(6,2)``. Here's what will happen, for different values in the rows of
+``TABLE_1``, for this expression:
 
 ::
 
     ... WHERE 1000.00 > ANY
           (SELECT column_1 FROM Table_1) ...
 
-* If ``TABLE_1`` contains the values {``100.00, 200.00, 300.00``}, the 
-  expression is ``TRUE``: all of ``TABLE_1``\'s values are less than 
-  ``1000.00``. 
+* If ``TABLE_1`` contains the values {``100.00, 200.00, 300.00``}, the
+  expression is ``TRUE``: all of ``TABLE_1``\'s values are less than
+  ``1000.00``.
 
-* If ``TABLE_1`` contains the values {``100.00, 2000.00, 300.00``}, the 
-  expression is ``TRUE`` too: at least some of ``TABLE_1``\'s values are less 
-  than ``1000.00``. 
+* If ``TABLE_1`` contains the values {``100.00, 2000.00, 300.00``}, the
+  expression is ``TRUE`` too: at least some of ``TABLE_1``\'s values are less
+  than ``1000.00``.
 
-* If ``TABLE_1`` contains no values, the expression is ``FALSE``: when the set 
-  is empty, ``ANY`` is ``FALSE``. 
+* If ``TABLE_1`` contains no values, the expression is ``FALSE``: when the set
+  is empty, ``ANY`` is ``FALSE``.
 
-* If ``TABLE_1`` contains the values {``1000.00, 2000.00, 3000.00``}, the 
-  expression is ``FALSE`` too: all of ``TABLE_1``\'s values are greater than or 
-  equal to ``1000.00``. 
+* If ``TABLE_1`` contains the values {``1000.00, 2000.00, 3000.00``}, the
+  expression is ``FALSE`` too: all of ``TABLE_1``\'s values are greater than or
+  equal to ``1000.00``.
 
-* If ``TABLE_1`` contains the values {``100.00, NULL, 300.00``}, the expression 
-  is ``UNKNOWN``: when ``NULL``\s are involved, ``ANY`` is ``UNKNOWN``. 
+* If ``TABLE_1`` contains the values {``100.00, NULL, 300.00``}, the expression
+  is ``UNKNOWN``: when ``NULL``\s are involved, ``ANY`` is ``UNKNOWN``.
 
-There is a small trap when one considers the expression "``... 1000.00 <> ANY`` 
-(<subquery>) ``...``". Such an expression could be carelessly read as "... 1000 
-is not equal to any subquery result ..." -- that is, 1000 is not equal to every 
-row returned by the subquery. That is not the correct way to read such 
-expressions because it leads to the English-language ambiguity that "any" can 
-mean "every". There are three ways to avoid such ambiguities: 
+There is a small trap when one considers the expression "``... 1000.00 <> ANY``
+(<subquery>) ``...``". Such an expression could be carelessly read as "... 1000
+is not equal to any subquery result ..." -- that is, 1000 is not equal to every
+row returned by the subquery. That is not the correct way to read such
+expressions because it leads to the English-language ambiguity that "any" can
+mean "every". There are three ways to avoid such ambiguities:
 
 1. Don't use the ``ANY`` <keyword>. Use its synonym, ``SOME``, instead.
 
-2. When negatives are involved, replace ``ANY`` with ``ALL``. Logic tells us 
-   that these transformations are possible: 
-   
+2. When negatives are involved, replace ``ANY`` with ``ALL``. Logic tells us
+   that these transformations are possible:
+
    ::
-   
+
        expression <> ANY subquery --> expression = ALL subquery
        NOT (expression = ANY subquery) --> expression <> ALL subquery
-   
+
    as long as the subquery does not return an empty set.
 
-3. Use a completely different syntax, for example, the ``EXISTS`` predicate, 
+3. Use a completely different syntax, for example, the ``EXISTS`` predicate,
    which we'll discuss later in this chapter.
 
 *Quantified retrieval*
 ----------------------
 
-Here's some examples of comparisons with subqueries, using the sample database 
-we defined in our chapter on "Simple Search Conditions". To find the records 
-for the employees reporting to a manager named D. Black: 
+Here's some examples of comparisons with subqueries, using the sample database
+we defined in our chapter on "Simple Search Conditions". To find the records
+for the employees reporting to a manager named D. Black:
 
 ::
 
@@ -444,11 +446,11 @@ The result is:
 | 4          | D        | MORGAN      | CHUCK     | 963 SOUTH     |
 +------------+----------+-------------+-----------+---------------+
 
-Because there is only one possible row in the ``DEPARTMENT`` Table with a 
-manager named ``BLACK D``, the equals operator can be used in this subquery 
-without a quantifier. If more than one value is possible, either ``ALL``, 
-``ANY`` or ``SOME`` is needed to quantify the comparison operator, as in this 
-example: 
+Because there is only one possible row in the ``DEPARTMENT`` Table with a
+manager named ``BLACK D``, the equals operator can be used in this subquery
+without a quantifier. If more than one value is possible, either ``ALL``,
+``ANY`` or ``SOME`` is needed to quantify the comparison operator, as in this
+example:
 
 ::
 
@@ -470,10 +472,10 @@ The result is:
 Predicates
 ==========
 
-In addition to quantified comparisons, SQL provides four other predicates that 
-operate on the results of a Table subquery: the <in predicate>, the <exists 
-predicate>, the <unique predicate>, and the <match predicate>. Each will return 
-a boolean value: either ``TRUE``, ``FALSE``, or ``UNKNOWN``. 
+In addition to quantified comparisons, SQL provides four other predicates that
+operate on the results of a Table subquery: the <in predicate>, the <exists
+predicate>, the <unique predicate>, and the <match predicate>. Each will return
+a boolean value: either ``TRUE``, ``FALSE``, or ``UNKNOWN``.
 
 *<in predicate>*
 ----------------
@@ -484,19 +486,19 @@ The required syntax for an <in predicate> is as follows.
 
     <in predicate> ::=
     row_expression [ NOT ] IN <in predicate value>
-    
+
        <in predicate value> ::=
        <Table subquery> |
        (row_expression [ {,row_expression}. . . ])
 
 
-An <in predicate> compares a value to a collection of values and returns either 
-``TRUE``, ``FALSE``, or ``UNKNOWN``. (If any argument is ``NULL``, the <in 
-predicate> returns ``UNKNOWN``.) ``IN`` searches for data that matches any one 
-of a specified collection of values. ``NOT IN`` searches for data that doesn't 
-match any of the values in the collection. Note the words we've used in this 
-explanation; ``IN`` can be used to replace the quantified comparison "=\ 
-``ANY``\ " — that is, these two expressions are equivalent: 
+An <in predicate> compares a value to a collection of values and returns either
+``TRUE``, ``FALSE``, or ``UNKNOWN``. (If any argument is ``NULL``, the <in
+predicate> returns ``UNKNOWN``.) ``IN`` searches for data that matches any one
+of a specified collection of values. ``NOT IN`` searches for data that doesn't
+match any of the values in the collection. Note the words we've used in this
+explanation; ``IN`` can be used to replace the quantified comparison "=\
+``ANY``\ " — that is, these two expressions are equivalent:
 
 ::
 
@@ -509,28 +511,28 @@ This example shows one of the two variants of ``IN``. The other variant is:
 
     IN (<list of values>)
 
-This syntax has nothing to do with subqueries, but while we're on the subject, 
-these two expressions are also equivalent: 
+This syntax has nothing to do with subqueries, but while we're on the subject,
+these two expressions are also equivalent:
 
 ::
 
     ... WHERE column_1 IN ( 'A', 'B', 'C') ...
     ... WHERE column_1 = 'A' OR column_1 = 'B' OR column_1 = 'C' ...
 
-With ``IN``, all the expressions must be comparable. You can use ``[NOT] IN`` 
-to compare one or more values to a collection; ``row_expression`` may be any 
-expression which evaluates either to a single value or to a row of values. 
+With ``IN``, all the expressions must be comparable. You can use ``[NOT] IN``
+to compare one or more values to a collection; ``row_expression`` may be any
+expression which evaluates either to a single value or to a row of values.
 
-The <in predicate> is ``TRUE`` if the value of ``row_expression`` is found 
-within the <in predicate value>. For example, these <in predicate>s are both 
-``TRUE``: 
+The <in predicate> is ``TRUE`` if the value of ``row_expression`` is found
+within the <in predicate value>. For example, these <in predicate>s are both
+``TRUE``:
 
 ::
 
     1 IN (1,2,3)
     1 IN (SELECT column_1 FROM Table_1 where column_1 = 1)
 
-``NOT IN`` is simply the negation of ``IN`` so these predicates are also 
+``NOT IN`` is simply the negation of ``IN`` so these predicates are also
 ``TRUE``:
 
 ::
@@ -538,23 +540,23 @@ within the <in predicate value>. For example, these <in predicate>s are both
     1 NOT IN (5,6,7)
     1 NOT IN (SELECT column_1 FROM Table_1 where column_1 = 15)
 
-In other words, the <in predicate> has two variants, both of which are merely 
-shorthands for some other comparison syntax, so the same rules that apply for 
-comparisons of specific <data type>s apply to ``IN`` as well. In both cases, 
-``IN`` appears to be more popular than the wordings it replaces. 
+In other words, the <in predicate> has two variants, both of which are merely
+shorthands for some other comparison syntax, so the same rules that apply for
+comparisons of specific <data type>s apply to ``IN`` as well. In both cases,
+``IN`` appears to be more popular than the wordings it replaces.
 
-If you want to restrict your code to Core SQL, make sure that all expressions 
-in an <in value list> are either <literal>s, references to host variables or 
-SQL parameters, <Field reference>s, or ``CURRENT_PATH``, ``CURRENT_ROLE``, 
-``CURRENT_USER``, ``SESSION_USER``, ``SYSTEM_USER``, ``USER``. 
+If you want to restrict your code to Core SQL, make sure that all expressions
+in an <in value list> are either <literal>s, references to host variables or
+SQL parameters, <Field reference>s, or ``CURRENT_PATH``, ``CURRENT_ROLE``,
+``CURRENT_USER``, ``SESSION_USER``, ``SYSTEM_USER``, ``USER``.
 
 *Retrieval with IN*
 -------------------
 
-Here's some examples of the <in predicate> using the sample database we defined 
-in Chapter 29 "Simple Search Conditions." To find the addresses of the 
-employees working in either department C or department D (retrieve values which 
-match any of a list of specified values): 
+Here's some examples of the <in predicate> using the sample database we defined
+in Chapter 29 "Simple Search Conditions." To find the addresses of the
+employees working in either department C or department D (retrieve values which
+match any of a list of specified values):
 
 ::
 
@@ -572,8 +574,8 @@ The result is:
 | D        | 4          | 963 SOUTH         |
 +----------+------------+-------------------+
 
-To find the employee numbers of the employees whose pay rate is not 5.00, 9.00, 
-or 16.00 (retrieve values which do not match any of a specified list): 
+To find the employee numbers of the employees whose pay rate is not 5.00, 9.00,
+or 16.00 (retrieve values which do not match any of a specified list):
 
 ::
 
@@ -591,8 +593,8 @@ The result is:
 | 4          |
 +------------+
 
-To find the names of employees earning a rate of 8.00 (retrieve values which 
-match any returned by a subquery): 
+To find the names of employees earning a rate of 8.00 (retrieve values which
+match any returned by a subquery):
 
 ::
 
@@ -611,12 +613,12 @@ The result is:
 | MORGAN      |
 +-------------+
 
-In this example, the subquery is first evaluated to find the payroll records 
-with a rate of 8.00. The employee numbers of the result are then compared to 
-the employee numbers of the ``EMPLOYEE`` Table to retrieve the surnames for the 
-final result. 
+In this example, the subquery is first evaluated to find the payroll records
+with a rate of 8.00. The employee numbers of the result are then compared to
+the employee numbers of the ``EMPLOYEE`` Table to retrieve the surnames for the
+final result.
 
-To find the employees located in the warehouse: 
+To find the employees located in the warehouse:
 
 ::
 
@@ -650,7 +652,7 @@ The result is:
 | ALICE     | SMITH       |
 +-----------+-------------+
 
-``IN`` expressions can be nested. To find the manager of employees working 
+``IN`` expressions can be nested. To find the manager of employees working
 in the warehouse:
 
 ::
@@ -669,8 +671,8 @@ The result is:
 | GREEN E       |
 +---------------+
 
-To find the names of employees who don't work on the 10th floor (retrieve 
-values which don't match any returned by a subquery): 
+To find the names of employees who don't work on the 10th floor (retrieve
+values which don't match any returned by a subquery):
 
 ::
 
@@ -708,19 +710,19 @@ The required syntax for an <exists predicate> is as follows.
     <exists predicate> ::=
     [ NOT ] EXISTS <Table subquery>
 
-An <exists predicate> is a test for a non-empty set and returns either ``TRUE`` 
-or ``FALSE``. ``EXISTS`` is ``TRUE`` if the Table subquery returns at least one 
-row; otherwise it is ``FALSE``. ``NOT EXISTS`` is ``TRUE`` if the Table 
-subquery returns zero rows; otherwise it is ``FALSE``. 
+An <exists predicate> is a test for a non-empty set and returns either ``TRUE``
+or ``FALSE``. ``EXISTS`` is ``TRUE`` if the Table subquery returns at least one
+row; otherwise it is ``FALSE``. ``NOT EXISTS`` is ``TRUE`` if the Table
+subquery returns zero rows; otherwise it is ``FALSE``.
 
-By tradition, the <Table subquery> following an <exists predicate> begins with 
-``SELECT *``. In this case, the asterisk is not a shorthand for a list of 
-Columns, it merely stands for "some Column." Unless you're using Core SQL, it 
-doesn't actually matter what you put here — but in Core SQL, the Table 
-subquery's select list must either be just an asterisk or it must evaluate to a 
-single derived Column. Whatever you use, the result is the same; if the 
-subquery returns any rows, ``EXISTS`` is ``TRUE`` — regardless of the number 
-of Columns that the subquery result contains. Here's an example: 
+By tradition, the <Table subquery> following an <exists predicate> begins with
+``SELECT *``. In this case, the asterisk is not a shorthand for a list of
+Columns, it merely stands for "some Column." Unless you're using Core SQL, it
+doesn't actually matter what you put here — but in Core SQL, the Table
+subquery's select list must either be just an asterisk or it must evaluate to a
+single derived Column. Whatever you use, the result is the same; if the
+subquery returns any rows, ``EXISTS`` is ``TRUE`` — regardless of the number
+of Columns that the subquery result contains. Here's an example:
 
 ::
 
@@ -728,15 +730,15 @@ of Columns that the subquery result contains. Here's an example:
     FROM   Table_1
     WHERE  EXISTS (SELECT * FROM Table_2);
 
-If there are any rows at all in ``TABLE_2``, then the search condition is 
-``TRUE`` and all values of ``TABLE_1.COLUMN_1`` will be selected. This is a 
-rare example of a rather static subquery. Much more often, the Table subquery 
-will be a correlated subquery. 
+If there are any rows at all in ``TABLE_2``, then the search condition is
+``TRUE`` and all values of ``TABLE_1.COLUMN_1`` will be selected. This is a
+rare example of a rather static subquery. Much more often, the Table subquery
+will be a correlated subquery.
 
-If you use ``EXISTS``, followed by a correlated subquery with a single outer 
-reference, you are accomplishing the same thing as you would accomplish with a 
-quantified ``ANY`` comparison. For example, here are two equivalent SQL 
-statements: 
+If you use ``EXISTS``, followed by a correlated subquery with a single outer
+reference, you are accomplishing the same thing as you would accomplish with a
+quantified ``ANY`` comparison. For example, here are two equivalent SQL
+statements:
 
 ::
 
@@ -747,7 +749,7 @@ statements:
        (SELECT column_1)
        FROM   Table _2
        WHERE  Table_2.column_2 = 5);
-       
+
     -- the same query, using EXISTS and a correlated subquery
     SELECT *
     FROM   Table_1
@@ -757,17 +759,17 @@ statements:
        WHERE  Table_2.column_2 = 5 AND
        Table_1.column_1 > Table_2.column_1);
 
-The ``EXISTS`` version of the request is more cumbersome, but it's a better 
-choice if there are several items to compare between the outer statement and 
-the subquery. 
+The ``EXISTS`` version of the request is more cumbersome, but it's a better
+choice if there are several items to compare between the outer statement and
+the subquery.
 
-``NOT EXISTS`` is merely the negation of ``EXISTS``, but it deserves attention 
-as a separate operator. The interesting case is a double-nested ``NOT EXISTS`` 
-predicate, which can solve questions of the general form — find all the A's 
-which are related to all of the B's. Logicians call these FORALL questions. An 
-example of a FORALL question is, "List the students who are in a class for 
-every course that the school offers." Expressed with a double-nested ``NOT 
-EXISTS`` predicate, this question is answered with: 
+``NOT EXISTS`` is merely the negation of ``EXISTS``, but it deserves attention
+as a separate operator. The interesting case is a double-nested ``NOT EXISTS``
+predicate, which can solve questions of the general form — find all the A's
+which are related to all of the B's. Logicians call these FORALL questions. An
+example of a FORALL question is, "List the students who are in a class for
+every course that the school offers." Expressed with a double-nested ``NOT
+EXISTS`` predicate, this question is answered with:
 
 ::
 
@@ -782,18 +784,18 @@ EXISTS`` predicate, this question is answered with:
           WHERE  Classes.course_id = Courses.course_id AND
                  Classes.student_id = Students.student_id));
 
-In other words, "Look for the case where there exists no student where there 
-exists no course where there exists a class for the course containing the 
-student." We can't say that quickly three times, but it doesn't matter; you can 
-use this example as a template for FORALL questions. 
+In other words, "Look for the case where there exists no student where there
+exists no course where there exists a class for the course containing the
+student." We can't say that quickly three times, but it doesn't matter; you can
+use this example as a template for FORALL questions.
 
 Retrieval with EXISTS
 _____________________
 
-Here's some examples of the <exists predicate> using the sample database we 
-defined in our Chapter on "Simple Search Conditions." To find the names of 
-employees earning a rate of 8.00 (retrieve a value only if some condition 
-exists): 
+Here's some examples of the <exists predicate> using the sample database we
+defined in our Chapter on "Simple Search Conditions." To find the names of
+employees earning a rate of 8.00 (retrieve a value only if some condition
+exists):
 
 ::
 
@@ -826,7 +828,7 @@ The result is:
 | FRANCIS     |
 +-------------+
 
-``EXISTS`` expressions can be nested. To find the managers of employees 
+``EXISTS`` expressions can be nested. To find the managers of employees
 working in the warehouse:
 
 ::
@@ -856,50 +858,50 @@ The required syntax for a <unique predicate> is as follows.
     <unique predicate> ::=
     [ NOT ] UNIQUE <Table subquery>
 
-A <unique predicate> is a test for duplicate rows and returns either ``TRUE`` 
-or ``FALSE``. ``UNIQUE`` returns ``TRUE`` if the Table subquery returns zero 
-rows or one row or if every row returned by the Table subquery is unique (that 
-is, every row contains a different set of non-null values than every other 
-row); otherwise it returns ``FALSE``. ``NOT UNIQUE`` returns ``TRUE`` if any 
-row returned by the Table subquery is an exact duplicate of another row; 
-otherwise it returns ``FALSE``. The <unique predicate> shouldn't be used if the 
-Table subquery returns Columns with a <data type> of ``BLOB``, ``CLOB``, 
-``NCLOB``, or ``ARRAY``. 
+A <unique predicate> is a test for duplicate rows and returns either ``TRUE``
+or ``FALSE``. ``UNIQUE`` returns ``TRUE`` if the Table subquery returns zero
+rows or one row or if every row returned by the Table subquery is unique (that
+is, every row contains a different set of non-null values than every other
+row); otherwise it returns ``FALSE``. ``NOT UNIQUE`` returns ``TRUE`` if any
+row returned by the Table subquery is an exact duplicate of another row;
+otherwise it returns ``FALSE``. The <unique predicate> shouldn't be used if the
+Table subquery returns Columns with a <data type> of ``BLOB``, ``CLOB``,
+``NCLOB``, or ``ARRAY``.
 
-For an example of how ``UNIQUE`` works, suppose that ``TABLE_1`` has one 
-Column, defined as ``DECIMAL(6,2)``. Here's what will happen, for different 
-values in the rows of ``TABLE_1``, for this expression: 
+For an example of how ``UNIQUE`` works, suppose that ``TABLE_1`` has one
+Column, defined as ``DECIMAL(6,2)``. Here's what will happen, for different
+values in the rows of ``TABLE_1``, for this expression:
 
 ::
 
     ... WHERE UNIQUE (SELECT column_1 FROM Table_1) ...
 
-* If ``TABLE_1`` contains the values {``100.00, 200.00, 300.00``}, the 
-  expression is ``TRUE``; all of ``TABLE_1``\'s rows are different. 
+* If ``TABLE_1`` contains the values {``100.00, 200.00, 300.00``}, the
+  expression is ``TRUE``; all of ``TABLE_1``\'s rows are different.
 
-* If ``TABLE_1`` contains only {``100.00``}, the expression is ``TRUE`` too; 
-  all of ``TABLE_1``\'s rows are different because there is only one. 
+* If ``TABLE_1`` contains only {``100.00``}, the expression is ``TRUE`` too;
+  all of ``TABLE_1``\'s rows are different because there is only one.
 
-* If ``TABLE_1`` contains no values, the expression is also ``TRUE``; when the 
-  set is empty, ``UNIQUE`` is ``TRUE``. 
+* If ``TABLE_1`` contains no values, the expression is also ``TRUE``; when the
+  set is empty, ``UNIQUE`` is ``TRUE``.
 
-* If ``TABLE_1`` contains the values {``100.00, 2000.00, 100.00``}, the 
-  expression is ``FALSE``; at least two of ``TABLE_1``\'s rows are the same. 
+* If ``TABLE_1`` contains the values {``100.00, 2000.00, 100.00``}, the
+  expression is ``FALSE``; at least two of ``TABLE_1``\'s rows are the same.
 
-* If ``TABLE_1`` contains the values {``100.00, NULL, 300.00``}, the expression 
-  is ``TRUE``; when ``NULL``\s are involved, ``UNIQUE`` ignores them and looks 
-  at the remaining values. In this case, all of ``TABLE_1``\'s remaining rows 
-  are different. 
+* If ``TABLE_1`` contains the values {``100.00, NULL, 300.00``}, the expression
+  is ``TRUE``; when ``NULL``\s are involved, ``UNIQUE`` ignores them and looks
+  at the remaining values. In this case, all of ``TABLE_1``\'s remaining rows
+  are different.
 
-* If ``TABLE_1`` contains the values {``100.00, NULL, 100.00``}, the expression 
-  is ``FALSE``; after eliminating ``NULL``\s, at least two of ``TABLE_1``\'s 
-  remaining rows are the same. 
+* If ``TABLE_1`` contains the values {``100.00, NULL, 100.00``}, the expression
+  is ``FALSE``; after eliminating ``NULL``\s, at least two of ``TABLE_1``\'s
+  remaining rows are the same.
 
-The <unique predicate> was introduced to SQL with SQL-92 but is still not much 
-used in application programs. Its main purpose is to expose the operation which 
-the DBMS uses to handle ``UNIQUE`` Constraints. For example, in the following 
-pair of SQL statements, the first is a ``UNIQUE`` Constraint definition and the 
-second is a statement that the DBMS implicitly uses to enforce the Constraint: 
+The <unique predicate> was introduced to SQL with SQL-92 but is still not much
+used in application programs. Its main purpose is to expose the operation which
+the DBMS uses to handle ``UNIQUE`` Constraints. For example, in the following
+pair of SQL statements, the first is a ``UNIQUE`` Constraint definition and the
+second is a statement that the DBMS implicitly uses to enforce the Constraint:
 
 ::
 
@@ -911,7 +913,7 @@ second is a statement that the DBMS implicitly uses to enforce the Constraint:
     SELECT * FROM Table_1
     WHERE  UNIQUE (SELECT column_1 FROM Table_1);
 
-If you want to restrict your code to Core SQL, don't use the <unique 
+If you want to restrict your code to Core SQL, don't use the <unique
 predicate>.
 
 *<match predicate>*
@@ -925,14 +927,14 @@ The required syntax for a <match predicate> is as follows.
     row_expression MATCH [ UNIQUE ] [ SIMPLE | PARTIAL | FULL ]
     <Table subquery>
 
-A <match predicate> is a test for matching rows and returns either ``TRUE`` or 
-``FALSE``. The ``row_expression`` can be any expression which evaluates to one 
-row of values; this row must be comparable to the rows returned by the Table 
-subquery — that is, ``row_expression`` and Table subquery must return rows 
-with the same number of values and each pair of corresponding values must have 
-comparable <data type>s. The <match predicate> can't be used if either 
-``row_expression`` or the Table subquery returns values with a <data type> of 
-``BLOB``, ``CLOB``, ``NCLOB``, or ``ARRAY``. 
+A <match predicate> is a test for matching rows and returns either ``TRUE`` or
+``FALSE``. The ``row_expression`` can be any expression which evaluates to one
+row of values; this row must be comparable to the rows returned by the Table
+subquery — that is, ``row_expression`` and Table subquery must return rows
+with the same number of values and each pair of corresponding values must have
+comparable <data type>s. The <match predicate> can't be used if either
+``row_expression`` or the Table subquery returns values with a <data type> of
+``BLOB``, ``CLOB``, ``NCLOB``, or ``ARRAY``.
 
 The <match predicate> has eight possible forms:
 
@@ -952,70 +954,70 @@ The <match predicate> has eight possible forms:
 
 8. ``row_expression MATCH UNIQUE FULL`` Table subquery
 
-The first and second forms are equivalent, as are the third and fourth forms; 
-if none of {``SIMPLE | PARTIAL | UNIQUE``} is specified, the default is 
-``SIMPLE``. 
+The first and second forms are equivalent, as are the third and fourth forms;
+if none of {``SIMPLE | PARTIAL | UNIQUE``} is specified, the default is
+``SIMPLE``.
 
-The expression "``row_expression MATCH SIMPLE`` Table subquery" is ``TRUE`` 
-only in two cases: 
+The expression "``row_expression MATCH SIMPLE`` Table subquery" is ``TRUE``
+only in two cases:
 
-1. It is ``TRUE`` if the result of ``row_expression`` contains at least one 
+1. It is ``TRUE`` if the result of ``row_expression`` contains at least one
    ``NULL`` — e.g., if ``row_expression`` evaluates to {``100, NULL, 300``}.
 
-2. It is ``TRUE`` if the result of ``row_expression`` contains no ``NULL``\s 
-   and the Table subquery returns at least one row that is equal to 
+2. It is ``TRUE`` if the result of ``row_expression`` contains no ``NULL``\s
+   and the Table subquery returns at least one row that is equal to
    ``row_expression``.
 
-The expression "``row_expression MATCH UNIQUE SIMPLE`` Table subquery" is 
-``TRUE`` only in two cases: 
+The expression "``row_expression MATCH UNIQUE SIMPLE`` Table subquery" is
+``TRUE`` only in two cases:
 
-1. It is ``TRUE`` if the result of ``row_expression`` contains at least one 
+1. It is ``TRUE`` if the result of ``row_expression`` contains at least one
    ``NULL``.
 
-2. It is ``TRUE`` if the result of ``row_expression`` contains no ``NULL``\s 
-   and the Table subquery returns exactly one row that is equal to 
+2. It is ``TRUE`` if the result of ``row_expression`` contains no ``NULL``\s
+   and the Table subquery returns exactly one row that is equal to
    ``row_expression``.
 
-The expression "``row_expression MATCH PARTIAL`` Table subquery" is ``TRUE`` 
+The expression "``row_expression MATCH PARTIAL`` Table subquery" is ``TRUE``
 only in two cases:
 
-1. It is ``TRUE`` if the result of ``row_expression`` contains only 
-   ``NULL``\s — e.g., if ``row_expression`` evaluates to, {``NULL, NULL, 
+1. It is ``TRUE`` if the result of ``row_expression`` contains only
+   ``NULL``\s — e.g., if ``row_expression`` evaluates to, {``NULL, NULL,
    NULL``}.
 
-2. It is ``TRUE`` if the Table subquery returns at least one row whose 
-   values equal their corresponding non-null values in ``row_expression`` — 
-   e.g., if ``row_expression`` evaluates to {``100, NULL, 300``}, at least 
-   one row returned by the subquery must be {``100``, <any value at all>, 
+2. It is ``TRUE`` if the Table subquery returns at least one row whose
+   values equal their corresponding non-null values in ``row_expression`` —
+   e.g., if ``row_expression`` evaluates to {``100, NULL, 300``}, at least
+   one row returned by the subquery must be {``100``, <any value at all>,
    ``300``}.
 
-The expression "``row_expression MATCH UNIQUE PARTIAL`` Table subquery" is 
+The expression "``row_expression MATCH UNIQUE PARTIAL`` Table subquery" is
 ``TRUE`` only in two cases:
 
 1. It is ``TRUE`` if the result of ``row_expression`` contains only ``NULL``\s.
 
-2. It is ``TRUE`` if the Table subquery returns exactly one row whose values 
+2. It is ``TRUE`` if the Table subquery returns exactly one row whose values
    equal their corresponding non-null values in ``row_expression``.
 
-The expression "``row_expression MATCH FULL`` Table subquery" is ``TRUE`` 
+The expression "``row_expression MATCH FULL`` Table subquery" is ``TRUE``
 only in two cases:
 
 1. It is ``TRUE`` if the result of ``row_expression`` contains only ``NULL``\s.
 
-2. It is ``TRUE`` if the result of ``row_expression`` contains no ``NULL``\s 
-   and the Table subquery returns at least one row that is equal to 
+2. It is ``TRUE`` if the result of ``row_expression`` contains no ``NULL``\s
+   and the Table subquery returns at least one row that is equal to
    ``row_expression``.
 
-The expression "``row_expression MATCH UNIQUE FULL`` Table subquery" is 
+The expression "``row_expression MATCH UNIQUE FULL`` Table subquery" is
 ``TRUE`` only in two cases:
 
 1. It is ``TRUE`` if the result of ``row_expression`` contains only ``NULL``\s.
 
-2. It is ``TRUE`` if the result of ``row_expression`` contains no ``NULL``\s 
-   and the Table subquery returns exactly one row that is equal to 
+2. It is ``TRUE`` if the result of ``row_expression`` contains no ``NULL``\s
+   and the Table subquery returns exactly one row that is equal to
    ``row_expression``.
 
-Assume a Table called ``TABLE_1``, defined with three Columns and containing 
+Assume a Table called ``TABLE_1``, defined with three Columns and containing
 this data:
 
 +--------------------------------------------+
@@ -1032,7 +1034,7 @@ this data:
 | 10           | 10           | 20           |
 +--------------+--------------+--------------+
 
-Using ``TABLE_1``, here are some examples of <match predicate> expressions, 
+Using ``TABLE_1``, here are some examples of <match predicate> expressions,
 all of which are ``TRUE``:
 
 ::
@@ -1054,7 +1056,7 @@ all of which are ``TRUE``:
     ... WHERE ROW(10,10,10) MATCH FULL
          (SELECT * FROM Table_1) ...
 
-Still using ``TABLE_1``, here are some examples of <match predicate> 
+Still using ``TABLE_1``, here are some examples of <match predicate>
 expressions, all of which are ``FALSE``:
 
 ::
@@ -1081,45 +1083,45 @@ The required syntax for a <quantified predicate> is as follows.
     FOR ALL <Table reference> list (<search condition>) |
     FOR ANY <Table reference> list (<search condition>) |
     FOR SOME <Table reference> list (<search condition>)
-    
+
        <Table reference> list ::=
        <Table reference> [ {,<Table reference>} ... ]
 
-A <quantified predicate> is a three-valued comparison test; it takes the 
-Cartesian product of "<Table reference> list," compares the resulting rows with 
-the search condition specified and returns either ``TRUE``, ``FALSE``, or 
-``UNKNOWN``. The <Table reference> list may contain one or more <Table name>s 
-or expressions that evaluate to Tables. The <quantified predicate>s work the 
-same way that the regular quantifiers do — that is: 
+A <quantified predicate> is a three-valued comparison test; it takes the
+Cartesian product of "<Table reference> list," compares the resulting rows with
+the search condition specified and returns either ``TRUE``, ``FALSE``, or
+``UNKNOWN``. The <Table reference> list may contain one or more <Table name>s
+or expressions that evaluate to Tables. The <quantified predicate>s work the
+same way that the regular quantifiers do — that is:
 
-``FOR ALL`` returns ``TRUE`` if the search condition is ``TRUE`` for every 
-row of the result of "<Table reference> list," returns TRUE if the result of 
-"<Table reference> list" is zero rows, returns ``FALSE`` if the search 
-condition is ``FALSE`` for at least one row of the result of "<Table 
-reference> list," and otherwise returns ``UNKNOWN``. 
+``FOR ALL`` returns ``TRUE`` if the search condition is ``TRUE`` for every
+row of the result of "<Table reference> list," returns TRUE if the result of
+"<Table reference> list" is zero rows, returns ``FALSE`` if the search
+condition is ``FALSE`` for at least one row of the result of "<Table
+reference> list," and otherwise returns ``UNKNOWN``.
 
-``FOR ANY`` returns ``TRUE`` if the search condition is ``TRUE`` for at least 
-one row of the result of "<Table reference> list," returns ``FALSE`` if the 
-search condition is ``FALSE`` for every row of the result of "<Table 
-reference> list," returns ``FALSE`` if the result of "<Table reference> list" 
-is zero rows and otherwise returns ``UNKNOWN``. (As usual, ``FOR SOME`` is a 
-synonym for ``FOR ANY``.) 
+``FOR ANY`` returns ``TRUE`` if the search condition is ``TRUE`` for at least
+one row of the result of "<Table reference> list," returns ``FALSE`` if the
+search condition is ``FALSE`` for every row of the result of "<Table
+reference> list," returns ``FALSE`` if the result of "<Table reference> list"
+is zero rows and otherwise returns ``UNKNOWN``. (As usual, ``FOR SOME`` is a
+synonym for ``FOR ANY``.)
 
-Subqueries are good for answering many complex analytical questions, but they 
-can be hard to understand. As a good example, consider the "double ``NOT 
-EXISTS``" method, which handles FORALL questions in an ugly manner. The SQL3 
-Standard tries to resolve this by introducing ``FOR ALL`` and ``FOR ANY`` — 
-two new predicates, which work only with Tables. Syntactically, the quantified 
-predicates don't have to involve subqueries. But there are times when they 
-could be replacements for subqueries (particularly the confusing ``NOT EXISTS`` 
-syntax). Here are some simple examples: 
+Subqueries are good for answering many complex analytical questions, but they
+can be hard to understand. As a good example, consider the "double ``NOT
+EXISTS``" method, which handles FORALL questions in an ugly manner. The SQL3
+Standard tries to resolve this by introducing ``FOR ALL`` and ``FOR ANY`` —
+two new predicates, which work only with Tables. Syntactically, the quantified
+predicates don't have to involve subqueries. But there are times when they
+could be replacements for subqueries (particularly the confusing ``NOT EXISTS``
+syntax). Here are some simple examples:
 
 ::
 
     ... FOR ALL
           (SELECT * FROM Employee AS Emps) (empnum>50)
 
-evaluates to ``FALSE`` if there are no employees with employee numbers greater 
+evaluates to ``FALSE`` if there are no employees with employee numbers greater
 than 50.
 
 ::
@@ -1129,22 +1131,22 @@ than 50.
 
 evaluates to ``TRUE`` if at least one employee works in the basement.
 
-If you want to restrict your code to Core SQL, don't use the <quantified 
+If you want to restrict your code to Core SQL, don't use the <quantified
 predicate>.
 
 Joins versus Subqueries
 =======================
 
-Often, SQL statements containing subqueries can be re-formulated as statements 
-containing joins or vice versa. The choice of which to use normally depends on 
-taste or optimization considerations. There are some scenarios, though, which 
-call for subqueries rather than joins: 
+Often, SQL statements containing subqueries can be re-formulated as statements
+containing joins or vice versa. The choice of which to use normally depends on
+taste or optimization considerations. There are some scenarios, though, which
+call for subqueries rather than joins:
 
-* When you want duplicates, but not false duplicates. Suppose ``Table_1`` has 
-  three rows — {``1,1,2``} — and ``Table_2`` has two rows — {``1,2,2``}. 
-  If you need to list the rows in ``Table_1`` which are also in ``Table_2``, 
-  only this subquery-based ``SELECT`` statement will give the right answer 
-  (``1,1,2``): 
+* When you want duplicates, but not false duplicates. Suppose ``Table_1`` has
+  three rows — {``1,1,2``} — and ``Table_2`` has two rows — {``1,2,2``}.
+  If you need to list the rows in ``Table_1`` which are also in ``Table_2``,
+  only this subquery-based ``SELECT`` statement will give the right answer
+  (``1,1,2``):
 
   ::
 
@@ -1155,65 +1157,65 @@ call for subqueries rather than joins:
           FROM Table_2);
 
   This SQL statement won't work:
-  
+
   ::
-  
+
       SELECT Table_1.column_1
       FROM   Table_1.Table_2
       WHERE Table_1.column_1 = Table_2.column_1;
-  
-  because the result will be {``1,1,2,2``} — and the duplication of 2 is an 
+
+  because the result will be {``1,1,2,2``} — and the duplication of 2 is an
   error. This SQL statement won't work either:
 
   ::
-  
+
       SELECT DISTINCT Table_1.column_1
       FROM   Table_1.Table_2
       WHERE  Table_1.column_1 = Table_2.column_1;
-  
-  because the result will be {``1,2``} — and the removal of the duplicated 1 
+
+  because the result will be {``1,2``} — and the removal of the duplicated 1
   is an error too.
 
 * When the outermost statement is not a query. The SQL statement:
 
   ::
-  
+
       UPDATE Table_1 SET column_1 = (SELECT column_1 FROM Table_2);
-  
+
   can't be expressed using a join unless some rare SQL3 features are used.
 
 * When the join is over an expression. The SQL statement:
-  
+
   ::
-  
+
       SELECT * FROM Table_1
       WHERE column_1 + 5 =
          (SELECT MAX(column_1) FROM Table_2);
 
-  is hard to express with a join. In fact, the only way we can think of is 
+  is hard to express with a join. In fact, the only way we can think of is
   this SQL statement:
-  
+
   ::
-  
+
       SELECT Table_1.*
       FROM   Table_1,
              (SELECT MAX(column_1) AS max_column_1 FROM Table_2) AS Table_2
       WHERE  Table_1.column_1 + 5 = Table_2.max_column_1;
 
-  which still involves a parenthesized query, so nothing is gained from the 
+  which still involves a parenthesized query, so nothing is gained from the
   transformation.
 
-* When you want to see the exception. For example, suppose the question is, 
-  "What books are longer than *Das Kapital*?" These two queries are effectively 
-  *almost* the same: 
-  
+* When you want to see the exception. For example, suppose the question is,
+  "What books are longer than *Das Kapital*?" These two queries are effectively
+  *almost* the same:
+
   ::
-  
+
       SELECT DISTINCT Bookcolumn_1.*
       FROM   Books AS Bookcolumn_1 JOIN Books AS Bookcolumn_2
              USING(page_count)
       WHERE  title = 'Das Kapital';
-      
+
       SELECT DISTINCT Bookcolumn_1.*
       FROM   Books AS Bookcolumn_1
       WHERE  Bookcolumn_1.page_count >
@@ -1221,31 +1223,31 @@ call for subqueries rather than joins:
          FROM   Books AS Bookcolumn_2
          WHERE  title = 'Das Kapital');
 
-  The difference between these two SQL statements is, if there are two editions 
-  of *Das Kapital* (with different page counts), then the self-join example 
-  will return the books which are longer than the shortest edition of *Das 
-  Kapital*. That might be the wrong answer because the original question didn't 
-  ask for ". . . longer than ``ANY`` book named *Das Kapital*" (it seems to 
-  contain a false assumption that there's only one edition). 
+  The difference between these two SQL statements is, if there are two editions
+  of *Das Kapital* (with different page counts), then the self-join example
+  will return the books which are longer than the shortest edition of *Das
+  Kapital*. That might be the wrong answer because the original question didn't
+  ask for ". . . longer than ``ANY`` book named *Das Kapital*" (it seems to
+  contain a false assumption that there's only one edition).
 
 Subquery Examples
 =================
 
-The following examples are derived, with much editing, from an SQL application 
-suite for a public library. They illustrate the most common situations where 
-subqueries have proven to be useful tools. 
+The following examples are derived, with much editing, from an SQL application
+suite for a public library. They illustrate the most common situations where
+subqueries have proven to be useful tools.
 
-When a query is on one Table, but requires a quick look at a Column in another 
-Table — for example, "Show the number of books checked out for a particular 
-patron." Here's a subquery that answers this: 
+When a query is on one Table, but requires a quick look at a Column in another
+Table — for example, "Show the number of books checked out for a particular
+patron." Here's a subquery that answers this:
 
 ::
 
     SELECT COUNT(*) FROM Circulations WHERE patron_id = ANY
        (SELECT patron_id FROM Patrons WHERE Surname = 'Jones');
 
-When detail and summary data are retrieved or compared in the same SQL 
-statement — for example, "Set a report item to show the average cost of 
+When detail and summary data are retrieved or compared in the same SQL
+statement — for example, "Set a report item to show the average cost of
 books." Here's a subquery that does this:
 
 ::
@@ -1253,10 +1255,10 @@ books." Here's a subquery that does this:
     UPDATE Reports SET
        average_book_cost = (SELECT AVG(book_cost) FROM Books);
 
-When a selection involves some calculation or complexity that has nothing to do 
-with the contents of what is ultimately selected — for example, "Who has 
-taken out books from either branch 9 or branch 10." Here's a subquery that 
-answers this: 
+When a selection involves some calculation or complexity that has nothing to do
+with the contents of what is ultimately selected — for example, "Who has
+taken out books from either branch 9 or branch 10." Here's a subquery that
+answers this:
 
 ::
 
@@ -1267,13 +1269,13 @@ answers this:
 Subquery Tips
 =============
 
-Make sure your scalar subqueries return a maximum of one row. You can help by 
-*(a)* using ``DISTINCT`` to remove duplicates, *(b)* selecting a value returned 
-by a set-function, and *(c)* including a primary key among the selected 
-Columns. 
+Make sure your scalar subqueries return a maximum of one row. You can help by
+*(a)* using ``DISTINCT`` to remove duplicates, *(b)* selecting a value returned
+by a set-function, and *(c)* including a primary key among the selected
+Columns.
 
-If your DBMS won't support row subqueries, you can still avoid repeating the 
-same subquery twice. For example, replace a construct like this: 
+If your DBMS won't support row subqueries, you can still avoid repeating the
+same subquery twice. For example, replace a construct like this:
 
 ::
 
@@ -1290,41 +1292,41 @@ with a construct like this:
        (SELECT smallint_column_1 * 100000 + smallint_column_2
         FROM Table_2);
 
-Put the fastest subquery at the deepest level. Because most DBMSs will process 
-non-correlated subqueries by travelling from innermost statements to outermost 
-statements, you're (to some extent) controlling the order of evaluation by 
-choosing which expression will be inner and which will be outer. 
+Put the fastest subquery at the deepest level. Because most DBMSs will process
+non-correlated subqueries by travelling from innermost statements to outermost
+statements, you're (to some extent) controlling the order of evaluation by
+choosing which expression will be inner and which will be outer.
 
-Use scalar subqueries rather than Table subqueries. Because scalar subqueries 
-are more restrictive, you are giving your DBMS more information when you use a 
-construct that requires a scalar subquery. The DBMS might pass that extra 
-information to its optimizer. 
+Use scalar subqueries rather than Table subqueries. Because scalar subqueries
+are more restrictive, you are giving your DBMS more information when you use a
+construct that requires a scalar subquery. The DBMS might pass that extra
+information to its optimizer.
 
-Consider alternatives to correlated subqueries. There are some SQL statements 
-that work better (or look more natural) if you use joins, set functions, or 
-Table operators. 
+Consider alternatives to correlated subqueries. There are some SQL statements
+that work better (or look more natural) if you use joins, set functions, or
+Table operators.
 
 Dialects
 ========
 
-SQL-89 was very restrictive about subqueries. SQL-92 removed most of the 
-restrictions and SQL3 changed very little. So most of the information in this 
-chapter will apply for most of the DBMSs in use today. But it doesn't hurt to 
-know what some of the historical restrictions are. Cautious programmers will 
-avoid these situations: 
+SQL-89 was very restrictive about subqueries. SQL-92 removed most of the
+restrictions and SQL3 changed very little. So most of the information in this
+chapter will apply for most of the DBMSs in use today. But it doesn't hurt to
+know what some of the historical restrictions are. Cautious programmers will
+avoid these situations:
 
 * Row subqueries.
 
 * Subqueries nested to a depth greater than 16 levels.
 
-* Statements with more than 15 <Table reference>s (this is a maximum in the 
+* Statements with more than 15 <Table reference>s (this is a maximum in the
   FIPS specification).
 
 * Subqueries that contain ``UNION``, ``EXCEPT``, or ``INTERSECT``.
 
 * Scalar subqueries that contain ``DISTINCT``, ``GROUP BY``, or ``HAVING``.
 
-* Subqueries which do not appear on the right side of a comparison operator 
-  within a ``WHERE`` clause. This last restriction is the most significant 
-  because it used to be the case that "``WHERE`` expression = (``SELECT`` ...)" 
-  was legal syntax, but almost nothing else was. 
+* Subqueries which do not appear on the right side of a comparison operator
+  within a ``WHERE`` clause. This last restriction is the most significant
+  because it used to be the case that "``WHERE`` expression = (``SELECT`` ...)"
+  was legal syntax, but almost nothing else was.

--- a/docs/chapters/32.rst
+++ b/docs/chapters/32.rst
@@ -4,41 +4,43 @@
 Chapter 32 -- Searching with Set Operators
 ==========================================
 
-SQL supports three set operators: ``UNION``, ``EXCEPT`` and ``INTERSECT``. We 
-described their general effects in our discussion of set theory (see our 
-chapter on "General Concepts"). Here's a quick recap, using two Tables: 
-``TABLE_1`` contains these three, one-Column rows: {``1,2,3``} and ``TABLE_2`` 
-contains these three, one- Column rows: {``1,3,5``}. 
+.. include:: ../_include/note.rst
 
-The expression: 
+SQL supports three set operators: ``UNION``, ``EXCEPT`` and ``INTERSECT``. We
+described their general effects in our discussion of set theory (see our
+chapter on "General Concepts"). Here's a quick recap, using two Tables:
+``TABLE_1`` contains these three, one-Column rows: {``1,2,3``} and ``TABLE_2``
+contains these three, one- Column rows: {``1,3,5``}.
 
-::
-
-    (Table_1) UNION (Table_2) 
-
-yields all non-duplicate rows from both ``TABLE_1`` and ``TABLE_2``, so the 
-result is these four rows: {``1,2,3,5``}. The expression: 
+The expression:
 
 ::
 
-    (Table_1) EXCEPT (Table_2) 
+    (Table_1) UNION (Table_2)
 
-yields all rows that are in ``TABLE_1`` and are not also in ``TABLE_2``, so the 
-result is this row: {``2``}. The expression: 
+yields all non-duplicate rows from both ``TABLE_1`` and ``TABLE_2``, so the
+result is these four rows: {``1,2,3,5``}. The expression:
 
 ::
 
-    (Table_1) INTERSECT (Table_2) 
+    (Table_1) EXCEPT (Table_2)
 
-yields all rows that are in ``TABLE_1`` and are also in ``TABLE_2``, so the 
-result is these two rows: {``1,3``} 
+yields all rows that are in ``TABLE_1`` and are not also in ``TABLE_2``, so the
+result is this row: {``2``}. The expression:
 
-The result in all three cases is, of course, another Table: ``UNION`` and 
-``EXCEPT`` and ``INTERSECT`` take two Tables as input, and produce one result 
-Table as output (that's why some sources -- particularly FIPS -- refer to 
-``UNION`` and ``EXCEPT`` and ``INTERSECT`` as "Table operators" rather than 
-"set operators") -- and so these constructs can also be used as a <Table 
-reference> in an SQL statement. 
+::
+
+    (Table_1) INTERSECT (Table_2)
+
+yields all rows that are in ``TABLE_1`` and are also in ``TABLE_2``, so the
+result is these two rows: {``1,3``}
+
+The result in all three cases is, of course, another Table: ``UNION`` and
+``EXCEPT`` and ``INTERSECT`` take two Tables as input, and produce one result
+Table as output (that's why some sources -- particularly FIPS -- refer to
+``UNION`` and ``EXCEPT`` and ``INTERSECT`` as "Table operators" rather than
+"set operators") -- and so these constructs can also be used as a <Table
+reference> in an SQL statement.
 
 .. rubric:: Table of Contents
 
@@ -48,191 +50,191 @@ reference> in an SQL statement.
 <query expression>
 ==================
 
-In this chapter, we'll discuss both the implementation problems and the details 
-for the three set operators. You'll notice that the list of 
-implementation-specific restrictions is quite long, which reflects the 
-difficulty that DBMS vendors have supporting set operators. Before we begin our 
-discussion though, we want to emphasize that each of the set operators can be 
-used to form what the SQL Standard calls a <query expression> -- that is, an 
-expression that results in a Table. Here is the full syntax required for a 
-<query expression>: 
+In this chapter, we'll discuss both the implementation problems and the details
+for the three set operators. You'll notice that the list of
+implementation-specific restrictions is quite long, which reflects the
+difficulty that DBMS vendors have supporting set operators. Before we begin our
+discussion though, we want to emphasize that each of the set operators can be
+used to form what the SQL Standard calls a <query expression> -- that is, an
+expression that results in a Table. Here is the full syntax required for a
+<query expression>:
 
 ::
 
     <query expression> ::=
     [ WITH [ RECURSIVE ] <with list> ] <query expression body>
-    
+
        <with list> ::=
        <with list element> [ {,<with list element> } ... ]
-       
+
           <with list element> ::=
           <query name> [ (<Column name list>) ] AS (<query expression> )
              [ <search or cycle clause> ]
-       
+
        <query expression body> ::=
        <non-join query expression> | <joined table>
-       
+
           <non-join query expression> ::=
           <non-join query term> |
           <query expression> UNION [ ALL | DISTINCT ]
                [ <corresponding spec> ] <query term> |
             <query expression> EXCEPT [ ALL | DISTINCT ]
                [ <corresponding spec> ] <query term>
-               
+
                <query term> ::=
                <non-join query term> |
                <joined table>
-               
+
                <non-join query term> ::=
                <non-join query primary> |
                <query term> INTERSECT [ ALL | DISTINCT ]
                   [ <corresponding spec> ] <query primary>
-                  
+
                   <query primary> ::=
                   <non-join query primary> |
                   <joined table>
-                  
+
                   <non-join query primary> ::=
                   <simple table> |
                   (<non-join query expression>)
-                  
+
                      <simple table> ::=
                      <query specification> |
                      VALUES (<row value constructor>s) |
                      TABLE <Table name>
-               
+
                <corresponding spec> ::=
                CORRESPONDING [ BY (<Column name list>) ]
-               
+
                   <Column name list> ::=
                   <Column name> [ {,<Column name>} ...]
-               
+
                <search or cycle clause> ::=
                <search clause> |
                <cycle clause> |
                <search clause> <cycle clause>
-               
+
                <search clause> ::=
                SEARCH <recursive search order> SET <Column name>
-               
+
                   <recursive search order> ::=
                   DEPTH FIRST BY <sort specification list> |
                   BREADTH FIRST BY <sort specification list>
-               
+
                <cycle clause> ::=
                CYCLE <cycle column list>
-               
+
                   SET <Column name> TO <cycle mark value>
                   DEFAULT <non-cycle mark value> USING <Column name>
-                  
+
                   <cycle column list> ::=
                   <Column name> [ {,<Column name>}... ]
-                  
+
                   <cycle mark value> ::= <value expression>
-                  
+
                   <non-cycle mark value> ::= <value expression>
 
-Although this syntax diagram looks extremely complicated, don;t be too 
-discouraged! Most SQL queries are fairly simple ``SELECT`` statements, and 
-those are mostly the types of examples we'll show you. And, in this chapter, 
-we're just going to concentrate on the set operators anyway. However, a brief 
-description of some of the terms in the diagram is warranted. 
+Although this syntax diagram looks extremely complicated, don;t be too
+discouraged! Most SQL queries are fairly simple ``SELECT`` statements, and
+those are mostly the types of examples we'll show you. And, in this chapter,
+we're just going to concentrate on the set operators anyway. However, a brief
+description of some of the terms in the diagram is warranted.
 
-* ``UNION`` and ``EXCEPT`` may appear in a <non-join query expression> and 
-  ``INTERSECT`` may appear in a <non-join query term>. In none of the cases are 
-  the input Columns involved allowed to have a ``BLOB``, ``CLOB`` or ``NCLOB`` 
-  <data type>. 
+* ``UNION`` and ``EXCEPT`` may appear in a <non-join query expression> and
+  ``INTERSECT`` may appear in a <non-join query term>. In none of the cases are
+  the input Columns involved allowed to have a ``BLOB``, ``CLOB`` or ``NCLOB``
+  <data type>.
 
-* A <query term> is either a <joined table> (see our chapter on "Searching with 
-  Joins") or a <non-join query term>. 
+* A <query term> is either a <joined table> (see our chapter on "Searching with
+  Joins") or a <non-join query term>.
 
-* A <non-join query term> is either a <non-join query primary> or a <query 
-  term> that uses ``INTERSECT``. 
+* A <non-join query term> is either a <non-join query primary> or a <query
+  term> that uses ``INTERSECT``.
 
-* You use a <query primary> to specify the second Table operand of an 
-  ``INTERSECT`` operation. A <query primary> is either a <joined table>, a 
-  parenthesized <non-join query expression>, a ``SELECT`` statement (i.e., 
-  ``SELECT`` ... ``FROM`` ... ``WHERE`` ...), a Table constructor, or ``TABLE`` 
-  <Table name> (which evaluates to ``SELECT * FROM`` <Table name>). If you want 
-  to restrict your code to Core SQL, don't use ``TABLE`` <Table name>. 
+* You use a <query primary> to specify the second Table operand of an
+  ``INTERSECT`` operation. A <query primary> is either a <joined table>, a
+  parenthesized <non-join query expression>, a ``SELECT`` statement (i.e.,
+  ``SELECT`` ... ``FROM`` ... ``WHERE`` ...), a Table constructor, or ``TABLE``
+  <Table name> (which evaluates to ``SELECT * FROM`` <Table name>). If you want
+  to restrict your code to Core SQL, don't use ``TABLE`` <Table name>.
 
-* A Table constructor is the <keyword> ``VALUES`` followed by a comma- 
-  delimited, parenthesized list of rows or an expression that evaluates to a 
-  Table. Here's an example of the first case: 
-  
+* A Table constructor is the <keyword> ``VALUES`` followed by a comma-
+  delimited, parenthesized list of rows or an expression that evaluates to a
+  Table. Here's an example of the first case:
+
   ::
-  
+
       ... VALUES (10,'hello',B'1011'),
                  (20,'goodbye',B'1111'),
-                 (30,'bobby',B'0000') ... 
-  
-  is a Table constructor that constructs a three-Column Table with three rows. 
-  (Each value inside the ``VALUES`` clause may be any expression that evaluates 
-  to a single value.) Here's another example, this time of the second case: 
-  
-  ::
-  
-      ... VALUES (SELECT column_1, column_5 FROM Table_1 WHERE column_1=10) ... 
-  
-  is a Table constructor that constructs a two-Column Table. 
+                 (30,'bobby',B'0000') ...
 
-If you want to restrict your code to Core SQL, don't use a Table constructor 
-that involves a Table expression, don't use a Table constructor anywhere but in 
-an ``INSERT`` statement and make all your Table constructors contain exactly 
-one row. 
+  is a Table constructor that constructs a three-Column Table with three rows.
+  (Each value inside the ``VALUES`` clause may be any expression that evaluates
+  to a single value.) Here's another example, this time of the second case:
+
+  ::
+
+      ... VALUES (SELECT column_1, column_5 FROM Table_1 WHERE column_1=10) ...
+
+  is a Table constructor that constructs a two-Column Table.
+
+If you want to restrict your code to Core SQL, don't use a Table constructor
+that involves a Table expression, don't use a Table constructor anywhere but in
+an ``INSERT`` statement and make all your Table constructors contain exactly
+one row.
 
 Set Operation Syntax
 ====================
 
-The required syntax for the simplest form of a set operation is: 
+The required syntax for the simplest form of a set operation is:
 
 ::
 
-  <query expression> {UNION | EXCEPT | INTERSECT} <query expression> 
+  <query expression> {UNION | EXCEPT | INTERSECT} <query expression>
 
-Here's an example of each: 
+Here's an example of each:
 
 ::
 
   SELECT boss_name, salary FROM Bosses
   UNION
   SELECT employee_name, salary FROM Employees;
-  
+
   SELECT boss_name, salary FROM Bosses
   EXCEPT
   SELECT employee_name, salary FROM Employees;
-  
+
   SELECT boss_name, salary FROM Bosses
   INTERSECT
   SELECT employee_name, salary FROM Employees;
 
-Despite the complicated <query expression> syntax we showed you earlier, assume 
-that <query expression> means "``SELECT`` ..." or "``VALUES`` ..." or 
-"``TABLE`` <Table name>" — we want deliberately to avoid some complications 
-of the official syntax description. For now, it is enough to say that there are 
-slight restrictions on the type of <query expression> that can be an argument 
-for ``UNION`` or ``EXCEPT`` and slightly different restrictions for 
-``INTERSECT``. These restrictions are obscure and have little or no practical 
-effect. 
+Despite the complicated <query expression> syntax we showed you earlier, assume
+that <query expression> means "``SELECT`` ..." or "``VALUES`` ..." or
+"``TABLE`` <Table name>" — we want deliberately to avoid some complications
+of the official syntax description. For now, it is enough to say that there are
+slight restrictions on the type of <query expression> that can be an argument
+for ``UNION`` or ``EXCEPT`` and slightly different restrictions for
+``INTERSECT``. These restrictions are obscure and have little or no practical
+effect.
 
-In the previous examples, the first ``SELECT`` statement retrieves two Columns 
-(``BOSS_NAME``, ``SALARY``) and so does the second ``SELECT`` statement 
-(``EMPLOYEE_NAME``, ``SALARY``). This reflects a mandatory rule — each input 
-Table must have the same number of Columns and each corresponding pair of 
-Columns must have comparable <data type>s. This is because each pair of Columns 
-will merge into a single Column of the result Table — that is, ``BOSS_NAME`` 
-and ``EMPLOYEE_NAME`` will merge into one result Column and so will ``SALARY`` 
-and ``SALARY``. Usually, your DBMS decides which Column to merge with which 
-Column by looking at ordinal position; it merges the first Columns from each 
-input Table, then the second Columns, and so on. Merging by ordinal position is 
-the simplest method, but there are alternative ways, which we'll discuss later. 
-First, though, we'll add a bit more to our basic set operation syntax. 
+In the previous examples, the first ``SELECT`` statement retrieves two Columns
+(``BOSS_NAME``, ``SALARY``) and so does the second ``SELECT`` statement
+(``EMPLOYEE_NAME``, ``SALARY``). This reflects a mandatory rule — each input
+Table must have the same number of Columns and each corresponding pair of
+Columns must have comparable <data type>s. This is because each pair of Columns
+will merge into a single Column of the result Table — that is, ``BOSS_NAME``
+and ``EMPLOYEE_NAME`` will merge into one result Column and so will ``SALARY``
+and ``SALARY``. Usually, your DBMS decides which Column to merge with which
+Column by looking at ordinal position; it merges the first Columns from each
+input Table, then the second Columns, and so on. Merging by ordinal position is
+the simplest method, but there are alternative ways, which we'll discuss later.
+First, though, we'll add a bit more to our basic set operation syntax.
 
 *ALL | DISTINCT*
 ----------------
 
-The required syntax for a slightly more complicated form of a set operation 
-is: 
+The required syntax for a slightly more complicated form of a set operation
+is:
 
 ::
 
@@ -241,32 +243,32 @@ is:
   [ ALL | DISTINCT ]
   <query expression>
 
-Although the default for all three set operations is duplicate elimination, you 
-can instruct your DBMS otherwise. The optional <keyword> ``ALL`` after 
-``UNION``, ``EXCEPT``, or ``INTERSECT`` means "keep all duplicates," while the 
-optional <keyword> ``DISTINCT`` means "eliminate duplicates." In SQL-92, the 
-<keyword> ``DISTINCT`` was not valid syntax, but it has always been the default 
-— that is, if you do not explicitly say ``ALL``, then the DBMS assumes that 
-you want to eliminate duplicates. Assume that ``TABLE_1`` contains these five, 
-one-Column rows: {``0,1,2,2,3``} and ``TABLE_2`` contains these five, 
-one-Column rows: {``1,2,3,5,5``}. 
+Although the default for all three set operations is duplicate elimination, you
+can instruct your DBMS otherwise. The optional <keyword> ``ALL`` after
+``UNION``, ``EXCEPT``, or ``INTERSECT`` means "keep all duplicates," while the
+optional <keyword> ``DISTINCT`` means "eliminate duplicates." In SQL-92, the
+<keyword> ``DISTINCT`` was not valid syntax, but it has always been the default
+— that is, if you do not explicitly say ``ALL``, then the DBMS assumes that
+you want to eliminate duplicates. Assume that ``TABLE_1`` contains these five,
+one-Column rows: {``0,1,2,2,3``} and ``TABLE_2`` contains these five,
+one-Column rows: {``1,2,3,5,5``}.
 
-The expressions: 
+The expressions:
 
 ::
 
   (Table_1) UNION (Table_2)
   (Table_1) UNION DISTINCT (Table_2)
 
-both yield all non-duplicate rows from ``TABLE_1`` and ``TABLE_2``: 
-{``0,1,2,3,5``}. The expression: 
+both yield all non-duplicate rows from ``TABLE_1`` and ``TABLE_2``:
+{``0,1,2,3,5``}. The expression:
 
 ::
 
   (Table_1) UNION ALL (Table_2)
 
 yields all rows from ``TABLE_1`` and ``TABLE_2``: {``0,1,2,2,2,3,3,5,5``}. The
-expressions: 
+expressions:
 
 ::
 
@@ -274,63 +276,63 @@ expressions:
   (Table_1) EXCEPT DISTINCT (Table_2)
 
 both yield all non-duplicate rows that are in ``TABLE_1`` and are not also in
-``TABLE_2``: {``0``}. The expression: 
+``TABLE_2``: {``0``}. The expression:
 
 ::
 
   (Table_1) EXCEPT ALL (Table_2)
 
-yields all rows that are in ``TABLE_1`` and are not also in ``TABLE_2``: 
-{``0,2``}. (For ``EXCEPT ALL``, if a row appears *x* times in the first Table 
-and *y* times in the second Table, it will appear *z* times in the result Table 
-(where *z* is *x* - *y* or zero, whichever is greater). The expressions: 
+yields all rows that are in ``TABLE_1`` and are not also in ``TABLE_2``:
+{``0,2``}. (For ``EXCEPT ALL``, if a row appears *x* times in the first Table
+and *y* times in the second Table, it will appear *z* times in the result Table
+(where *z* is *x* - *y* or zero, whichever is greater). The expressions:
 
 ::
 
 (Table_1) INTERSECT (Table_2)
 (Table_1) INTERSECT DISTINCT (Table_2)
 
-both yield all non-duplicate rows that are in ``TABLE_1`` and are also in 
-``TABLE_2``: {``1,2,3``} The expression: 
+both yield all non-duplicate rows that are in ``TABLE_1`` and are also in
+``TABLE_2``: {``1,2,3``} The expression:
 
 ::
 
   (Table_1) INTERSECT ALL (Table_2)
 
-yields all rows that are in ``TABLE_1`` and are also in ``TABLE_2``: 
-{``1,2,3``}. (For ``INTERSECT ALL``, if a row appears *x* times in the first 
-Table and *y* times in the second Table, it will appear *z* times in the result 
-Table (where *z* is the lesser of *x* and *y*). 
+yields all rows that are in ``TABLE_1`` and are also in ``TABLE_2``:
+{``1,2,3``}. (For ``INTERSECT ALL``, if a row appears *x* times in the first
+Table and *y* times in the second Table, it will appear *z* times in the result
+Table (where *z* is the lesser of *x* and *y*).
 
-That is, when you use an expression like "``SELECT`` ... <set operator> 
-``SELECT`` ...," the effect is the same as if you'd used "``SELECT DISTINCT`` 
-... <set operator> ``SELECT DISTINCT`` ..." When you use an expression like 
-"``SELECT`` ... <set operator> ``ALL SELECT`` ...," then any duplicates are 
-paired off against each other, one by one. 
+That is, when you use an expression like "``SELECT`` ... <set operator>
+``SELECT`` ...," the effect is the same as if you'd used "``SELECT DISTINCT``
+... <set operator> ``SELECT DISTINCT`` ..." When you use an expression like
+"``SELECT`` ... <set operator> ``ALL SELECT`` ...," then any duplicates are
+paired off against each other, one by one.
 
 .. CAUTION::
 
-  The ``[ALL | DISTINCT]`` option also appears at the beginning of a ``SELECT`` 
-  expression (i.e., ``SELECT [ALL|DISTINCT]`` <select list> ``FROM`` 
-  <Table-reference> ...). But in that case, the default is ``ALL`` rather than 
-  ``DISTINCT``. By contrast, after a set operator, the default is ``DISTINCT``. 
-  There's an inconsistency here — maybe the original assumption was that when 
-  you ``SELECT`` you don't need ``DISTINCT``, but when you ``UNION`` you do 
-  need ``DISTINCT``. 
+  The ``[ALL | DISTINCT]`` option also appears at the beginning of a ``SELECT``
+  expression (i.e., ``SELECT [ALL|DISTINCT]`` <select list> ``FROM``
+  <Table-reference> ...). But in that case, the default is ``ALL`` rather than
+  ``DISTINCT``. By contrast, after a set operator, the default is ``DISTINCT``.
+  There's an inconsistency here — maybe the original assumption was that when
+  you ``SELECT`` you don't need ``DISTINCT``, but when you ``UNION`` you do
+  need ``DISTINCT``.
 
-Probably ``UNION ALL`` is a faster operation than ``UNION DISTINCT``, but for 
-theoretical reasons you shouldn't go out of your way to preserve duplicate 
-rows. Use the ``ALL`` option only for those cases where duplicates don't 
-matter, where duplicates won't happen anyway or where the result of ``UNION 
-ALL`` is only going to be used for summary-information purposes. 
+Probably ``UNION ALL`` is a faster operation than ``UNION DISTINCT``, but for
+theoretical reasons you shouldn't go out of your way to preserve duplicate
+rows. Use the ``ALL`` option only for those cases where duplicates don't
+matter, where duplicates won't happen anyway or where the result of ``UNION
+ALL`` is only going to be used for summary-information purposes.
 
-For the purposes of set operation, two ``NULL``\s are "duplicates" of each 
-other. Now let's expand our set operation syntax a little more. 
+For the purposes of set operation, two ``NULL``\s are "duplicates" of each
+other. Now let's expand our set operation syntax a little more.
 
 *CORRESPONDING*
 ---------------
 
-The required syntax for the final form of a set operation is: 
+The required syntax for the final form of a set operation is:
 
 ::
 
@@ -340,9 +342,9 @@ The required syntax for the final form of a set operation is:
   [ CORRESPONDING [ BY (<Column name list>) ] ]
   <query expression>
 
-In a well-designed database, when Tables have similar Columns, the Columns have 
-similar names. For example, suppose two Tables, ``VILLAS`` and ``MANSIONS``, 
-are defined with these ``CREATE TABLE`` statements: 
+In a well-designed database, when Tables have similar Columns, the Columns have
+similar names. For example, suppose two Tables, ``VILLAS`` and ``MANSIONS``,
+are defined with these ``CREATE TABLE`` statements:
 
 ::
 
@@ -350,17 +352,17 @@ are defined with these ``CREATE TABLE`` statements:
      county char(20),
      acreage DECIMAL(4,2),
      price DECIMAL(8));
-  
+
   CREATE TABLE Mansions (
      owner char(20),
      acreage DECIMAL(4,2),
      house_rating INT,
      price DECIMAL(8));
 
-Notice that two <Column name>s -- ``ACREAGE`` and ``PRICE`` -- are in both 
-Tables, although the Columns they represent don't occupy the same ordinal 
-positions. Now, if we want a list of properties which are both villas and 
-mansions, we can use this simple intersection: 
+Notice that two <Column name>s -- ``ACREAGE`` and ``PRICE`` -- are in both
+Tables, although the Columns they represent don't occupy the same ordinal
+positions. Now, if we want a list of properties which are both villas and
+mansions, we can use this simple intersection:
 
 ::
 
@@ -368,12 +370,12 @@ mansions, we can use this simple intersection:
   INTERSECT
   SELECT acreage, price FROM Mansions;
 
-But such a query is lots of work. To formulate it, we must look at the 
-definitions for each Table, figure out which Columns they have in common and 
-then list those Columns, in the right order, in our query. It would be far 
-simpler to be able to say: "select Columns with the same names". The optional 
-``CORRESPONDING`` clause for a set operation does just that. Here's an example 
-that is equivalent to the last one: 
+But such a query is lots of work. To formulate it, we must look at the
+definitions for each Table, figure out which Columns they have in common and
+then list those Columns, in the right order, in our query. It would be far
+simpler to be able to say: "select Columns with the same names". The optional
+``CORRESPONDING`` clause for a set operation does just that. Here's an example
+that is equivalent to the last one:
 
 ::
 
@@ -381,17 +383,17 @@ that is equivalent to the last one:
   INTERSECT CORRESPONDING
   SELECT * FROM Mansions;
 
-The <keyword> ``CORRESPONDING``, used alone after a set operator, means 
-"instead of going by Column position as in the 'simple' format, merge all those 
-Columns which have the same name, regardless of their position". In this case, 
-the Columns which have the same name in both Tables are ``ACREAGE`` and 
-``PRICE``, so those are the Columns that will appear in the result Table. 
+The <keyword> ``CORRESPONDING``, used alone after a set operator, means
+"instead of going by Column position as in the 'simple' format, merge all those
+Columns which have the same name, regardless of their position". In this case,
+the Columns which have the same name in both Tables are ``ACREAGE`` and
+``PRICE``, so those are the Columns that will appear in the result Table.
 
-Now suppose that we only wanted the ``ACREAGE`` Column in our result -- we're 
-not interested in the ``PRICE`` at all. Since ``CORRESPONDING``, by itself, 
-automatically merges every pair of Columns with the same name, we can't use it 
-to form a quick query for the answer we want. Frankly, the easy solution is to 
-return to the simple format and say: 
+Now suppose that we only wanted the ``ACREAGE`` Column in our result -- we're
+not interested in the ``PRICE`` at all. Since ``CORRESPONDING``, by itself,
+automatically merges every pair of Columns with the same name, we can't use it
+to form a quick query for the answer we want. Frankly, the easy solution is to
+return to the simple format and say:
 
 ::
 
@@ -399,9 +401,9 @@ return to the simple format and say:
   INTERSECT
   SELECT acreage FROM Villas;
 
-But let's pretend that we have some reason to avoid using a ``SELECT`` in this 
-situation. There are alternatives, one of which is the expression "``TABLE`` 
-<Table-name>", so let's consider this expression: 
+But let's pretend that we have some reason to avoid using a ``SELECT`` in this
+situation. There are alternatives, one of which is the expression "``TABLE``
+<Table-name>", so let's consider this expression:
 
 ::
 
@@ -409,7 +411,7 @@ situation. There are alternatives, one of which is the expression "``TABLE``
   INTERSECT CORRESPONDING
   TABLE Villas;
 
-which gives us two Columns -- ``ACREAGE`` and ``PRICE`` -- and now let's 
+which gives us two Columns -- ``ACREAGE`` and ``PRICE`` -- and now let's
 consider this expression:
 
 ::
@@ -418,69 +420,69 @@ consider this expression:
   INTERSECT CORRESPONDING BY (acreage)
   TABLE Villas;
 
-which gives us one Column -- ``ACREAGE``. It's a contrived example, but if we 
-assume that the query is not ``SELECT``, then "``INTERSECT CORRESPONDING BY 
-...``" is the simplest way to use a set operator and merge specific same-name 
-Columns. 
+which gives us one Column -- ``ACREAGE``. It's a contrived example, but if we
+assume that the query is not ``SELECT``, then "``INTERSECT CORRESPONDING BY
+...``" is the simplest way to use a set operator and merge specific same-name
+Columns.
 
-The rules for this operation are: 
+The rules for this operation are:
 
-1. If ``CORRESPONDING BY`` is used with a set operator, at least one <Column 
-   name> must be in the comma-delimited and parenthesized ``BY`` list and each 
-   of the <Column name>s in the list must identify a Column that appears in 
-   both input Tables. The number of Columns in the result Table will equal the 
-   number of Columns in the ``BY`` list. 
+1. If ``CORRESPONDING BY`` is used with a set operator, at least one <Column
+   name> must be in the comma-delimited and parenthesized ``BY`` list and each
+   of the <Column name>s in the list must identify a Column that appears in
+   both input Tables. The number of Columns in the result Table will equal the
+   number of Columns in the ``BY`` list.
 
-2. If ``CORRESPONDING`` is used with a set operator, you may not specify a 
-   Column list. The number of Columns in the result Table will equal the number 
-   of Columns that both Tables have in common. 
+2. If ``CORRESPONDING`` is used with a set operator, you may not specify a
+   Column list. The number of Columns in the result Table will equal the number
+   of Columns that both Tables have in common.
 
-3. If you omit the ``CORRESPONDING`` clause entirely, the number of Columns in 
-   the result Table will equal the number of Columns that you explicitly 
-   specify in your query. 
+3. If you omit the ``CORRESPONDING`` clause entirely, the number of Columns in
+   the result Table will equal the number of Columns that you explicitly
+   specify in your query.
 
-To sum it up, there are three ways to pick which Columns to merge with a set 
-operation: *(a)* merge "all" Columns by ordinal position (the simple format), 
-*(b)* merge "all Columns with the same name" (the ``CORRESPONDING`` format) and 
-*(c)* merge "specified Columns with the same name (the ``CORRESPONDING BY`` 
-format). 
+To sum it up, there are three ways to pick which Columns to merge with a set
+operation: *(a)* merge "all" Columns by ordinal position (the simple format),
+*(b)* merge "all Columns with the same name" (the ``CORRESPONDING`` format) and
+*(c)* merge "specified Columns with the same name (the ``CORRESPONDING BY``
+format).
 
 Result Names and ORDER BY
 =========================
 
-When you're doing a set operation, if the <Column name>s of two merged Columns 
-are the same, then the merged result Column has that name too. If the <Column 
-name>s of two merged Columns are not the same, then, by default, the merged 
-Column is given some unique temporary name by your DBMS. Why would anyone care 
-what the name of a merged Column is? Well, if you want the rows in the result 
-Table to come out in some specific order, you'll have to use an ``ORDER BY`` 
-clause — which can only operate on the result Table and that means the names 
-of the result Table's Columns must be known. An ``ORDER BY`` clause may 
-optionally appear after a <query expression>; here is the required syntax: 
+When you're doing a set operation, if the <Column name>s of two merged Columns
+are the same, then the merged result Column has that name too. If the <Column
+name>s of two merged Columns are not the same, then, by default, the merged
+Column is given some unique temporary name by your DBMS. Why would anyone care
+what the name of a merged Column is? Well, if you want the rows in the result
+Table to come out in some specific order, you'll have to use an ``ORDER BY``
+clause — which can only operate on the result Table and that means the names
+of the result Table's Columns must be known. An ``ORDER BY`` clause may
+optionally appear after a <query expression>; here is the required syntax:
 
 ::
 
   <query expression> [ ORDER BY <sort specification list> ]
-  
+
      <sort specification list> ::=
      <sort specification> [ {,<sort specification> }. . . ]
-     
+
         <sort specification> ::=
         <sort key> [ COLLATE <Collation name> ] [ {ASC | DESC} ]
-        
+
            <sort key> ::= scalar_expression
 
-The ``ORDER BY`` clause provides your DBMS with a list of items to sort and the 
-order in which to sort them; either ascending order (``ASC``, the default) or 
-descending order (``DESC``). It must follow a <query expression> — this means 
-it operates on the final Table that results from the evaluation of the query; 
-it cannot operate on any interim result Tables at all. The <sort key> you 
-specify can be any expression that evaluates to a single value that identifies 
-a Column of the final result Table — this is almost always a <Column name> 
-and thus our concern to know what name will result from a set operation. 
+The ``ORDER BY`` clause provides your DBMS with a list of items to sort and the
+order in which to sort them; either ascending order (``ASC``, the default) or
+descending order (``DESC``). It must follow a <query expression> — this means
+it operates on the final Table that results from the evaluation of the query;
+it cannot operate on any interim result Tables at all. The <sort key> you
+specify can be any expression that evaluates to a single value that identifies
+a Column of the final result Table — this is almost always a <Column name>
+and thus our concern to know what name will result from a set operation.
 
-Suppose, then, you want to specify a sort order for the result of our earlier 
-examples: 
+Suppose, then, you want to specify a sort order for the result of our earlier
+examples:
 
 ::
 
@@ -488,20 +490,20 @@ examples:
   UNION
   SELECT employee_name, salary FROM Employees;
 
-In this case, it isn't possible to add an ``ORDER BY`` clause that specifies 
-"``ORDER BY boss_name``" or "``ORDER BY employee_name``" at the end of the 
-query -- these names identify the original Columns, not the merged result 
-Column. The name of the merged result Column is defined by the Standard to be 
-implementation-dependent: that is, it will be a name provided by your DBMS, but 
-what name will be provided doesn't even have to be documented; it's considered 
-to be an internal thing. 
+In this case, it isn't possible to add an ``ORDER BY`` clause that specifies
+"``ORDER BY boss_name``" or "``ORDER BY employee_name``" at the end of the
+query -- these names identify the original Columns, not the merged result
+Column. The name of the merged result Column is defined by the Standard to be
+implementation-dependent: that is, it will be a name provided by your DBMS, but
+what name will be provided doesn't even have to be documented; it's considered
+to be an internal thing.
 
-In SQL-92, you can solve this dilemma with an ``ORDER BY`` clause that 
-specifies "``ORDER BY 1``" -- this instructs the DBMS to sort by the first 
-result Column, no name required. This, however, is not legal in SQL3, so you'll 
-have to force your own names for the result Columns by providing an ``AS`` 
-clause in each select list for corresponding Columns and then using that name 
-in the ``ORDER BY`` clause. Here's an example: 
+In SQL-92, you can solve this dilemma with an ``ORDER BY`` clause that
+specifies "``ORDER BY 1``" -- this instructs the DBMS to sort by the first
+result Column, no name required. This, however, is not legal in SQL3, so you'll
+have to force your own names for the result Columns by providing an ``AS``
+clause in each select list for corresponding Columns and then using that name
+in the ``ORDER BY`` clause. Here's an example:
 
 ::
 
@@ -510,15 +512,15 @@ in the ``ORDER BY`` clause. Here's an example:
   SELECT employee_name AS sort_name, salary FROM Employees
   ORDER BY sort_name;
 
-With this syntax, you're forcing the corresponding Columns in each input Table 
-to have the same name. This name is thus the name given to the merged result 
-Column and can therefore be used in an ``ORDER`` by clause to identify that 
-result Column. 
+With this syntax, you're forcing the corresponding Columns in each input Table
+to have the same name. This name is thus the name given to the merged result
+Column and can therefore be used in an ``ORDER`` by clause to identify that
+result Column.
 
-[Obscure Rule] The Collation of a merged Column with a character string <data 
-type> will depend on the coercibility characteristics of the two input Columns, 
-and whether you add the optional ``COLLATE`` specification or not. If you want 
-to restrict your code to Core SQL, don't add the ``COLLATE`` clause. 
+[Obscure Rule] The Collation of a merged Column with a character string <data
+type> will depend on the coercibility characteristics of the two input Columns,
+and whether you add the optional ``COLLATE`` specification or not. If you want
+to restrict your code to Core SQL, don't add the ``COLLATE`` clause.
 
 Result <data type>s and Compatibility
 =====================================
@@ -531,22 +533,22 @@ Consider this SQL statement:
   UNION
   SELECT 'BB', 12 FROM Table_2;``
 
-The two queries that make up the ``UNION`` operator's Table operands are union 
-compatible: each corresponding pair of Columns is comparable (that is, we can 
-compare ``'A'`` with ``'BB'`` and we can compare ``5.0`` with ``12``). The 
-rules about the resultant merged Columns are: 
+The two queries that make up the ``UNION`` operator's Table operands are union
+compatible: each corresponding pair of Columns is comparable (that is, we can
+compare ``'A'`` with ``'BB'`` and we can compare ``5.0`` with ``12``). The
+rules about the resultant merged Columns are:
 
-1. The first result Column has a ``CHAR(2)`` <data type> (see Rules of 
-   Aggregation for the ``CASE`` expression, in our chapter on "Simple Search 
-   Conditions"), belongs to the same Character set that ``'A'`` does (the 
-   result always belongs to the Character set of the first input Column), and 
-   has ``COERCIBLE`` coercibility. 
+1. The first result Column has a ``CHAR(2)`` <data type> (see Rules of
+   Aggregation for the ``CASE`` expression, in our chapter on "Simple Search
+   Conditions"), belongs to the same Character set that ``'A'`` does (the
+   result always belongs to the Character set of the first input Column), and
+   has ``COERCIBLE`` coercibility.
 
-2. The second result Column has a ``DECIMAL`` or ``NUMERIC`` <data type>, with 
-   implementor-defined precision and a scale of 2 (again, see "Rules of 
-   Aggregation" for the ``CASE`` expression). 
+2. The second result Column has a ``DECIMAL`` or ``NUMERIC`` <data type>, with
+   implementor-defined precision and a scale of 2 (again, see "Rules of
+   Aggregation" for the ``CASE`` expression).
 
-Now consider this SQL statement: 
+Now consider this SQL statement:
 
 ::
 
@@ -554,14 +556,14 @@ Now consider this SQL statement:
   UNION
   SELECT 12, 'BB' FROM Table_;
 
-This statement will fail: it's an error to try to merge Columns which are not 
-union compatible. 
+This statement will fail: it's an error to try to merge Columns which are not
+union compatible.
 
 Set Operation Examples
 ======================
 
-Earlier in this chapter, we defined two example Tables: ``VILLAS`` and 
-``MANSIONS``. Let's suppose that they have these contents: 
+Earlier in this chapter, we defined two example Tables: ``VILLAS`` and
+``MANSIONS``. Let's suppose that they have these contents:
 
 +-------------------------------------------+
 | *VILLAS*                                  |
@@ -593,8 +595,8 @@ Earlier in this chapter, we defined two example Tables: ``VILLAS`` and
 | Mudriy       | ``NULL``    | ``NULL``         | ``NULL``     |
 +--------------+-------------+------------------+--------------+
 
-Based on this data, here are some example of SQL statements that use set 
-operators, and their results. 
+Based on this data, here are some example of SQL statements that use set
+operators, and their results.
 
 Example Statement:
 
@@ -705,240 +707,240 @@ Result table:
 Updatability
 ============
 
-Like joined Tables, Tables merged with a set operator aren't updatable in 
-SQL-92. Usually, this means that a View which is based on a query containing a 
-set operator can't be the object of a ``DELETE``, ``INSERT`` or ``UPDATE`` 
-statement. 
+Like joined Tables, Tables merged with a set operator aren't updatable in
+SQL-92. Usually, this means that a View which is based on a query containing a
+set operator can't be the object of a ``DELETE``, ``INSERT`` or ``UPDATE``
+statement.
 
-But such Views might be updatable in SQL3. For example, if the set operator is 
-``UNION ALL``, and the original Tables are both updatable, then so is the 
-result Table. This feature causes some complications, since the DBMS has to 
-track the original Tables. Most DBMSs support set operations by creating new 
-temporary Tables, therefore a data-change operation would only affect the 
-result Table and not the original Table. 
+But such Views might be updatable in SQL3. For example, if the set operator is
+``UNION ALL``, and the original Tables are both updatable, then so is the
+result Table. This feature causes some complications, since the DBMS has to
+track the original Tables. Most DBMSs support set operations by creating new
+temporary Tables, therefore a data-change operation would only affect the
+result Table and not the original Table.
 
-Consider a situation where you want to change the rows that result from a 
-``UNION`` of two Tables. There are three possible situations: 
+Consider a situation where you want to change the rows that result from a
+``UNION`` of two Tables. There are three possible situations:
 
-1. You want to delete a row. In this case, if the row you want to ``DELETE`` 
-   was derived from the first input Table, then the ``DELETE`` operation will 
-   remove that row from the first input Table. If the row you want to 
-   ``DELETE`` was derived from the second input Table, then the ``DELETE`` 
-   operation will remove that row from the second input Table. 
+1. You want to delete a row. In this case, if the row you want to ``DELETE``
+   was derived from the first input Table, then the ``DELETE`` operation will
+   remove that row from the first input Table. If the row you want to
+   ``DELETE`` was derived from the second input Table, then the ``DELETE``
+   operation will remove that row from the second input Table.
 
-2. You want to update a row. Once again, if the row you want to ``UPDATE`` was 
-   derived from the first input Table, then the ``UPDATE`` operation will 
-   change that row in the first input Table. If the row you want to ``UPDATE`` 
-   was derived from the second input Table, then the ``UPDATE`` operation will 
-   change that row in the second input Table. 
+2. You want to update a row. Once again, if the row you want to ``UPDATE`` was
+   derived from the first input Table, then the ``UPDATE`` operation will
+   change that row in the first input Table. If the row you want to ``UPDATE``
+   was derived from the second input Table, then the ``UPDATE`` operation will
+   change that row in the second input Table.
 
-3. You want to insert a row. This isn't allowed, because your DBMS wouldn't 
-   know which underlying Table the new row should be put into. 
+3. You want to insert a row. This isn't allowed, because your DBMS wouldn't
+   know which underlying Table the new row should be put into.
 
-Now consider a situation where you want to change the rows that result from an 
-``EXCEPT`` operation of two Tables. There are two possible situations: 
+Now consider a situation where you want to change the rows that result from an
+``EXCEPT`` operation of two Tables. There are two possible situations:
 
-1. You want to update a row. Since every row of the result is derived from a 
-   row of the first input Table, the ``UPDATE`` operation will change that row 
-   in the first input Table. 
+1. You want to update a row. Since every row of the result is derived from a
+   row of the first input Table, the ``UPDATE`` operation will change that row
+   in the first input Table.
 
-2. You want to delete a row *or* insert a row. Neither of these are allowed. In 
-   the first case, if you delete a row and that row was derived from a row that 
-   is duplicated in the first input Table, the row you "deleted" would still be 
-   in the result, causing confusion. In the second case, if you insert a row 
-   that also happens to be duplicated in the second input Table, the row you 
-   "inserted" wouldn't be part of the result, causing confusion. 
+2. You want to delete a row *or* insert a row. Neither of these are allowed. In
+   the first case, if you delete a row and that row was derived from a row that
+   is duplicated in the first input Table, the row you "deleted" would still be
+   in the result, causing confusion. In the second case, if you insert a row
+   that also happens to be duplicated in the second input Table, the row you
+   "inserted" wouldn't be part of the result, causing confusion.
 
-Finally, consider a situation where you want to change the rows that result 
-from an ``INTERSECT`` operation of two Tables. There are three possible 
-situations: 
+Finally, consider a situation where you want to change the rows that result
+from an ``INTERSECT`` operation of two Tables. There are three possible
+situations:
 
-1. You want to insert a row. If the first input Table doesn't contain a row 
-   with the same values, that row is inserted into the first input Table and if 
-   the second input Table doesn't contain a row with the same values, that row 
-   is inserted into the second input Table. However, if the first input Table 
-   already contains a row with the same values as the row you want to insert -- 
-   but the result Table doesn't have a row derived from that row of the first 
-   input Table, then the new row is inserted into the first input Table. The 
-   same thing holds for the second input Table too: if the second input Table 
-   already contains a row with the same values as the row you want to insert -- 
-   but the result Table doesn't have a row derived from that row of the second 
-   input Table, then the new row is inserted into the second input Table. 
+1. You want to insert a row. If the first input Table doesn't contain a row
+   with the same values, that row is inserted into the first input Table and if
+   the second input Table doesn't contain a row with the same values, that row
+   is inserted into the second input Table. However, if the first input Table
+   already contains a row with the same values as the row you want to insert --
+   but the result Table doesn't have a row derived from that row of the first
+   input Table, then the new row is inserted into the first input Table. The
+   same thing holds for the second input Table too: if the second input Table
+   already contains a row with the same values as the row you want to insert --
+   but the result Table doesn't have a row derived from that row of the second
+   input Table, then the new row is inserted into the second input Table.
 
-2. You want to update a row. If the row you want to ``UPDATE`` was derived from 
-   the first input Table, then the ``UPDATE`` operation will change that row in 
-   the first input Table. If the row you want to ``UPDATE`` was derived from 
-   the second input Table, then the ``UPDATE`` operation will change that row 
-   in the second input Table. 
+2. You want to update a row. If the row you want to ``UPDATE`` was derived from
+   the first input Table, then the ``UPDATE`` operation will change that row in
+   the first input Table. If the row you want to ``UPDATE`` was derived from
+   the second input Table, then the ``UPDATE`` operation will change that row
+   in the second input Table.
 
-3. You want to delete a row. This isn't allowed, because your DBMS wouldn't 
-   know which underlying Table the new row should be put into. 
+3. You want to delete a row. This isn't allowed, because your DBMS wouldn't
+   know which underlying Table the new row should be put into.
 
 Recursive Unions
 ================
 
-[Obscure Rule] applies for this entire section. 
+[Obscure Rule] applies for this entire section.
 
-Suppose you make widgets, which are made of doohickeys and framistats, and 
-framistats in turn are made of a certain number of screws, nails and so on. You 
-get a request: list all parts -- that is, list all widgets, all doohickeys, all 
-framistats, all screws and all nails. This is a "bill of materials" problem. 
-It's not a burning issue, but it's hard to solve with SQL-92, where the only 
-way you can generate a list of parts is to use several queries to scan the 
-``PARTS`` Table -- whenever your DBMS finds a part that's made up of other 
-parts, it has to start another query to determine its components, and so on. 
-SQL3 supports a set operation -- the ``RECURSIVE UNION`` -- to solve this 
-problem: it follows a trail of rows for you. Let's go back to the full syntax 
-required for a <query expression> that we showed you at the beginning of this 
-chapter. The parts we haven't talked about yet are used to form a ``RECURSIVE 
-UNION``. Here's the relevant syntax: 
+Suppose you make widgets, which are made of doohickeys and framistats, and
+framistats in turn are made of a certain number of screws, nails and so on. You
+get a request: list all parts -- that is, list all widgets, all doohickeys, all
+framistats, all screws and all nails. This is a "bill of materials" problem.
+It's not a burning issue, but it's hard to solve with SQL-92, where the only
+way you can generate a list of parts is to use several queries to scan the
+``PARTS`` Table -- whenever your DBMS finds a part that's made up of other
+parts, it has to start another query to determine its components, and so on.
+SQL3 supports a set operation -- the ``RECURSIVE UNION`` -- to solve this
+problem: it follows a trail of rows for you. Let's go back to the full syntax
+required for a <query expression> that we showed you at the beginning of this
+chapter. The parts we haven't talked about yet are used to form a ``RECURSIVE
+UNION``. Here's the relevant syntax:
 
 ::
 
   <query expression> ::=
   [ WITH [RECURSIVE] <with list> ] <query expression body>
-  
+
      <with list> ::=
      <with list element> [ {,<with list element> } . . . ]
-     
+
         <with list element> ::=
         <query name> [ (<Column name list>) ] AS (<query expression>)
            [ <search or cycle clause> ]
-        
+
         <query expression body> ::=
         <non-join query expression> | <joined table>
-        
+
         <search or cycle clause> ::=
         <search clause> | <cycle clause> | <search clause> <cycle clause>
-        
+
            <search clause> ::=
            SEARCH <recursive search order> SET <Column name>
-        
+
               <recursive search order> ::=
               DEPTH FIRST BY <sort specification list> |
               BREADTH FIRST BY <sort specification list>
-           
+
            <cycle clause> ::=
            CYCLE <cycle column list>
              SET <Column name> TO <cycle mark value>
              DEFAULT <non-cycle mark value> USING <Column name>
-             
+
               <cycle column list> ::=
               <Column name> [ {,<Column name>} . . . ]
-              
+
               <cycle mark value> ::= <value expression>
-              
+
               <non-cycle mark value> ::= <value expression>
 
-The optional ``WITH`` clause for a <query expression> is made up of one or more 
-elements, each of which is a named query that optionally includes names for the 
-Columns that result from that query. (If you include the optional <Column name> 
-list, you must provide a name for every result Column.) The definition of a 
-``WITH`` element may also include the optional <search or cycle clause>. 
+The optional ``WITH`` clause for a <query expression> is made up of one or more
+elements, each of which is a named query that optionally includes names for the
+Columns that result from that query. (If you include the optional <Column name>
+list, you must provide a name for every result Column.) The definition of a
+``WITH`` element may also include the optional <search or cycle clause>.
 
-A ``WITH`` clause preceding a <query expression> provides a list of related 
-element queries for a search. ``WITH`` by itself identifies a non-recursive set 
-of element queries -- this means that an element in the list may not contain 
-the <query name> of an element that follows it in the list. ``WITH RECURSIVE``, 
-on the other hand, identifies a set of element queries that are potentially 
-recursive -- so an element can contain the <query name> of a following element. 
+A ``WITH`` clause preceding a <query expression> provides a list of related
+element queries for a search. ``WITH`` by itself identifies a non-recursive set
+of element queries -- this means that an element in the list may not contain
+the <query name> of an element that follows it in the list. ``WITH RECURSIVE``,
+on the other hand, identifies a set of element queries that are potentially
+recursive -- so an element can contain the <query name> of a following element.
 
-If a ``WITH`` clause's elements cycle at least once -- that is, if element one 
-uses element two and element two uses element three and element three cycles 
-back to use element one -- and if at least one element is a <non-join query 
-expression> formed with ``UNION``, then the ``WITH`` clause is ``RECURSIVE``: 
-a potentially recursive ``WITH`` clause's element queries each depend on the 
-query which follows them in the list -- that is, the first element in the list 
-is a query that contains the <query name> of the second element in the list 
-(and so depends on that query), the second element is a query that contains the 
-<query name> of the third element, and so on and a ``WITH RECURSIVE`` clause's 
-element queries each depend on another element in a way that causes a least one 
-cycle of each element query to be executed. A linearly recursive ``WITH`` 
-clause is a clause where each element query has at most one reference to 
-another query in the list. 
+If a ``WITH`` clause's elements cycle at least once -- that is, if element one
+uses element two and element two uses element three and element three cycles
+back to use element one -- and if at least one element is a <non-join query
+expression> formed with ``UNION``, then the ``WITH`` clause is ``RECURSIVE``:
+a potentially recursive ``WITH`` clause's element queries each depend on the
+query which follows them in the list -- that is, the first element in the list
+is a query that contains the <query name> of the second element in the list
+(and so depends on that query), the second element is a query that contains the
+<query name> of the third element, and so on and a ``WITH RECURSIVE`` clause's
+element queries each depend on another element in a way that causes a least one
+cycle of each element query to be executed. A linearly recursive ``WITH``
+clause is a clause where each element query has at most one reference to
+another query in the list.
 
-The optional <Column name> subclause within the ``WITH`` clause allows you to 
-specify names for the Columns returned by the query. (Note that the element 
-query may not use an expression which would result in a result Column with a 
-``NO COLLATION`` coercibility attribute.) If any two Columns returned by a 
-``WITH`` element query have the same name, or if the ``WITH`` query is 
-potentially recursive, you must use the <Column name> subclause to uniquely 
-name each Column of the result Table. 
+The optional <Column name> subclause within the ``WITH`` clause allows you to
+specify names for the Columns returned by the query. (Note that the element
+query may not use an expression which would result in a result Column with a
+``NO COLLATION`` coercibility attribute.) If any two Columns returned by a
+``WITH`` element query have the same name, or if the ``WITH`` query is
+potentially recursive, you must use the <Column name> subclause to uniquely
+name each Column of the result Table.
 
-For each element query in a ``WITH`` clause, the element is a recursive query 
-if it depends on another element query. (Such queries may not include set 
-operators unless the second operand includes the name of the element query this 
-element depends on, nor may they invoke routines that affect the element query 
-this element depends on, nor may they include table subqueries that affect the 
-element query this element depends on, nor may they include ``OUTER JOIN`` 
-specifications that affect a <Table reference> that names the element query 
-this element depends on, nor may they include a <query specification> that 
-names the element query this element depends on.) Each element query 
-accumulates rows for the final result. An element's <query name> is the name 
-used in an iteration of the entire <query expression> to identify the parents 
-of any row being accumulated into the result. If each accumulated row has only 
-one parent (that is, it results from a query that uses only one other query in 
-the ``WITH`` list), the query is a linear ``RECURSIVE UNION``. If accumulated 
-rows have more than one parent (that is, they result from a query that uses 
-more than one other query in the ``WITH`` list), the query is a nonlinear 
-``RECURSIVE UNION``. 
+For each element query in a ``WITH`` clause, the element is a recursive query
+if it depends on another element query. (Such queries may not include set
+operators unless the second operand includes the name of the element query this
+element depends on, nor may they invoke routines that affect the element query
+this element depends on, nor may they include table subqueries that affect the
+element query this element depends on, nor may they include ``OUTER JOIN``
+specifications that affect a <Table reference> that names the element query
+this element depends on, nor may they include a <query specification> that
+names the element query this element depends on.) Each element query
+accumulates rows for the final result. An element's <query name> is the name
+used in an iteration of the entire <query expression> to identify the parents
+of any row being accumulated into the result. If each accumulated row has only
+one parent (that is, it results from a query that uses only one other query in
+the ``WITH`` list), the query is a linear ``RECURSIVE UNION``. If accumulated
+rows have more than one parent (that is, they result from a query that uses
+more than one other query in the ``WITH`` list), the query is a nonlinear
+``RECURSIVE UNION``.
 
-An expandable element query is a linearly recursive element query whose query 
-contains ``UNION`` or ``UNION ALL``. If a ``WITH`` clause element query is not 
-expandable, the element definition may not include a <search or cycle clause>. 
+An expandable element query is a linearly recursive element query whose query
+contains ``UNION`` or ``UNION ALL``. If a ``WITH`` clause element query is not
+expandable, the element definition may not include a <search or cycle clause>.
 
-A ``WITH`` element query defined with a <search clause> can specify a search 
-order of either "``SEARCH DEPTH FIRST BY``" or "``SEARCH BREADTH FIRST BY``" 
-followed, in both cases, by a <sort key> and either ``ASC`` or ``DESC`` (the 
-syntax for the <sort specification list> is the same as the syntax we showed 
-you earlier for the ORDER BY clause's <sort specification list>). ``SEARCH 
-DEPTH FIRST`` means "travel down the tree structure first" and ``SEARCH BREADTH 
-FIRST`` means "travel across the tree structure first". The Column named in the 
-``SET`` subclause that follows must be a Column with an ``INTEGER`` <data 
-type>; your DBMS will set that Column to a value that indicates when a row 
-accumulated into the result was found. 
+A ``WITH`` element query defined with a <search clause> can specify a search
+order of either "``SEARCH DEPTH FIRST BY``" or "``SEARCH BREADTH FIRST BY``"
+followed, in both cases, by a <sort key> and either ``ASC`` or ``DESC`` (the
+syntax for the <sort specification list> is the same as the syntax we showed
+you earlier for the ORDER BY clause's <sort specification list>). ``SEARCH
+DEPTH FIRST`` means "travel down the tree structure first" and ``SEARCH BREADTH
+FIRST`` means "travel across the tree structure first". The Column named in the
+``SET`` subclause that follows must be a Column with an ``INTEGER`` <data
+type>; your DBMS will set that Column to a value that indicates when a row
+accumulated into the result was found.
 
-A ``WITH`` element query defined with a <cycle clause> helps your DBMS 
-determine whether a row that has already been accumulated is found a second 
-time. This rarely happens in real life and so it probably means an error when 
-it happens for a query. By adding a <cycle clause> to a ``WITH`` element 
-definition, you can avoid getting into infinite loops by setting a limit on how 
-long you want the search to go on. The <cycle column list> names the Columns 
-affected by the <cycle clause>. The ``SET`` <column name> and the ``USING`` 
-<column name> may not identify any of the Columns returned by the query, nor 
-may they be the same Column. The <cycle mark value> and the <non-cycle mark 
-value> must both be <character string literal>s that are one character long. 
-They may not be the same value. 
+A ``WITH`` element query defined with a <cycle clause> helps your DBMS
+determine whether a row that has already been accumulated is found a second
+time. This rarely happens in real life and so it probably means an error when
+it happens for a query. By adding a <cycle clause> to a ``WITH`` element
+definition, you can avoid getting into infinite loops by setting a limit on how
+long you want the search to go on. The <cycle column list> names the Columns
+affected by the <cycle clause>. The ``SET`` <column name> and the ``USING``
+<column name> may not identify any of the Columns returned by the query, nor
+may they be the same Column. The <cycle mark value> and the <non-cycle mark
+value> must both be <character string literal>s that are one character long.
+They may not be the same value.
 
 Dialects
 ========
 
 Here are just some of the many restrictions that some DBMSs had placed on set
-operations in the past: 
+operations in the past:
 
-* IBM DB2: the <data type>s of corresponding Columns must be exactly the same 
-  and be defined with exactly the same size. 
+* IBM DB2: the <data type>s of corresponding Columns must be exactly the same
+  and be defined with exactly the same size.
 
-* IBM SQL/DS: neither of the input <query expression>s may contain 
-  ``DISTINCT``. 
+* IBM SQL/DS: neither of the input <query expression>s may contain
+  ``DISTINCT``.
 
-* Various: neither the input <query expression>s nor the result Table may be 
-  used with set functions, with ``GROUP BY`` or with ``HAVING``. 
+* Various: neither the input <query expression>s nor the result Table may be
+  used with set functions, with ``GROUP BY`` or with ``HAVING``.
 
-* dBASE IV, SQL Server: all set operators are unsupported, period. 
+* dBASE IV, SQL Server: all set operators are unsupported, period.
 
-Those restrictions are history now. The ones which you are much more likely to 
-encounter are the ones that are allowed for Entry-Level SQL-92: 
+Those restrictions are history now. The ones which you are much more likely to
+encounter are the ones that are allowed for Entry-Level SQL-92:
 
-* No derived Column list is allowed, which effectively means that you can't use 
-  <literal>s or expressions in queries that use set operators. 
+* No derived Column list is allowed, which effectively means that you can't use
+  <literal>s or expressions in queries that use set operators.
 
-* Set operators are illegal inside subqueries, in ``INSERT ... SELECT`` and in 
-  View definitions. 
+* Set operators are illegal inside subqueries, in ``INSERT ... SELECT`` and in
+  View definitions.
 
-* ``EXCEPT``, ``INTERSECT`` and ``CORRESPONDING`` are illegal. 
+* ``EXCEPT``, ``INTERSECT`` and ``CORRESPONDING`` are illegal.
 
-Even if your DBMS supports SQL3, it might only be Core SQL. If you want to 
-restrict your code to Core SQL, don't use ``WITH [RECURSIVE]``, the 
-``INTERSECT`` set operator, a ``CORRESPONDING`` clause with any set operator or 
-any set operator with an explicit ``DISTINCT``. 
+Even if your DBMS supports SQL3, it might only be Core SQL. If you want to
+restrict your code to Core SQL, don't use ``WITH [RECURSIVE]``, the
+``INTERSECT`` set operator, a ``CORRESPONDING`` clause with any set operator or
+any set operator with an explicit ``DISTINCT``.

--- a/docs/chapters/33.rst
+++ b/docs/chapters/33.rst
@@ -4,14 +4,16 @@
 Chapter 33 -- Searching with Groups
 ===================================
 
-This chapter deals with three optional points of a ``SELECT`` statement: the 
-``GROUP BY`` clause, the set functions {``AVG, COUNT, MAX, MIN, SUM, EVERY, 
-ANY, SOME, GROUPING``} and the ``HAVING`` clause. Often these things appear 
-together: the common factor is summaries, or amalgams, of Columns -- with 
-groups, rather than with details. We group together where values are equal. For 
-example, confronted with the detail list {Smith Smith Smith Jones Jones}, we 
-could summarize it to be: "three Smiths, two Joneses". Such a summary is known 
-in SQL as a *grouped Table*. 
+.. include:: ../_include/note.rst
+
+This chapter deals with three optional points of a ``SELECT`` statement: the
+``GROUP BY`` clause, the set functions {``AVG, COUNT, MAX, MIN, SUM, EVERY,
+ANY, SOME, GROUPING``} and the ``HAVING`` clause. Often these things appear
+together: the common factor is summaries, or amalgams, of Columns -- with
+groups, rather than with details. We group together where values are equal. For
+example, confronted with the detail list {Smith Smith Smith Jones Jones}, we
+could summarize it to be: "three Smiths, two Joneses". Such a summary is known
+in SQL as a *grouped Table*.
 
 .. rubric:: Table of Contents
 
@@ -21,7 +23,7 @@ in SQL as a *grouped Table*.
 GROUP BY Clause
 ===============
 
-The ``GROUP BY`` clause is an optional portion of the ``SELECT`` statement. 
+The ``GROUP BY`` clause is an optional portion of the ``SELECT`` statement.
 It defines a grouped Table. The required syntax for the ``GROUP BY`` clause is:
 
 ::
@@ -49,11 +51,11 @@ It defines a grouped Table. The required syntax for the ``GROUP BY`` clause is:
              CUBE (<grouping Column reference list>) |
              ()
 
-``GROUP BY`` defines a grouped Table: a set of groups of rows, where each group 
-consists of the rows in which all the values of the grouping Column(s) are 
-equal (the group is the entire Table if you use the ``HAVING`` clause without a 
-preceding ``GROUP BY`` clause). Here are three ``SELECT`` statements; each 
-contains a ``GROUP BY`` clause: 
+``GROUP BY`` defines a grouped Table: a set of groups of rows, where each group
+consists of the rows in which all the values of the grouping Column(s) are
+equal (the group is the entire Table if you use the ``HAVING`` clause without a
+preceding ``GROUP BY`` clause). Here are three ``SELECT`` statements; each
+contains a ``GROUP BY`` clause:
 
 ::
 
@@ -68,27 +70,27 @@ contains a ``GROUP BY`` clause:
    WHERE    column_1 BETWEEN 10 AND 50
    GROUP BY column_1 HAVING SUM(column_1)>12;
 
-These examples illustrate that the ``GROUP BY`` clause contains a list of 
-<Column reference>s (the grouping Columns) and that it comes at a certain place 
-within the various optional or compulsory clauses of a ``SELECT`` statement. In 
-each case, the grouping <Column reference> names a Column that belongs to a 
-Table named in the ``SELECT ... FROM`` clause -- the argument of the ``GROUP 
-BY`` clause is a list of (optionally qualified) <Column name>s and only <Column 
-name>s; SQL doesn't allow you to use <literal>s, Column expressions, or any 
-operator/function except ``COLLATE`` in a ``GROUP BY`` clause. In addition, 
-when a ``SELECT`` statement includes ``GROUP BY``, the statement's select list 
-may consist only of references to Columns that are single-valued per group -- 
-this means that the select list can't include a reference to an interim result 
-Column that isn't also included in the ``GROUP BY`` clause unless that Column 
-is an argument for one of the set functions (``AVG, COUNT, MAX, MIN, SUM, 
-EVERY, ANY, SOME``; each of which reduce the collection of values from a Column 
-to a single value). These are severe restrictions, but we'll show you ways to 
-get around some of the restrictions. 
+These examples illustrate that the ``GROUP BY`` clause contains a list of
+<Column reference>s (the grouping Columns) and that it comes at a certain place
+within the various optional or compulsory clauses of a ``SELECT`` statement. In
+each case, the grouping <Column reference> names a Column that belongs to a
+Table named in the ``SELECT ... FROM`` clause -- the argument of the ``GROUP
+BY`` clause is a list of (optionally qualified) <Column name>s and only <Column
+name>s; SQL doesn't allow you to use <literal>s, Column expressions, or any
+operator/function except ``COLLATE`` in a ``GROUP BY`` clause. In addition,
+when a ``SELECT`` statement includes ``GROUP BY``, the statement's select list
+may consist only of references to Columns that are single-valued per group --
+this means that the select list can't include a reference to an interim result
+Column that isn't also included in the ``GROUP BY`` clause unless that Column
+is an argument for one of the set functions (``AVG, COUNT, MAX, MIN, SUM,
+EVERY, ANY, SOME``; each of which reduce the collection of values from a Column
+to a single value). These are severe restrictions, but we'll show you ways to
+get around some of the restrictions.
 
-The ``GROUP BY`` clause allows you to summarize SQL-data. For an example of how 
-it works, let's look at some basic queries on one of the sample Tables we 
-defined in our chapter on "Simple Search Conditions": the ``PAYROLL`` Table, 
-which looks like this: 
+The ``GROUP BY`` clause allows you to summarize SQL-data. For an example of how
+it works, let's look at some basic queries on one of the sample Tables we
+defined in our chapter on "Simple Search Conditions": the ``PAYROLL`` Table,
+which looks like this:
 
 
 +-----------------------------------------------------------------------+
@@ -117,7 +119,7 @@ which looks like this:
 | 40         | 16.00    | 10TH FLOOR   | 1989-10-31     | 14:35:07      |
 +------------+----------+--------------+----------------+---------------+
 
-The simplest ``GROUP BY`` example on ``PAYROLL`` groups the ``LOCATION`` 
+The simplest ``GROUP BY`` example on ``PAYROLL`` groups the ``LOCATION``
 Column into its four different values. Here's the ``SELECT`` statement:
 
 ::
@@ -125,14 +127,14 @@ Column into its four different values. Here's the ``SELECT`` statement:
    SELECT   location FROM Payroll
    GROUP BY location;
 
-To get the result for this ``SELECT`` statement, your DBMS will first 
-evaluate the ``FROM`` clause to construct an interim result Table (in 
-this case, the entire ``PAYROLL`` Table), then pass this interim result 
-to the ``GROUP BY`` clause. When it evaluates the ``GROUP BY`` clause, 
-it breaks the interim result into groups which have the same values in 
-``LOCATION`` (the grouping Column), then passes this interim result to 
-the select list. When it evaluates the select list, your DBMS throws out 
-all Columns which aren't named in the select list. The result, then, is: 
+To get the result for this ``SELECT`` statement, your DBMS will first
+evaluate the ``FROM`` clause to construct an interim result Table (in
+this case, the entire ``PAYROLL`` Table), then pass this interim result
+to the ``GROUP BY`` clause. When it evaluates the ``GROUP BY`` clause,
+it breaks the interim result into groups which have the same values in
+``LOCATION`` (the grouping Column), then passes this interim result to
+the select list. When it evaluates the select list, your DBMS throws out
+all Columns which aren't named in the select list. The result, then, is:
 
 
 +-----------------+
@@ -147,7 +149,7 @@ all Columns which aren't named in the select list. The result, then, is:
 | BASEMENT        |
 +-----------------+
 
-A slightly more complicated example groups ``PAYROLL``\'s ``LOCATION`` and 
+A slightly more complicated example groups ``PAYROLL``\'s ``LOCATION`` and
 ``RATE`` Columns. Here's the ``SELECT`` statement:
 
 ::
@@ -155,15 +157,15 @@ A slightly more complicated example groups ``PAYROLL``\'s ``LOCATION`` and
    SELECT   location, rate FROM Payroll
    GROUP BY location, rate;
 
-To get the result for this ``SELECT`` statement, your DBMS will follow the same 
-steps we described for the last example -- up until it reaches the interim 
-result that contains groups which have the same values in ``LOCATION`` (the 
-first grouping Column). At this point, instead of passing the result to the 
-select list, the DBMS will now break the new interim result into groups which 
-have the same values in ``LOCATION`` and ``RATE`` (the second grouping Column). 
-This interim result is then passed on to the select list for evaluation. The 
-final result is (note that the ``NULL`` value in the ``RATE`` Column is in a 
-group of its own; for ``GROUP BY`` all ``NULL``\s form a single group): 
+To get the result for this ``SELECT`` statement, your DBMS will follow the same
+steps we described for the last example -- up until it reaches the interim
+result that contains groups which have the same values in ``LOCATION`` (the
+first grouping Column). At this point, instead of passing the result to the
+select list, the DBMS will now break the new interim result into groups which
+have the same values in ``LOCATION`` and ``RATE`` (the second grouping Column).
+This interim result is then passed on to the select list for evaluation. The
+final result is (note that the ``NULL`` value in the ``RATE`` Column is in a
+group of its own; for ``GROUP BY`` all ``NULL``\s form a single group):
 
 +--------------+----------+
 | ``LOCATION`` | ``RATE`` |
@@ -187,7 +189,7 @@ group of its own; for ``GROUP BY`` all ``NULL``\s form a single group):
 | BASEMENT     | 8.00     |
 +--------------+----------+
 
-One last example: grouping with a ``WHERE`` clause. Here's a ``SELECT`` 
+One last example: grouping with a ``WHERE`` clause. Here's a ``SELECT``
 statement:
 
 ::
@@ -196,12 +198,12 @@ statement:
    WHERE    rate > 6.00
    GROUP BY location, rate;
 
-To get the result for this ``SELECT`` statement, your DBMS will get a copy of 
-the ``PAYROLL`` Table (evaluate the ``FROM`` clause), remove any rows where the 
-``RATE`` value is less than or equal to 6 (evaluate the ``WHERE`` clause), 
-break the result into groups which have the same values in ``LOCATION`` and 
-``RATE`` (evaluate the ``GROUP BY`` clause) and remove any groups which aren't 
-named in the select list. The result is: 
+To get the result for this ``SELECT`` statement, your DBMS will get a copy of
+the ``PAYROLL`` Table (evaluate the ``FROM`` clause), remove any rows where the
+``RATE`` value is less than or equal to 6 (evaluate the ``WHERE`` clause),
+break the result into groups which have the same values in ``LOCATION`` and
+``RATE`` (evaluate the ``GROUP BY`` clause) and remove any groups which aren't
+named in the select list. The result is:
 
 +-----------------+------------+
 | ``LOCATION``    | ``RATE``   |
@@ -224,32 +226,32 @@ named in the select list. The result is:
 
 In the ``GROUP BY`` clause:
 
-* Each Column in a ``GROUP BY`` clause must unambiguously name a Column that 
-  belongs to a Table named in the ``SELECT`` statement's ``FROM`` clause. The 
-  name may be qualified, i.e.: it may be a <Column reference>. Such a Column is 
-  called a grouping Column: its values will be grouped for the final result. 
+* Each Column in a ``GROUP BY`` clause must unambiguously name a Column that
+  belongs to a Table named in the ``SELECT`` statement's ``FROM`` clause. The
+  name may be qualified, i.e.: it may be a <Column reference>. Such a Column is
+  called a grouping Column: its values will be grouped for the final result.
 
-* The grouping Column <data type> may not be ``BLOB``, ``CLOB``, ``NCLOB`` or 
-  ``ARRAY``. 
+* The grouping Column <data type> may not be ``BLOB``, ``CLOB``, ``NCLOB`` or
+  ``ARRAY``.
 
-* If the grouping Column <data type> is ``CHAR`` or ``VARCHAR``, then the 
-  <Column reference> may be accompanied by ``COLLATE`` <Collation name>. This 
-  addition was added to SQL with SQL-92 and may not be supported by all DBMSs. 
-  The idea is that you should be able to match for upper|lower case, or use 
-  ``PAD SPACES`` when you're defining a group's values. Other than ``COLLATE``, 
-  all SQL operators and functions are illegal in a ``GROUP BY`` clause. 
+* If the grouping Column <data type> is ``CHAR`` or ``VARCHAR``, then the
+  <Column reference> may be accompanied by ``COLLATE`` <Collation name>. This
+  addition was added to SQL with SQL-92 and may not be supported by all DBMSs.
+  The idea is that you should be able to match for upper|lower case, or use
+  ``PAD SPACES`` when you're defining a group's values. Other than ``COLLATE``,
+  all SQL operators and functions are illegal in a ``GROUP BY`` clause.
 
 In the select list:
 
-* You must follow "The Single-Value Rule" -- every Column named in the select 
-  list must also be a grouping Column, unless it is an argument for one of the 
-  set functions. 
+* You must follow "The Single-Value Rule" -- every Column named in the select
+  list must also be a grouping Column, unless it is an argument for one of the
+  set functions.
 
-* The select list may include derived Columns -- <literal>s, scalar functions, 
-  and <Column name>s within expressions (only the ``GROUP BY`` clause disallows 
-  expressions). 
+* The select list may include derived Columns -- <literal>s, scalar functions,
+  and <Column name>s within expressions (only the ``GROUP BY`` clause disallows
+  expressions).
 
-Here are some examples of grouped ``SELECT`` statements, legal and not 
+Here are some examples of grouped ``SELECT`` statements, legal and not
 (``a`` is a Column of Table ``T``):
 
 ::
@@ -280,27 +282,27 @@ Here are some examples of grouped ``SELECT`` statements, legal and not
    SELECT a+5 FROM T GROUP BY a+5;
       -- illegal: expression in GROUP BY
 
-.. CAUTION:: 
+.. CAUTION::
 
-  The superficial similarity of the ``GROUP BY`` clause and the ``ORDER BY`` 
-  clause often misleads people. The big difference is that grouping is done on 
-  the input (that is, the Tables named in the ``FROM`` clause), while ordering 
-  is done on the output (that is, the Columns named in the select list). So, 
-  although you can say "``ORDER BY`` integer" (only in SQL-92 though) and 
-  "``ORDER BY`` expression", it makes no sense to say "``GROUP BY`` integer" or 
-  "``GROUP BY`` expression". On the other hand, grouping Columns don't have to 
-  be in the select list, as sorted Columns must. 
+  The superficial similarity of the ``GROUP BY`` clause and the ``ORDER BY``
+  clause often misleads people. The big difference is that grouping is done on
+  the input (that is, the Tables named in the ``FROM`` clause), while ordering
+  is done on the output (that is, the Columns named in the select list). So,
+  although you can say "``ORDER BY`` integer" (only in SQL-92 though) and
+  "``ORDER BY`` expression", it makes no sense to say "``GROUP BY`` integer" or
+  "``GROUP BY`` expression". On the other hand, grouping Columns don't have to
+  be in the select list, as sorted Columns must.
 
-.. CAUTION:: 
+.. CAUTION::
 
-  The SQL Standard doesn't specify how many Columns can be grouped or what the 
-  size of a grouping Column may be (except that it can't be a large object 
-  string), but most DBMSs allow fairly small numbers and sizes. When people 
-  create Tables, they often allot hundreds of characters for ``VARCHAR`` 
-  Columns (like "address" or "comment"), thinking that there is plenty of room 
-  in the row. Later they find that their DBMS can't use those Columns In a 
-  ``GROUP BY`` clause, due to their size. Moral: Don't make Columns bigger than 
-  they have to be. 
+  The SQL Standard doesn't specify how many Columns can be grouped or what the
+  size of a grouping Column may be (except that it can't be a large object
+  string), but most DBMSs allow fairly small numbers and sizes. When people
+  create Tables, they often allot hundreds of characters for ``VARCHAR``
+  Columns (like "address" or "comment"), thinking that there is plenty of room
+  in the row. Later they find that their DBMS can't use those Columns In a
+  ``GROUP BY`` clause, due to their size. Moral: Don't make Columns bigger than
+  they have to be.
 
 The Single-Value Rule
 _____________________
@@ -313,18 +315,18 @@ and countries. If this SQL statement were legal:
    SELECT    city, country FROM Cities_And_Countries
    GROUP BY country;
 
-what value would come out in the ``CITY`` Column? There are plausible answers 
-such as "any city will do provided it's in the country", or "the DBMS should 
-assume that we want to group by both country and city". The problem with those 
-answers is that they try to compensate for a formal user error. What the user 
-really needs to know is "that does not compute". 
+what value would come out in the ``CITY`` Column? There are plausible answers
+such as "any city will do provided it's in the country", or "the DBMS should
+assume that we want to group by both country and city". The problem with those
+answers is that they try to compensate for a formal user error. What the user
+really needs to know is "that does not compute".
 
-The rule does not mean that all values must be distinct. We could multiply 
-everything times zero, yielding zeros in every Column in the select list, and 
-we would still be specifying "single-valued per group". The true meaning is 
-that there must be, for each group, one (and only one) value which is 
-appropriate as an answer for the query. Sometimes the DBMS doesn't realize 
-this, as in a SQL statement like: 
+The rule does not mean that all values must be distinct. We could multiply
+everything times zero, yielding zeros in every Column in the select list, and
+we would still be specifying "single-valued per group". The true meaning is
+that there must be, for each group, one (and only one) value which is
+appropriate as an answer for the query. Sometimes the DBMS doesn't realize
+this, as in a SQL statement like:
 
 ::
 
@@ -345,9 +347,9 @@ a "textbook" describing the one DBMS which does not follow the Standard.
 Grouping by Expressions
 _______________________
 
-We said earlier that, while you can use "``GROUP BY`` Column list" in your 
-``SELECT`` statements, you can't use "``GROUP BY`` expression list". This means 
-that these two SQL statements are both illegal: 
+We said earlier that, while you can use "``GROUP BY`` Column list" in your
+``SELECT`` statements, you can't use "``GROUP BY`` expression list". This means
+that these two SQL statements are both illegal:
 
 ::
 
@@ -366,14 +368,14 @@ Bummer. Luckily, there is a way out if you have SQL-92 and some patience:
    FROM     (SELECT EXTRACT(MONTH FROM bdate) AS ebdate FROM Table_1)
    GROUP BY ebdate;
 
-This example uses a Table subquery in the ``FROM`` clause, and puts all the 
-necessary calculations inside that Table subquery. The outer ``SELECT`` does a 
-grouping of the result -- which is now legal, since the ``EBDATE`` Column is 
-clearly identified as a Column belonging to the Table named in the ``FROM`` 
-clause. If your DBMS doesn't support Table subqueries in the ``FROM`` clause, 
-try making a View, or a temporary Table, with the same logic. Whatever you do 
-will be slow, because two Tables are being produced, one for the temporary 
-Table and one for the grouping. 
+This example uses a Table subquery in the ``FROM`` clause, and puts all the
+necessary calculations inside that Table subquery. The outer ``SELECT`` does a
+grouping of the result -- which is now legal, since the ``EBDATE`` Column is
+clearly identified as a Column belonging to the Table named in the ``FROM``
+clause. If your DBMS doesn't support Table subqueries in the ``FROM`` clause,
+try making a View, or a temporary Table, with the same logic. Whatever you do
+will be slow, because two Tables are being produced, one for the temporary
+Table and one for the grouping.
 
 *New Syntax*
 ------------
@@ -408,18 +410,18 @@ set operator to put the different result sets together. For example:
    WHERE    A.number = B.number
    GROUP BY GROUPING SETS (A.id,(A.id,B.name));
 
-In this example, the ``GROUP BY`` clause determines the first requirement -- 
-groups of IDs -- by grouping the ``A.ID`` values from the ``TABLE_1`` Table. It 
-then determines the second requirement -- number of IDs by ``ID`` and ``NAME`` 
--- by grouping the ``A.ID`` values from ``TABLE_1`` with the ``B.NAME`` values 
-from ``TABLE_2``. 
+In this example, the ``GROUP BY`` clause determines the first requirement --
+groups of IDs -- by grouping the ``A.ID`` values from the ``TABLE_1`` Table. It
+then determines the second requirement -- number of IDs by ``ID`` and ``NAME``
+-- by grouping the ``A.ID`` values from ``TABLE_1`` with the ``B.NAME`` values
+from ``TABLE_2``.
 
-The grouping forms like "``GROUP BY`` (grouping Columns), <grouping set list>", 
-also known as *concatenated grouping*, puts groups together. 
+The grouping forms like "``GROUP BY`` (grouping Columns), <grouping set list>",
+also known as *concatenated grouping*, puts groups together.
 
-A <grouping specification> of () (called *grand total* in the Standard) is 
-equivalent to grouping the entire result Table; i.e.: to the result returned 
-by: 
+A <grouping specification> of () (called *grand total* in the Standard) is
+equivalent to grouping the entire result Table; i.e.: to the result returned
+by:
 
 ::
 
@@ -427,8 +429,8 @@ by:
    WHERE  conditions
    HAVING conditions
 
-A <grouping specification> of ``ROLLUP`` means get one group out of all 
-grouping Columns, by rolling each group into the next until only one 
+A <grouping specification> of ``ROLLUP`` means get one group out of all
+grouping Columns, by rolling each group into the next until only one
 remains. It is equivalent to the result returned by:
 
 ::
@@ -544,12 +546,12 @@ This time, the result is:
 | ``NULL``     | ``NULL``     | 11.22     |
 +--------------+--------------+-----------+
 
-In addition to the same groups returned by the ordinary ``GROUP BY``, ``GROUP 
-BY ROLLUP`` gets a group of each group: the group of ``COLUMN_1`` "1" values 
-(with a ``NULL`` for the grouping of "A" and "B" in ``COLUMN_2``), the group of 
-``COLUMN_1`` "2" values (with a ``NULL`` for the grouping of "A" in 
-``COLUMN_2``) and the group of ``COLUMN_1`` "1" and "2" values (with a ``NULL`` 
-for the grouping of "A" and "B" in ``COLUMN_2``). 
+In addition to the same groups returned by the ordinary ``GROUP BY``, ``GROUP
+BY ROLLUP`` gets a group of each group: the group of ``COLUMN_1`` "1" values
+(with a ``NULL`` for the grouping of "A" and "B" in ``COLUMN_2``), the group of
+``COLUMN_1`` "2" values (with a ``NULL`` for the grouping of "A" in
+``COLUMN_2``) and the group of ``COLUMN_1`` "1" and "2" values (with a ``NULL``
+for the grouping of "A" and "B" in ``COLUMN_2``).
 
 Finally, let's do a ``GROUP BY`` with ``CUBE``:
 
@@ -583,24 +585,24 @@ This time, the result is:
 | ``NULL``     | ``NULL``     | 11.22     |
 +--------------+--------------+-----------+
 
-In addition to the same groups returned by the ``GROUP BY ROLLUP``, ``GROUP BY 
-CUBE`` gets a group of each combination of groups: the group of ``COLUMN_1`` 
-"1" values, the group of ``COLUMN_1`` "2" values, the group of ``COLUMN_2`` "A" 
-values (with a ``NULL`` for the grouping of "1" and "2" in ``COLUMN_1``) and 
-the group of ``COLUMN_2`` "B" values (with a ``NULL`` for the grouping of "1" 
-in ``COLUMN_1``). 
+In addition to the same groups returned by the ``GROUP BY ROLLUP``, ``GROUP BY
+CUBE`` gets a group of each combination of groups: the group of ``COLUMN_1``
+"1" values, the group of ``COLUMN_1`` "2" values, the group of ``COLUMN_2`` "A"
+values (with a ``NULL`` for the grouping of "1" and "2" in ``COLUMN_1``) and
+the group of ``COLUMN_2`` "B" values (with a ``NULL`` for the grouping of "1"
+in ``COLUMN_1``).
 
-If you want to restrict your code to Core SQL, don't use ``ROLLUP`` or 
-``CUBE``, and don't add a ``COLLATE`` clause to any grouping Column reference. 
+If you want to restrict your code to Core SQL, don't use ``ROLLUP`` or
+``CUBE``, and don't add a ``COLLATE`` clause to any grouping Column reference.
 
 Set Functions
 =============
 
-The SQL set functions -- more commonly called *aggregate functions* -- are 
-``AVG``, ``COUNT``, ``MAX``, ``MIN``, ``SUM``, ``EVERY``, ``ANY``, ``SOME``. 
-Each one takes the collection of values from a Column and reduces the 
-collection to a single value. The required syntax for a set function 
-specification is: 
+The SQL set functions -- more commonly called *aggregate functions* -- are
+``AVG``, ``COUNT``, ``MAX``, ``MIN``, ``SUM``, ``EVERY``, ``ANY``, ``SOME``.
+Each one takes the collection of values from a Column and reduces the
+collection to a single value. The required syntax for a set function
+specification is:
 
 ::
 
@@ -618,22 +620,22 @@ specification is:
           <grouping operation> ::=
           GROUPING (<Column reference>)
 
-The Column expression that follows a <general set function> can be a <Column 
-reference>, a <literal>, a scalar function or an arithmetic expression -- in 
-short, it can be any expression (other than a query or subquery or another set 
-function) which evaluates to a Column, as long as that Column doesn't have a 
-<data type> of ``BLOB``, ``CLOB`` or ``NCLOB``. Each <general set function> 
-operates on the entire collection of non-null values in its Column argument -- 
-grouping rules apply because grouping is implied -- and can optionally be 
-qualified with either ``DISTINCT`` or ``ALL``. If you specify ``DISTINCT``, 
-your DBMS will eliminate any duplicate values from the Column before applying 
-the set function. If you specify ``ALL``, your DBMS will apply the set function 
-to every non-null value in the Column. The default is ``ALL``. When a set 
-function eliminates ``NULL``\s, your DBMS will return the ``SQLSTATE warning 
-01003 "warning-null value eliminated in set function."`` 
+The Column expression that follows a <general set function> can be a <Column
+reference>, a <literal>, a scalar function or an arithmetic expression -- in
+short, it can be any expression (other than a query or subquery or another set
+function) which evaluates to a Column, as long as that Column doesn't have a
+<data type> of ``BLOB``, ``CLOB`` or ``NCLOB``. Each <general set function>
+operates on the entire collection of non-null values in its Column argument --
+grouping rules apply because grouping is implied -- and can optionally be
+qualified with either ``DISTINCT`` or ``ALL``. If you specify ``DISTINCT``,
+your DBMS will eliminate any duplicate values from the Column before applying
+the set function. If you specify ``ALL``, your DBMS will apply the set function
+to every non-null value in the Column. The default is ``ALL``. When a set
+function eliminates ``NULL``\s, your DBMS will return the ``SQLSTATE warning
+01003 "warning-null value eliminated in set function."``
 
-Here's an example Table; we'll use it for the explanations of the set functions 
-that follow: 
+Here's an example Table; we'll use it for the explanations of the set functions
+that follow:
 
 +--------------+
 | ``TABLE_1``  |
@@ -653,41 +655,41 @@ that follow:
 | ``NULL``     |
 +--------------+
 
-The ``COUNT`` function has two forms: it can have an asterisk as an argument 
+The ``COUNT`` function has two forms: it can have an asterisk as an argument
 or a Column expression as an argument. It returns an integer.
 
-* ``COUNT(*)`` returns the number of rows in the argument Table, rather than the 
-  number of values in any particular Column, so this SQL statement returns 
-  ``6``: 
+* ``COUNT(*)`` returns the number of rows in the argument Table, rather than the
+  number of values in any particular Column, so this SQL statement returns
+  ``6``:
 
   ::
 
       SELECT COUNT(*) FROM Table_1
 
-* ``COUNT(Column)`` and ``COUNT(ALL Column)`` are equivalent: both return the 
-  number of non-null values in "Column", so these SQL statements both return 
-  ``5``: 
+* ``COUNT(Column)`` and ``COUNT(ALL Column)`` are equivalent: both return the
+  number of non-null values in "Column", so these SQL statements both return
+  ``5``:
 
   ::
 
       SELECT COUNT(column_1) FROM Table_1;
       SELECT COUNT(ALL column_1) FROM Table_1;
 
-* ``COUNT(DISTINCT Column)`` returns the number of unique, non-null values in 
-  "Column", so this SQL statement returns ``3``: 
+* ``COUNT(DISTINCT Column)`` returns the number of unique, non-null values in
+  "Column", so this SQL statement returns ``3``:
 
   ::
 
       SELECT COUNT(DISTINCT column_1) FROM Table_1;
 
-The ``MAX`` function returns the maximum value and can't be used with Columns 
-that have a <data type> of ``ROW``, ``REF``, ``BLOB``, ``CLOB`` or ``NCLOB``, 
-or with a UDT. The <data type> and size of the result will be the same as the 
-<data type> and size of the expression itself. 
+The ``MAX`` function returns the maximum value and can't be used with Columns
+that have a <data type> of ``ROW``, ``REF``, ``BLOB``, ``CLOB`` or ``NCLOB``,
+or with a UDT. The <data type> and size of the result will be the same as the
+<data type> and size of the expression itself.
 
-* ``MAX(Column)``, ``MAX(ALL Column)`` and ``MAX(DISTINCT Column)`` are 
-  equivalent: all three return the largest of the non-null values in "Column", 
-  so these SQL statements all return ``30``: 
+* ``MAX(Column)``, ``MAX(ALL Column)`` and ``MAX(DISTINCT Column)`` are
+  equivalent: all three return the largest of the non-null values in "Column",
+  so these SQL statements all return ``30``:
 
   ::
 
@@ -697,14 +699,14 @@ or with a UDT. The <data type> and size of the result will be the same as the
 
 It's rare to find explicit ``ALL`` or ``DISTINCT`` with ``MAX``.
 
-The ``MIN`` function returns the minimum value and can't be used with Columns 
-that have a <data type> of ``ROW``, ``REF``, ``BLOB``, ``CLOB`` or ``NCLOB``, 
-or with a UDT. The <data type> and size of the result will be the same as the 
-<data type> and size of the expression itself. 
+The ``MIN`` function returns the minimum value and can't be used with Columns
+that have a <data type> of ``ROW``, ``REF``, ``BLOB``, ``CLOB`` or ``NCLOB``,
+or with a UDT. The <data type> and size of the result will be the same as the
+<data type> and size of the expression itself.
 
-* ``MIN(Column)``, ``MIN(ALL Column)`` and ``MIN(DISTINCT Column)`` are 
-  equivalent: all three return the smallest of the non-null values in "Column", 
-  so these SQL statements all return ``10``: 
+* ``MIN(Column)``, ``MIN(ALL Column)`` and ``MIN(DISTINCT Column)`` are
+  equivalent: all three return the smallest of the non-null values in "Column",
+  so these SQL statements all return ``10``:
 
   ::
 
@@ -712,25 +714,25 @@ or with a UDT. The <data type> and size of the result will be the same as the
       SELECT MIN(ALL column_1) FROM Table_1;
       SELECT MIN(DISTINCT column_1) FROM Table_1;
 
-As with ``MAX``, it's rare to find explicit ``ALL`` or ``DISTINCT`` with 
+As with ``MAX``, it's rare to find explicit ``ALL`` or ``DISTINCT`` with
 ``MIN``.
 
-The ``SUM`` function returns a total and can't be used with Columns that have a 
-<data type> of ``ROW``, ``REF``, ``BLOB``, ``CLOB`` or ``NCLOB``, or with a 
-UDT. The <data type> of the expression must be numeric or ``INTERVAL``; in the 
-first case, the result <data type> will also be numeric, with the same scale as 
-the expression, but (possibly) a larger precision. That's necessary -- consider 
-what would happen if you had a ``DECIMAL(2)`` Column containing two values: 
-``51``, ``51``. The result of ``SUM`` would be ``102``, which is 
-``DECIMAL(3)``, so the DBMS has to be able to increase the precision for the 
-result. If you're not sure that your DBMS will give ``SUM`` a great enough 
-precision, increase the precision of the expression using a ``CAST`` function. 
-In the second case, the result <data type> will be ``INTERVAL`` with the same 
-precision as the expression. 
+The ``SUM`` function returns a total and can't be used with Columns that have a
+<data type> of ``ROW``, ``REF``, ``BLOB``, ``CLOB`` or ``NCLOB``, or with a
+UDT. The <data type> of the expression must be numeric or ``INTERVAL``; in the
+first case, the result <data type> will also be numeric, with the same scale as
+the expression, but (possibly) a larger precision. That's necessary -- consider
+what would happen if you had a ``DECIMAL(2)`` Column containing two values:
+``51``, ``51``. The result of ``SUM`` would be ``102``, which is
+``DECIMAL(3)``, so the DBMS has to be able to increase the precision for the
+result. If you're not sure that your DBMS will give ``SUM`` a great enough
+precision, increase the precision of the expression using a ``CAST`` function.
+In the second case, the result <data type> will be ``INTERVAL`` with the same
+precision as the expression.
 
-* ``SUM(Column)`` and ``SUM(ALL Column)`` are equivalent: both return the total 
-  of the non-null values in "Column", so these SQL statements both return 
-  ``90``: 
+* ``SUM(Column)`` and ``SUM(ALL Column)`` are equivalent: both return the total
+  of the non-null values in "Column", so these SQL statements both return
+  ``90``:
 
   ::
 
@@ -744,39 +746,39 @@ precision as the expression.
 
       SELECT SUM(DISTINCT column_1) FROM Table_1;
 
-The ``AVG`` function returns an average and can't be used with Columns that 
-have a <data type> of ``ROW``, ``REF``, ``BLOB``, ``CLOB`` or ``NCLOB``, or 
-with a UDT. The <data type> of the expression must be numeric or ``INTERVAL``; 
-in the first case, the result <data type> will also be numeric, with scale and 
-precision equal to or greater than the expression's scale and precision (most 
-DBMSs increase the scale but leave the precision alone). In the second case, 
-the result <data type> will be ``INTERVAL`` with the same precision as the 
-expression. 
+The ``AVG`` function returns an average and can't be used with Columns that
+have a <data type> of ``ROW``, ``REF``, ``BLOB``, ``CLOB`` or ``NCLOB``, or
+with a UDT. The <data type> of the expression must be numeric or ``INTERVAL``;
+in the first case, the result <data type> will also be numeric, with scale and
+precision equal to or greater than the expression's scale and precision (most
+DBMSs increase the scale but leave the precision alone). In the second case,
+the result <data type> will be ``INTERVAL`` with the same precision as the
+expression.
 
-* ``AVG(Column)`` and ``AVG(ALL Column)`` are equivalent: both return the 
-  average of the non-null values in "Column", so these SQL statements both 
-  return ``18``: 
+* ``AVG(Column)`` and ``AVG(ALL Column)`` are equivalent: both return the
+  average of the non-null values in "Column", so these SQL statements both
+  return ``18``:
 
   ::
 
       SELECT AVG(column_1) FROM Table_1;
       SELECT AVG(ALL column_1) FROM Table_1;
 
-* ``AVG(DISTINCT Column)`` returns the average of the unique, non-null 
+* ``AVG(DISTINCT Column)`` returns the average of the unique, non-null
   values in "Column", so this SQL statement returns ``20``:
 
   ::
 
       SELECT AVG(DISTINCT column_1) FROM Table_1;
 
-The ``EVERY`` function, new to SQL with SQL3, returns a truth value and can 
+The ``EVERY`` function, new to SQL with SQL3, returns a truth value and can
 only be used with Columns that have a <data type> of ``BOOLEAN``.
 
-* ``EVERY(Column)``, ``EVERY(ALL Column)`` and ``EVERY(DISTINCT Column)`` are 
-  equivalent: all three return ``FALSE`` if any of the values in "Column" are 
-  ``FALSE`` and all three return ``TRUE`` if no value in "Column" is ``FALSE``. 
-  For these two Tables: 
-  
+* ``EVERY(Column)``, ``EVERY(ALL Column)`` and ``EVERY(DISTINCT Column)`` are
+  equivalent: all three return ``FALSE`` if any of the values in "Column" are
+  ``FALSE`` and all three return ``TRUE`` if no value in "Column" is ``FALSE``.
+  For these two Tables:
+
   +--------------+----------------+
   | ``TABLE_1``  | ``TABLE_2``    |
   +==============+================+
@@ -792,32 +794,32 @@ only be used with Columns that have a <data type> of ``BOOLEAN``.
   +--------------+----------------+
   | ``UNKNOWN``  |                |
   +--------------+----------------+
-  
+
   these SQL statements all return ``FALSE``:
-  
+
   ::
-  
+
       SELECT EVERY(column_1) FROM Table_1;
       SELECT EVERY(ALL column_1) FROM Table_1;
       SELECT EVERY(DISTINCT column_1) FROM Table_1;
-  
+
   And these SQL statements all return ``TRUE``:
-  
+
   ::
-  
+
       SELECT EVERY(column_1) FROM Table_2;
       SELECT EVERY(ALL column_1) FROM Table_2;
       SELECT EVERY(DISTINCT column_1) FROM Table_2;
 
-The ``ANY`` function (and its, synonym, ``SOME``), new to SQL with SQL3, 
-returns a truth value and can only be used with Columns that have a <data type> 
-of ``BOOLEAN``. 
+The ``ANY`` function (and its, synonym, ``SOME``), new to SQL with SQL3,
+returns a truth value and can only be used with Columns that have a <data type>
+of ``BOOLEAN``.
 
-* ``ANY(Column)``, ``ANY(ALL Column)`` and ``ANY(DISTINCT Column)`` are 
-  equivalent: all three return ``TRUE`` if any of the values in "Column" are 
-  ``TRUE`` and all three return ``FALSE`` if no value in "Column" is ``TRUE``. 
-  For these two Tables: 
-  
+* ``ANY(Column)``, ``ANY(ALL Column)`` and ``ANY(DISTINCT Column)`` are
+  equivalent: all three return ``TRUE`` if any of the values in "Column" are
+  ``TRUE`` and all three return ``FALSE`` if no value in "Column" is ``TRUE``.
+  For these two Tables:
+
   +--------------+----------------+
   | ``TABLE_1``  | ``TABLE_2```   |
   +==============+================+
@@ -833,66 +835,66 @@ of ``BOOLEAN``.
   +--------------+----------------+
   | ``UNKNOWN``  |                |
   +--------------+----------------+
-  
+
   these SQL statements all return ``TRUE``:
-  
+
   ::
-  
+
       SELECT ANY(column_1) FROM Table_1;
       SELECT ANY(ALL column_1) FROM Table_1;
       SELECT ANY(DISTINCT column_1) FROM Table_1;
-  
+
   And these SQL statements all return FALSE:
-  
+
   ::
-  
+
       SELECT ANY(column_1) FROM Table_2;
       SELECT ANY(ALL column_1) FROM Table_2;
       SELECT ANY(DISTINCT column_1) FROM Table_2;
 
-The ``GROUPING`` function, new to SQL with SQL3, operates on an argument that 
-must be a <Column reference>, where the Column referred to is a grouping Column 
-for the query. You use it in conjunction with the various grouping sets options 
-of the ``GROUP BY`` clause. It returns either an integer or the value of some 
-Column -- the Standard is unclear on this point. 
+The ``GROUPING`` function, new to SQL with SQL3, operates on an argument that
+must be a <Column reference>, where the Column referred to is a grouping Column
+for the query. You use it in conjunction with the various grouping sets options
+of the ``GROUP BY`` clause. It returns either an integer or the value of some
+Column -- the Standard is unclear on this point.
 
 *DISTINCT Set Functions*
 ------------------------
 
-Since ``DISTINCT`` <set function> is usually a slow process, it's worthwhile to 
-look for ways to avoid it. With ``MIN``, ``MAX``, ``EVERY``, ``ANY`` and 
-``SOME``, ``DISTINCT`` means nothing, so there's no problem omitting it there. 
-If the Column happens to be a primary key or unique key, then ``DISTINCT`` will 
-have no effect because the values are all distinct anyway, so again, no problem 
-omitting it there. (Although a unique key Column might have a million 
-``NULL``\s in it, that won't matter because the set functions ignore ``NULL``\s 
-anyway). The only things you must be sure of, if you remove the <keyword> 
-``DISTINCT`` because the Column is primary or unique, are *(a)* that the 
-``PRIMARY KEY/UNIQUE`` Constraint is ``NOT DEFERRABLE`` and *(b)* that there is 
-no chance that the database definition will ever change. 
+Since ``DISTINCT`` <set function> is usually a slow process, it's worthwhile to
+look for ways to avoid it. With ``MIN``, ``MAX``, ``EVERY``, ``ANY`` and
+``SOME``, ``DISTINCT`` means nothing, so there's no problem omitting it there.
+If the Column happens to be a primary key or unique key, then ``DISTINCT`` will
+have no effect because the values are all distinct anyway, so again, no problem
+omitting it there. (Although a unique key Column might have a million
+``NULL``\s in it, that won't matter because the set functions ignore ``NULL``\s
+anyway). The only things you must be sure of, if you remove the <keyword>
+``DISTINCT`` because the Column is primary or unique, are *(a)* that the
+``PRIMARY KEY/UNIQUE`` Constraint is ``NOT DEFERRABLE`` and *(b)* that there is
+no chance that the database definition will ever change.
 
 .. TIP::
 
-  If you use ODBC then you should check whether your DBMS supports the 
-  ``SQLRowCount`` function for results sets; if it does, then you won't have to 
-  use ``COUNT(*)`` to find out how many rows answer a query. This is 
-  particularly a time-saver if the query contains ``DISTINCT``, since 
-  ``COUNT(DISTINCT ...)`` is a particularly slow function. 
+  If you use ODBC then you should check whether your DBMS supports the
+  ``SQLRowCount`` function for results sets; if it does, then you won't have to
+  use ``COUNT(*)`` to find out how many rows answer a query. This is
+  particularly a time-saver if the query contains ``DISTINCT``, since
+  ``COUNT(DISTINCT ...)`` is a particularly slow function.
 
 *Set Functions and the "Ignore NULLs" Policy*
 ---------------------------------------------
 
-All the set functions ignore ``NULL``\s (the ``COUNT(*)`` function looks like 
-an exception but if you think of it as a shorthand for ``COUNT(1)`` you will 
-realize that no ``NULL``\s are ever involved there). In other words, when we 
-calculate ``SUM(x)`` we are not calculating the sum of all values of ``x``, but 
-the sum of all *known* values of ``x``. This policy is the result of practical 
-experience: some early SQL DBMSs didn't ignore ``NULL``\s, but now they all do. 
+All the set functions ignore ``NULL``\s (the ``COUNT(*)`` function looks like
+an exception but if you think of it as a shorthand for ``COUNT(1)`` you will
+realize that no ``NULL``\s are ever involved there). In other words, when we
+calculate ``SUM(x)`` we are not calculating the sum of all values of ``x``, but
+the sum of all *known* values of ``x``. This policy is the result of practical
+experience: some early SQL DBMSs didn't ignore ``NULL``\s, but now they all do.
 
-Now, this is a little inconsistent, because in most arithmetic expressions that 
-involve ``NULL``, the result is ``NULL`` (e.g.: "5 + ``NULL`` yields 
-``NULL``"). This leads to a TRAP: ``SUM(a)+SUM(b)`` is not the same as 
-``SUM(a+b)``! Consider these two rows: 
+Now, this is a little inconsistent, because in most arithmetic expressions that
+involve ``NULL``, the result is ``NULL`` (e.g.: "5 + ``NULL`` yields
+``NULL``"). This leads to a TRAP: ``SUM(a)+SUM(b)`` is not the same as
+``SUM(a+b)``! Consider these two rows:
 
 +--------+-------+----------+
 |        | ``a`` | ``b``    |
@@ -902,28 +904,28 @@ involve ``NULL``, the result is ``NULL`` (e.g.: "5 + ``NULL`` yields
 | row#2  |   5   | 5        |
 +--------+-------+----------+
 
-Since the ``SUM`` of {``5,5``} is ``10``, and the ``SUM`` of {``NULL,5``} is 
-``5``, the result of ``SUM(a)+SUM(b)`` is ``15``. However, since ``(5+NULL)`` 
-is ``NULL``, and ``(5+5)`` is ``10``, and the ``SUM`` of {``NULL,10``} is 
-``10``, then ``SUM(a+b)`` is ``10``! So which answer is correct: ``15`` or 
-``10``? The cautious person would perhaps reply: both answers are wrong -- the 
-result should be ``NULL``. However, we have already posited that in the context 
-of set functions we want to ignore ``NULL``\s. In this context, the best answer 
-is the one that ignores the most ``NULL``\s -- to wit: ``15``. Therefore the 
-correct expression to use is ``SUM(a)+SUM(b)``, not ``SUM(a+b)``. A clinching 
-argument is that ``SUM(a)+SUM(b)`` involves fewer "add" operations than 
-``SUM(a+b)``, and is therefore less subject to the cumulative effects of 
-rounding. Similar considerations apply for all set functions with expressions 
-that contain ``+`` or ``-`` or ``||`` operators. 
+Since the ``SUM`` of {``5,5``} is ``10``, and the ``SUM`` of {``NULL,5``} is
+``5``, the result of ``SUM(a)+SUM(b)`` is ``15``. However, since ``(5+NULL)``
+is ``NULL``, and ``(5+5)`` is ``10``, and the ``SUM`` of {``NULL,10``} is
+``10``, then ``SUM(a+b)`` is ``10``! So which answer is correct: ``15`` or
+``10``? The cautious person would perhaps reply: both answers are wrong -- the
+result should be ``NULL``. However, we have already posited that in the context
+of set functions we want to ignore ``NULL``\s. In this context, the best answer
+is the one that ignores the most ``NULL``\s -- to wit: ``15``. Therefore the
+correct expression to use is ``SUM(a)+SUM(b)``, not ``SUM(a+b)``. A clinching
+argument is that ``SUM(a)+SUM(b)`` involves fewer "add" operations than
+``SUM(a+b)``, and is therefore less subject to the cumulative effects of
+rounding. Similar considerations apply for all set functions with expressions
+that contain ``+`` or ``-`` or ``||`` operators.
 
-Because of the "ignore ``NULL``\s" policy, it should be rare for a set function 
-to return ``NULL``. The only cases are: for ``MIN`` or ``MAX`` or ``SUM`` or 
-``AVG``, if every one of the Column values is ``NULL``, or if the ``SELECT`` 
-returns no rows at all, the function returns ``NULL`` (so in fact these 
-functions could return ``NULL`` even if the Column is defined as ``NOT NULL``, 
-yielding another case where you shouldn't be fooled by a ``NOT NULL`` 
-Constraint definition.) The ``COUNT`` function can never return ``NULL`` -- if 
-there are no rows returned, then the count is, naturally enough, zero. 
+Because of the "ignore ``NULL``\s" policy, it should be rare for a set function
+to return ``NULL``. The only cases are: for ``MIN`` or ``MAX`` or ``SUM`` or
+``AVG``, if every one of the Column values is ``NULL``, or if the ``SELECT``
+returns no rows at all, the function returns ``NULL`` (so in fact these
+functions could return ``NULL`` even if the Column is defined as ``NOT NULL``,
+yielding another case where you shouldn't be fooled by a ``NOT NULL``
+Constraint definition.) The ``COUNT`` function can never return ``NULL`` -- if
+there are no rows returned, then the count is, naturally enough, zero.
 
 *Set Functions in Subqueries*
 -----------------------------
@@ -950,7 +952,7 @@ We'll give just one example of a restriction (from SQL-92) -- if the set
 function's argument is an "outer reference" Column (i.e.: the name of a Column
 in the outer enclosing query), then that must be the only <Column reference>
 within that argument and the set function has to appear either in a select
-list or within a subquery that belongs to a ``HAVING`` clause. For example, 
+list or within a subquery that belongs to a ``HAVING`` clause. For example,
 this complex query uses illegal syntax:
 
 ::
@@ -968,7 +970,7 @@ subqueries.
 -------------------------------
 
 Here's some examples of set functions, using the sample database we defined in
-our chapter on "Simple Search Conditions". To find the total number of 
+our chapter on "Simple Search Conditions". To find the total number of
 employees with payroll records (retrieve the number of records in a Table):
 
 ::
@@ -1020,7 +1022,7 @@ The result is:
 | 5             |
 +---------------+
 
-The ``DISTINCT`` option eliminates duplicates before a set function is 
+The ``DISTINCT`` option eliminates duplicates before a set function is
 processed.
 
 To find the sum of the pay rates by location (group a Table into like values
@@ -1078,70 +1080,70 @@ the ``FROM`` clause, and when counting, always use ``COUNT(*)``: don't use
 HAVING Clause
 =============
 
-What departments have four employees? In which branches is the smallest book's 
-size less than 40mm? Those are two questions that require comparison of an 
-absolute value with a set function, and thus represent the commonest situations 
-where we'd find it useful to bring in a ``HAVING`` clause. The ``HAVING`` 
-clause is an optional portion of the ``SELECT`` statement. It, too, defines a 
-grouped Table. The required syntax for the ``HAVING`` clause is: 
+What departments have four employees? In which branches is the smallest book's
+size less than 40mm? Those are two questions that require comparison of an
+absolute value with a set function, and thus represent the commonest situations
+where we'd find it useful to bring in a ``HAVING`` clause. The ``HAVING``
+clause is an optional portion of the ``SELECT`` statement. It, too, defines a
+grouped Table. The required syntax for the ``HAVING`` clause is:
 
 ::
 
     HAVING <search condition>
 
-The ``HAVING`` clause defines a grouped Table that contains only those groups 
-for which its search condition is ``TRUE`` and usually follows a ``GROUP BY`` 
-clause. ``HAVING`` operates on the interim result produced by the evaluation of 
-the ``SELECT`` statement at that stage: 
+The ``HAVING`` clause defines a grouped Table that contains only those groups
+for which its search condition is ``TRUE`` and usually follows a ``GROUP BY``
+clause. ``HAVING`` operates on the interim result produced by the evaluation of
+the ``SELECT`` statement at that stage:
 
-* If the statement is "``SELECT ... FROM ... HAVING ...``", ``HAVING`` operates 
-  on the entire ``FROM`` Table, treating it as a single group. (``GROUP BY`` is 
-  implied, but the result has no grouping Columns.) 
+* If the statement is "``SELECT ... FROM ... HAVING ...``", ``HAVING`` operates
+  on the entire ``FROM`` Table, treating it as a single group. (``GROUP BY`` is
+  implied, but the result has no grouping Columns.)
 
-* If the statement is "``SELECT ... FROM ... WHERE ... HAVING ...``", 
-  ``HAVING`` operates on the rows of the ``FROM`` Table that are ``TRUE`` for 
-  the ``WHERE`` conditions, again, treating the interim result as a single 
-  group. 
+* If the statement is "``SELECT ... FROM ... WHERE ... HAVING ...``",
+  ``HAVING`` operates on the rows of the ``FROM`` Table that are ``TRUE`` for
+  the ``WHERE`` conditions, again, treating the interim result as a single
+  group.
 
-* If the statement is "``SELECT ... FROM ... WHERE ... GROUP BY ... HAVING 
-  ...``", ``HAVING`` operates on the interim groups returned by ``GROUP BY``. 
+* If the statement is "``SELECT ... FROM ... WHERE ... GROUP BY ... HAVING
+  ...``", ``HAVING`` operates on the interim groups returned by ``GROUP BY``.
 
-The ``HAVING`` clause's search condition may include ``AND``\s, ``OR``\s, 
-relational operators, scalar and arithmetic expressions, and so on -- much like 
-a ``WHERE`` clause's search condition. The difference between a ``WHERE`` 
-condition and a ``HAVING`` condition is implied by the clause order. The DBMS 
-evaluates ``WHERE`` *before* it does the grouping; it evaluates ``HAVING`` 
-*after* it does the grouping -- thus, ``WHERE`` filters rows and ``HAVING`` 
-filters groups. It's usually more efficient to filter before grouping (because 
-then there will be fewer rows to group), so it's best to put most simple 
-conditions in the ``WHERE`` clause and use ``HAVING`` only for these 
-situations: 
+The ``HAVING`` clause's search condition may include ``AND``\s, ``OR``\s,
+relational operators, scalar and arithmetic expressions, and so on -- much like
+a ``WHERE`` clause's search condition. The difference between a ``WHERE``
+condition and a ``HAVING`` condition is implied by the clause order. The DBMS
+evaluates ``WHERE`` *before* it does the grouping; it evaluates ``HAVING``
+*after* it does the grouping -- thus, ``WHERE`` filters rows and ``HAVING``
+filters groups. It's usually more efficient to filter before grouping (because
+then there will be fewer rows to group), so it's best to put most simple
+conditions in the ``WHERE`` clause and use ``HAVING`` only for these
+situations:
 
-* If one of the condition's operands is a set function. Since a set function is 
-  not evaluated until you group, it is impossible to use one in a ``WHERE`` 
-  clause. 
+* If one of the condition's operands is a set function. Since a set function is
+  not evaluated until you group, it is impossible to use one in a ``WHERE``
+  clause.
 
-* If there is a quirk in a particular DBMS's optimizer. For one DBMS, ``GROUP 
-  BY a HAVING a = 7`` works well because (since the grouping Column and the 
-  condition Column are the same) the two clauses can be evaluated 
-  simultaneously. For most DBMSs, putting a condition in the ``HAVING`` clause 
-  is a hint that you want to avoid using any indexes. 
+* If there is a quirk in a particular DBMS's optimizer. For one DBMS, ``GROUP
+  BY a HAVING a = 7`` works well because (since the grouping Column and the
+  condition Column are the same) the two clauses can be evaluated
+  simultaneously. For most DBMSs, putting a condition in the ``HAVING`` clause
+  is a hint that you want to avoid using any indexes.
 
-Operands in the ``HAVING`` clause are subject to the same restrictions as in 
+Operands in the ``HAVING`` clause are subject to the same restrictions as in
 the select list:
 
 * Column expressions in both must be single-valued per group.
 
 * Column references must be unambiguous.
 
-* If a ``SELECT`` statement contains ``HAVING`` without a preceding ``GROUP 
-  BY`` clause, the select list can't include any references to Columns 
-  belonging to a Table named in the ``FROM`` clause unless those references are 
-  used with a set function. 
+* If a ``SELECT`` statement contains ``HAVING`` without a preceding ``GROUP
+  BY`` clause, the select list can't include any references to Columns
+  belonging to a Table named in the ``FROM`` clause unless those references are
+  used with a set function.
 
-* If ``HAVING`` includes a subquery, it can't include outer Column references 
-  unless those references are to grouping Columns or are used with a set 
-  function. 
+* If ``HAVING`` includes a subquery, it can't include outer Column references
+  unless those references are to grouping Columns or are used with a set
+  function.
 
 Let's look closely at an SQL statement which contains a ``HAVING`` clause:
 
@@ -1153,9 +1155,9 @@ Let's look closely at an SQL statement which contains a ``HAVING`` clause:
    GROUP BY column_1
    HAVING   COUNT(column_1) >= 5;
 
-In this SQL statement, the expression ``COUNT(column_2)`` is okay because, 
-although ``COLUMN_2`` is not a grouping Column, it appears within a set 
-function. Suppose that ``TABLE_1`` looks like this: 
+In this SQL statement, the expression ``COUNT(column_2)`` is okay because,
+although ``COLUMN_2`` is not a grouping Column, it appears within a set
+function. Suppose that ``TABLE_1`` looks like this:
 
 +-----------------------------+
 | ``TABLE_1``                 |
@@ -1183,10 +1185,10 @@ function. Suppose that ``TABLE_1`` looks like this:
 | 2            | 9            |
 +--------------+--------------+
 
-``TABLE_1`` has 3 rows where ``COLUMN_1`` is 1 and 7 rows where ``COLUMN_1`` is 
-2. The ``COLUMN_1 = 1`` group does not meet the ``HAVING`` clause's condition 
--- the smallest acceptable count is 5. However, the ``COLUMN_1 = 2`` group does 
-meet ``HAVING``'s condition, and so the result of our SQL statement is: 
+``TABLE_1`` has 3 rows where ``COLUMN_1`` is 1 and 7 rows where ``COLUMN_1`` is
+2. The ``COLUMN_1 = 1`` group does not meet the ``HAVING`` clause's condition
+-- the smallest acceptable count is 5. However, the ``COLUMN_1 = 2`` group does
+meet ``HAVING``'s condition, and so the result of our SQL statement is:
 
 +--------------+--------------+
 | ``COLUMN_1`` | ``COLUMN_2`` |
@@ -1206,10 +1208,10 @@ Here is another way to get the same result, without using a ``HAVING`` clause:
           GROUP BY column_1)
    WHERE  c_count >=5;
 
-It is always possible to eliminate a ``HAVING`` clause and use a query 
-expression in the ``FROM`` clause instead. But most programmers prefer to stick 
-with ``HAVING`` because it is the traditional and familiar tool for solving 
-this sort of problem. 
+It is always possible to eliminate a ``HAVING`` clause and use a query
+expression in the ``FROM`` clause instead. But most programmers prefer to stick
+with ``HAVING`` because it is the traditional and familiar tool for solving
+this sort of problem.
 
 *HAVING without GROUP BY*
 -------------------------
@@ -1222,9 +1224,9 @@ display how many ``a``\'s there are":
     SELECT COUNT(a) FROM Somethings
     HAVING COUNT(a) > 5;
 
-As is usual, because there is a set function in the ``SELECT`` statement, there 
-is an implied ``GROUP BY ()``. Therefore grouping rules apply: the select list 
-in such an SQL statement may contain only single-valued Columns. 
+As is usual, because there is a set function in the ``SELECT`` statement, there
+is an implied ``GROUP BY ()``. Therefore grouping rules apply: the select list
+in such an SQL statement may contain only single-valued Columns.
 
 *Retrieval Using Grouping*
 --------------------------
@@ -1262,9 +1264,9 @@ operation -- the result is a grouped View. Here's an example:
       FROM     Employees
       GROUP BY department_id;
 
-Now, whoever uses the ``EMPLOYEE_GROUPS`` View will see an ordinary Table with 
-two Columns: ``DEPARTMENT_ID`` and ``COUNT_EMPLOYEE_ID``. But the user's view 
-window won't be totally transparent. 
+Now, whoever uses the ``EMPLOYEE_GROUPS`` View will see an ordinary Table with
+two Columns: ``DEPARTMENT_ID`` and ``COUNT_EMPLOYEE_ID``. But the user's view
+window won't be totally transparent.
 
 **Problem 1**
 
@@ -1284,10 +1286,10 @@ this query into a query on the underlying Base table. The best transform is:
    WHERE    department_id = 'XX'
    GROUP BY department_id HAVING COUNT(employee_id) = 7;
 
-Observe that one, and only one, of the conditions of the original ``WHERE`` 
-clause has been split out and put in a new ``HAVING`` clause. Based on timings, 
-we believe that some DBMSs don't do this. We believe they put both conditions 
-in the HAVING clause. That's much less efficient. 
+Observe that one, and only one, of the conditions of the original ``WHERE``
+clause has been split out and put in a new ``HAVING`` clause. Based on timings,
+we believe that some DBMSs don't do this. We believe they put both conditions
+in the HAVING clause. That's much less efficient.
 
 **Problem 2**
 
@@ -1304,18 +1306,18 @@ Your DBMS might attempt to transform this into:
    SELECT   department_id, MAX(COUNT(employee_id)) FROM Employees
    GROUP BY department_id;
 
-that is, into a sensible question along the lines of "which department has most 
-employees". But ``MAX(COUNT(employee_id))`` is an illegal expression (you can't 
-nest set functions) and the result will be some error message defined by your 
-DBMS. This is legal: the SQL Standard doesn't demand that a DBMS should handle 
-groups within groups, or set functions within set functions. 
+that is, into a sensible question along the lines of "which department has most
+employees". But ``MAX(COUNT(employee_id))`` is an illegal expression (you can't
+nest set functions) and the result will be some error message defined by your
+DBMS. This is legal: the SQL Standard doesn't demand that a DBMS should handle
+groups within groups, or set functions within set functions.
 
 .. TIP::
 
-  That's why we named this View and its Column ``EMPLOYEE_GROUPS`` and 
-  ``COUNT_EMPLOYEE_ID`` -- the names tip off the user that a ``COUNT`` in a 
-  grouped View is involved. That lessens the confusion if the DBMS doesn't 
-  generate a clear error message. 
+  That's why we named this View and its Column ``EMPLOYEE_GROUPS`` and
+  ``COUNT_EMPLOYEE_ID`` -- the names tip off the user that a ``COUNT`` in a
+  grouped View is involved. That lessens the confusion if the DBMS doesn't
+  generate a clear error message.
 
 Dialects
 ========
@@ -1330,13 +1332,13 @@ The older (pre-1992) DBMSs had these restrictions on grouping:
 * Groups within Views and subqueries worked only under a full moon (or
   some undefined equivalent!).
 
-Nowadays, SQL DBMSs support grouping, set functions and ``HAVING`` clauses, in 
-a manner pretty much as we have described here, except for the new SQL3 
-features. 
+Nowadays, SQL DBMSs support grouping, set functions and ``HAVING`` clauses, in
+a manner pretty much as we have described here, except for the new SQL3
+features.
 
-It's also fairly easy to find DBMSs which will accept non-standard syntax. 
-Sybase ignores the Single-Value Rule so you can use any Column you like in the 
-select list. Oracle includes basic statistical-analysis set functions: STDDEV 
-(standard deviation) and VARIANCE. Several DBMSs allow "``GROUP BY`` 
-expression" or even "``GROUP BY`` ordinal position, as if the ``GROUP BY`` 
-clause is analogous to the ``ORDER BY`` clause. 
+It's also fairly easy to find DBMSs which will accept non-standard syntax.
+Sybase ignores the Single-Value Rule so you can use any Column you like in the
+select list. Oracle includes basic statistical-analysis set functions: STDDEV
+(standard deviation) and VARIANCE. Several DBMSs allow "``GROUP BY``
+expression" or even "``GROUP BY`` ordinal position, as if the ``GROUP BY``
+clause is analogous to the ``ORDER BY`` clause.

--- a/docs/chapters/34.rst
+++ b/docs/chapters/34.rst
@@ -4,9 +4,11 @@
 Chapter 34 -- Sorting Search Results
 ====================================
 
-In SQL, you can only sort search results returned by a Cursor. However, when 
-you're using Direct SQL, you're always using an implied Cursor, and so we'll 
-describe the ``ORDER BY`` clause now. 
+.. include:: ../_include/note.rst
+
+In SQL, you can only sort search results returned by a Cursor. However, when
+you're using Direct SQL, you're always using an implied Cursor, and so we'll
+describe the ``ORDER BY`` clause now.
 
 .. rubric:: Table of Contents
 
@@ -30,22 +32,22 @@ The required syntax for the ``ORDER BY`` clause is:
 
              <sort key> ::= scalar_expression
 
-An ``ORDER BY`` clause may optionally appear after a <query expression>: it 
-specifies the order rows should have when returned from that query (if you omit 
-the clause, your DBMS will return the rows in some random order). The query in 
-question may, of course, be a ``VALUES`` statement, a ``TABLE`` statement or 
-(most commonly) a ``SELECT`` statement. (For now, we are ignoring the 
-possibility that the SQL statement is ``DECLARE CURSOR``, since that is 
-strictly a matter for "SQL in Host Programs", a later chapter.) 
+An ``ORDER BY`` clause may optionally appear after a <query expression>: it
+specifies the order rows should have when returned from that query (if you omit
+the clause, your DBMS will return the rows in some random order). The query in
+question may, of course, be a ``VALUES`` statement, a ``TABLE`` statement or
+(most commonly) a ``SELECT`` statement. (For now, we are ignoring the
+possibility that the SQL statement is ``DECLARE CURSOR``, since that is
+strictly a matter for "SQL in Host Programs", a later chapter.)
 
-The ``ORDER BY`` clause provides your DBMS with a list of items to sort, and 
-the order in which to sort them: either ascending order (``ASC``, the default) 
-or descending order (``DESC``). It must follow a <query expression> because it 
-operates on the final Table that results from the evaluation of the query; it 
-cannot operate on any interim result Tables at all. The <sort key> you specify 
-can be any expression that evaluates to a single value that identifies a Column 
-of the final result Table -- this is almost always a <Column name>. Here's a 
-simple example: 
+The ``ORDER BY`` clause provides your DBMS with a list of items to sort, and
+the order in which to sort them: either ascending order (``ASC``, the default)
+or descending order (``DESC``). It must follow a <query expression> because it
+operates on the final Table that results from the evaluation of the query; it
+cannot operate on any interim result Tables at all. The <sort key> you specify
+can be any expression that evaluates to a single value that identifies a Column
+of the final result Table -- this is almost always a <Column name>. Here's a
+simple example:
 
 ::
 
@@ -53,7 +55,7 @@ simple example:
    FROM     Table_1
    ORDER BY column_1;
 
-This SQL statement retrieves all ``COLUMN_1`` values from ``TABLE_1``, 
+This SQL statement retrieves all ``COLUMN_1`` values from ``TABLE_1``,
 returning them in ascending order. This SQL statement does exactly the same:
 
 ::
@@ -62,7 +64,7 @@ returning them in ascending order. This SQL statement does exactly the same:
    FROM     Table_1
    ORDER BY column_1 ASC;
 
-This SQL statement also retrieves all ``COLUMN_1`` values from ``TABLE_1`` 
+This SQL statement also retrieves all ``COLUMN_1`` values from ``TABLE_1``
 -- but returns them in descending order:
 
 ::
@@ -71,14 +73,14 @@ This SQL statement also retrieves all ``COLUMN_1`` values from ``TABLE_1``
    FROM     Table_1
    ORDER BY column_1 DESC;
 
-The optional sort <keyword>s ``ASC`` and ``DESC`` stand respectively for 
-"ascending order" and "descending order". Some examples of ascending order are 
-{``1,2,3``} and {``'A','B','C'``}; examples of descending order are {``3,2,1``} 
-and {``'C','B','A'``}. If you omit the sort <keyword>, it defaults to ``ASC``. 
+The optional sort <keyword>s ``ASC`` and ``DESC`` stand respectively for
+"ascending order" and "descending order". Some examples of ascending order are
+{``1,2,3``} and {``'A','B','C'``}; examples of descending order are {``3,2,1``}
+and {``'C','B','A'``}. If you omit the sort <keyword>, it defaults to ``ASC``.
 
-Note that, because ``ORDER BY`` may operate only on a final result, you can't 
-put it in a subquery or before a set function -- that is, these two SQL 
-statements are illegal: 
+Note that, because ``ORDER BY`` may operate only on a final result, you can't
+put it in a subquery or before a set function -- that is, these two SQL
+statements are illegal:
 
 ::
 
@@ -96,15 +98,15 @@ statements are illegal:
    SELECT   column_1
    FROM    Table_2;
 
-An ``ORDER BY`` <sort key> is normally the name of a Column in the query's 
-select list. It cannot be a <literal> -- the SQL-92 option of putting an 
-integer after ``ORDER BY``, to identify a Column by its ordinal position in the 
-result Table, is not allowed in SQL3. The <sort key> can, however, be an 
-expression that evaluates to a Column of the result Table (even if that Column 
-isn't in the select list). Since this is the case, it is useful to remember 
-that such Column expressions may be given explicit names using "[``AS`` <Column 
-name>]" clauses. The "[``AS`` <Column name>]" clause can also be useful for 
-"unioned" ``SELECT``\s. For example: 
+An ``ORDER BY`` <sort key> is normally the name of a Column in the query's
+select list. It cannot be a <literal> -- the SQL-92 option of putting an
+integer after ``ORDER BY``, to identify a Column by its ordinal position in the
+result Table, is not allowed in SQL3. The <sort key> can, however, be an
+expression that evaluates to a Column of the result Table (even if that Column
+isn't in the select list). Since this is the case, it is useful to remember
+that such Column expressions may be given explicit names using "[``AS`` <Column
+name>]" clauses. The "[``AS`` <Column name>]" clause can also be useful for
+"unioned" ``SELECT``\s. For example:
 
 ::
 
@@ -115,15 +117,15 @@ name>]" clauses. The "[``AS`` <Column name>]" clause can also be useful for
   FROM     Table_2
   ORDER BY column_1_or_column_2;
 
-Whatever way you identify the result Columns you want to sort though, they may 
-not have a <data type> of ``BLOB``, ``CLOB`` or ``NCLOB``. For a <sort key> 
-with a character string <data type>, you may also specify an explicit Collation 
-for your DBMS to use when sorting that Column's values. 
+Whatever way you identify the result Columns you want to sort though, they may
+not have a <data type> of ``BLOB``, ``CLOB`` or ``NCLOB``. For a <sort key>
+with a character string <data type>, you may also specify an explicit Collation
+for your DBMS to use when sorting that Column's values.
 
-If ``ORDER BY`` contains multiple <sort key>s, the primary ordering is by the 
-first <sort key>, the secondary ordering is by the second <sort key> and so on 
--- this is called *major-to-minor ordering*. For example, here's an extract 
-from a telephone book: 
+If ``ORDER BY`` contains multiple <sort key>s, the primary ordering is by the
+first <sort key>, the secondary ordering is by the second <sort key> and so on
+-- this is called *major-to-minor ordering*. For example, here's an extract
+from a telephone book:
 
 +----------+---------------+----------+
 | Dunbar L | 11407 141 Ave | 456-4478 |
@@ -137,9 +139,9 @@ from a telephone book:
 | Duncan L | 9110 150 St   | 486-2075 |
 +----------+---------------+----------+
 
-As one would expect in a telephone book, the entries are sorted *(a)* by 
-surname and then *(b)* by first initial. In SQL, this order would be 
-accomplished with a ``SELECT`` statement like this one: 
+As one would expect in a telephone book, the entries are sorted *(a)* by
+surname and then *(b)* by first initial. In SQL, this order would be
+accomplished with a ``SELECT`` statement like this one:
 
 ::
 
@@ -150,42 +152,42 @@ accomplished with a ``SELECT`` statement like this one:
 *Sorting NULLs*
 ---------------
 
-It isn't usually possible to make meaningful comparisons with null values, so 
-the following comparison rules are applicable only in the context of an ``ORDER 
+It isn't usually possible to make meaningful comparisons with null values, so
+the following comparison rules are applicable only in the context of an ``ORDER
 BY`` clause:
 
 * A ``NULL`` is "equal" to a ``NULL`` for sorting purposes.
 
-* [NON-PORTABLE] Either a ``NULL`` is greater than all non-null values or a 
-  ``NULL`` is less than all non-null values -- it's non-standard because the 
-  SQL Standard requires implementors to define whether ``NULL``\s sort high or 
-  low. Most vendors say "``NULL``\s are greater than all non-null values" -- in 
-  this case, a Table with these rows: {``7,5,-1,NULL``} will end up in this 
-  order: {``-1,5,7,NULL``} if you ask for an ascending sort. 
+* [NON-PORTABLE] Either a ``NULL`` is greater than all non-null values or a
+  ``NULL`` is less than all non-null values -- it's non-standard because the
+  SQL Standard requires implementors to define whether ``NULL``\s sort high or
+  low. Most vendors say "``NULL``\s are greater than all non-null values" -- in
+  this case, a Table with these rows: {``7,5,-1,NULL``} will end up in this
+  order: {``-1,5,7,NULL``} if you ask for an ascending sort.
 
-[OCELOT Implementation] The OCELOT DBMS that comes with this book sorts 
-``NULL``\s low: a ``NULL`` is less than all non-null values. 
+[OCELOT Implementation] The OCELOT DBMS that comes with this book sorts
+``NULL``\s low: a ``NULL`` is less than all non-null values.
 
 *The Effect of DESC*
 --------------------
 
-We've already said that if you put the <keyword> ``DESC`` after a <sort key>, 
-the ordering will be *reversed* for that <sort key>. Unfortunately, we have to 
-belabor what appears to be an obvious and simple fact, because some pundits 
-have mis-stated it. The following statements, taken from SQL books available at 
-your book store, are drivel: 
+We've already said that if you put the <keyword> ``DESC`` after a <sort key>,
+the ordering will be *reversed* for that <sort key>. Unfortunately, we have to
+belabor what appears to be an obvious and simple fact, because some pundits
+have mis-stated it. The following statements, taken from SQL books available at
+your book store, are drivel:
 
-* "``DESC`` is a sticky flag, so if you say "``ORDER BY`` a ``DESC, b``" then 
-  both ``a`` and ``b`` will appear in descending order." If anyone knows how 
-  this myth got started, please write to us: we're curious. 
+* "``DESC`` is a sticky flag, so if you say "``ORDER BY`` a ``DESC, b``" then
+  both ``a`` and ``b`` will appear in descending order." If anyone knows how
+  this myth got started, please write to us: we're curious.
 
-* "If a vendor says that ``NULL``\s are greater than non-``NULL``\s, then (for 
-  standard SQL) they should appear last, even if ``DESC`` is specified." In 
-  other words -- taking the example we used in the last section -- if you asked 
-  for an ascending sort of a Table with these rows: {``7,5,-1,NULL``}, you'd 
-  get {``- 1,5,7,NULL``} and if you asked for a descending sort you'd get 
-  {``7,5,-1,NULL``}. In fact, standard SQL requires that the descending result 
-  be what a sane person would expect: {``NULL,7,5,-1``}. 
+* "If a vendor says that ``NULL``\s are greater than non-``NULL``\s, then (for
+  standard SQL) they should appear last, even if ``DESC`` is specified." In
+  other words -- taking the example we used in the last section -- if you asked
+  for an ascending sort of a Table with these rows: {``7,5,-1,NULL``}, you'd
+  get {``- 1,5,7,NULL``} and if you asked for a descending sort you'd get
+  {``7,5,-1,NULL``}. In fact, standard SQL requires that the descending result
+  be what a sane person would expect: {``NULL,7,5,-1``}.
 
 *Deprecated SQL-92 Syntax*
 --------------------------
@@ -199,20 +201,20 @@ that you should avoid or change for SQL3.
    WHERE    age < 21
    ORDER BY E.dept;
 
-Get rid of any <Column reference>s in an ``ORDER BY`` clause -- the actual name 
-of the Column in the select list is merely ``DEPT``, despite appearances. Use 
-an ``AS`` clause to give the Column another name if there is resulting 
-ambiguity. 
+Get rid of any <Column reference>s in an ``ORDER BY`` clause -- the actual name
+of the Column in the select list is merely ``DEPT``, despite appearances. Use
+an ``AS`` clause to give the Column another name if there is resulting
+ambiguity.
 
 ::
 
    SELECT   balance, (balance - amount) FROM Accounts
    ORDER BY 1, 2;
 
-Get rid of any Column ordinal position references in an ``ORDER BY`` clause -- 
-using ordinals as Column numbers is frowned on by SQL-92 and banned by SQL3. 
-Again, the solution is to use an ``AS`` clause, so the Columns have explicit 
-names -- for example: 
+Get rid of any Column ordinal position references in an ``ORDER BY`` clause --
+using ordinals as Column numbers is frowned on by SQL-92 and banned by SQL3.
+Again, the solution is to use an ``AS`` clause, so the Columns have explicit
+names -- for example:
 
 ::
 
@@ -230,33 +232,33 @@ These three SQL statements, which are illegal in SQL-92, are legal in SQL3:
    SELECT   column_1 FROM Table_1
    ORDER BY column_2;
 
-The <sort key> ``COLUMN_2`` is not in the select list, but it does belong to 
-``TABLE_1`` so this type of ``ORDER BY`` works, provided that the query does 
-not contain ``DISTINCT``, a grouped Table, a set function or a set operator. 
+The <sort key> ``COLUMN_2`` is not in the select list, but it does belong to
+``TABLE_1`` so this type of ``ORDER BY`` works, provided that the query does
+not contain ``DISTINCT``, a grouped Table, a set function or a set operator.
 
 ::
 
    SELECT   column_1 + 5 FROM Table_1
    ORDER BY column_1 + 5;
 
-The <sort key> "``COLUMN_1 + 5``" is an unnamed value expression, but this type 
-of ``ORDER BY`` is legal because "``COLUMN_1 + 5``" appears in the query's 
-select list. Your DBMS will find it by comparing the expressions, rather than 
-comparing <Column name>s. 
+The <sort key> "``COLUMN_1 + 5``" is an unnamed value expression, but this type
+of ``ORDER BY`` is legal because "``COLUMN_1 + 5``" appears in the query's
+select list. Your DBMS will find it by comparing the expressions, rather than
+comparing <Column name>s.
 
 ::
 
    SELECT   char_column FROM Table_1
    ORDER BY char_column COLLATE Schema_1.Polish;
 
-The ``COLLATE`` clause specified for the <sort key> overrides whatever default 
-Collation ``CHAR_COLUMN`` has. 
+The ``COLLATE`` clause specified for the <sort key> overrides whatever default
+Collation ``CHAR_COLUMN`` has.
 
-Essentially, these SQL3 "features" let you write sloppy code. We advise that 
-you stick with the SQL-92 rule that all <sort key>s must be names of Columns in 
-the result select list. These three SQL statements, equivalent to the ones 
-we've just shown you, are better code -- and are legal in both SQL-92 and 
-SQL3: 
+Essentially, these SQL3 "features" let you write sloppy code. We advise that
+you stick with the SQL-92 rule that all <sort key>s must be names of Columns in
+the result select list. These three SQL statements, equivalent to the ones
+we've just shown you, are better code -- and are legal in both SQL-92 and
+SQL3:
 
 ::
 
@@ -420,6 +422,6 @@ The result is:
 Dialects
 ========
 
-All SQL DBMSs support the ``ORDER BY`` clause. Some of them even allow the 
-"``ORDER BY`` <expression>" syntax described above as an SQL3 feature, or some 
-variant thereof -- we expect they all will fairly soon. 
+All SQL DBMSs support the ``ORDER BY`` clause. Some of them even allow the
+"``ORDER BY`` <expression>" syntax described above as an SQL3 feature, or some
+variant thereof -- we expect they all will fairly soon.

--- a/docs/chapters/35.rst
+++ b/docs/chapters/35.rst
@@ -4,34 +4,36 @@
 Chapter 35 -- Changing SQL-data
 ===============================
 
-The SQL-data change statements are ``INSERT``, ``UPDATE`` and ``DELETE``. Many 
-people call these the SQL "update" statements -- which is okay, provided you 
-don't mix up "update" (lower case, meaning ``INSERT`` or ``UPDATE`` or 
-``DELETE``) with ``UPDATE`` (upper case, meaning only ``UPDATE``). We prefer 
-the term "data change statements" because it's unambiguous. 
+.. include:: ../_include/note.rst
 
-In this chapter, we'll discuss changes to SQL-data in all aspects, including 
-hidden changes, changes of Views, the syntax of ``INSERT``, ``UPDATE`` and 
-``DELETE``, access (Privilege) rules and the new SQL3 feature: changes to 
-joined Tables. But we won't talk about four important and relevant matters 
-because they rate chapters of their own: 
+The SQL-data change statements are ``INSERT``, ``UPDATE`` and ``DELETE``. Many
+people call these the SQL "update" statements -- which is okay, provided you
+don't mix up "update" (lower case, meaning ``INSERT`` or ``UPDATE`` or
+``DELETE``) with ``UPDATE`` (upper case, meaning only ``UPDATE``). We prefer
+the term "data change statements" because it's unambiguous.
 
-**Multiple data changes and transactions**, discussed on our chapter on "SQL 
-Transactions". 
+In this chapter, we'll discuss changes to SQL-data in all aspects, including
+hidden changes, changes of Views, the syntax of ``INSERT``, ``UPDATE`` and
+``DELETE``, access (Privilege) rules and the new SQL3 feature: changes to
+joined Tables. But we won't talk about four important and relevant matters
+because they rate chapters of their own:
 
-**Data changes and Constraints**, discussed on our chapter on "SQL Constraints 
-and Assertions". 
+**Multiple data changes and transactions**, discussed on our chapter on "SQL
+Transactions".
 
-**Data changes and Triggers**, discussed on our chapter on "SQL Triggers". 
+**Data changes and Constraints**, discussed on our chapter on "SQL Constraints
+and Assertions".
 
-**Data changes through Cursors**, discussed on our chapter on "Embedded SQL 
-Binding Style" -- in particular, data changes with "positioned" 
-``UPDATE/DELETE``. 
+**Data changes and Triggers**, discussed on our chapter on "SQL Triggers".
 
-After reading this chapter, you'll know everything that there is to know about 
-the SQL data-change statements taken in isolation. But we give you fair 
-warning: we'll revisit some of these points when we put them in context later 
-on. 
+**Data changes through Cursors**, discussed on our chapter on "Embedded SQL
+Binding Style" -- in particular, data changes with "positioned"
+``UPDATE/DELETE``.
+
+After reading this chapter, you'll know everything that there is to know about
+the SQL data-change statements taken in isolation. But we give you fair
+warning: we'll revisit some of these points when we put them in context later
+on.
 
 .. rubric:: Table of Contents
 
@@ -41,89 +43,89 @@ on.
 The SQL-data Change Statements
 ==============================
 
-In SQL, there are fundamentally only three conceivable data-change operations 
-that can be performed at the row level: the addition of a new row, the editing 
-of an existing row and the removal of an existing row. So the only SQL 
-statements that you'll ever need to change SQL-data are (respectively): 
-``INSERT``, ``UPDATE`` and ``DELETE``. Before getting into the details of each 
-individual statement, we'll note those features or restrictions which are 
-common to two or more of them. 
+In SQL, there are fundamentally only three conceivable data-change operations
+that can be performed at the row level: the addition of a new row, the editing
+of an existing row and the removal of an existing row. So the only SQL
+statements that you'll ever need to change SQL-data are (respectively):
+``INSERT``, ``UPDATE`` and ``DELETE``. Before getting into the details of each
+individual statement, we'll note those features or restrictions which are
+common to two or more of them.
 
 **The "set at a Time" Rule**
 
-If multiple rows are involved in a data change operation, you must abandon "row 
-at a time" thinking. For example, a ``WHERE`` clause is completely evaluated 
-before a ``DELETE`` operation beings to remove rows, and an ``UPDATE`` 
-operation is not affected by a change to the last row for "uniqueness" 
-purposes. 
+If multiple rows are involved in a data change operation, you must abandon "row
+at a time" thinking. For example, a ``WHERE`` clause is completely evaluated
+before a ``DELETE`` operation beings to remove rows, and an ``UPDATE``
+operation is not affected by a change to the last row for "uniqueness"
+purposes.
 
 **The "Updatable Table" Rule**
 
-Although the object of a data-change statement can be a View (or a derived 
-Table), ultimately the changes actually happen to one or more Base tables. 
-Sometimes, though, an operation won't make sense if applied to the appropriate 
-Base table and so the SQL-data change statement won't work. 
+Although the object of a data-change statement can be a View (or a derived
+Table), ultimately the changes actually happen to one or more Base tables.
+Sometimes, though, an operation won't make sense if applied to the appropriate
+Base table and so the SQL-data change statement won't work.
 
 **The "Read Only" Rule**
 
-SQL provides a statement that is used to prevent any data changes from 
-happening: if you execute ``SET TRANSACTION READ ONLY``, then all ``INSERT``, 
-``UPDATE`` and ``DELETE`` statements will fail: your DBMS will return the 
-``SQLSTATE error 25006 "invalid transaction state-read-only transaction."`` 
+SQL provides a statement that is used to prevent any data changes from
+happening: if you execute ``SET TRANSACTION READ ONLY``, then all ``INSERT``,
+``UPDATE`` and ``DELETE`` statements will fail: your DBMS will return the
+``SQLSTATE error 25006 "invalid transaction state-read-only transaction."``
 
 **The "Default Values" Rule**
 
-Remember that any <Column definition> or Domain definition can include the 
-clause "``DEFAULT`` value". Your DBMS uses the value specified to provide a 
-value for a Column that is implicitly the object of a data change operation. 
-You can also use this value explicitly by specifying the <keyword> ``DEFAULT`` 
-in an ``INSERT`` statement or an ``UPDATE`` statement -- this has the effect of 
-setting a Column to its default value. If you didn't use a ``DEFAULT`` clause 
-when you defined a Column or Domain, that's okay -- it still has a default 
-value: ``NULL`` (provided, of course, that there isn't also a ``NOT NULL`` 
-Constraint on the Column or Domain). 
+Remember that any <Column definition> or Domain definition can include the
+clause "``DEFAULT`` value". Your DBMS uses the value specified to provide a
+value for a Column that is implicitly the object of a data change operation.
+You can also use this value explicitly by specifying the <keyword> ``DEFAULT``
+in an ``INSERT`` statement or an ``UPDATE`` statement -- this has the effect of
+setting a Column to its default value. If you didn't use a ``DEFAULT`` clause
+when you defined a Column or Domain, that's okay -- it still has a default
+value: ``NULL`` (provided, of course, that there isn't also a ``NOT NULL``
+Constraint on the Column or Domain).
 
 **The "Column Integrity" Rule**
 
-At the same time that you defined a Column, you declared what its <data type> 
-is. The <data type> limits the values that the Column can contain. For example, 
-if it's a ``DATE``, then you can't insert the character string ``'Hello, 
-world'`` into it. This limitation -- that a Column's data must conform to its 
-<data type> -- is enforced on any assignment: it is an implicit Constraint on 
-the Column. This implicit Constraint isn't like the explicit Constraints we 
-talked about in out chapter on constraints and assertions, though. The big 
-difference between them is that Column integrity is checked when the SQL-data 
-change statement starts, while explicit Constraints are checked when the SQL- 
-data change statement ends. In other words, your DBMS vets your ``INSERT``\s 
-and ``UPDATE``\s; it won't let utter garbage through no matter how you insist. 
+At the same time that you defined a Column, you declared what its <data type>
+is. The <data type> limits the values that the Column can contain. For example,
+if it's a ``DATE``, then you can't insert the character string ``'Hello,
+world'`` into it. This limitation -- that a Column's data must conform to its
+<data type> -- is enforced on any assignment: it is an implicit Constraint on
+the Column. This implicit Constraint isn't like the explicit Constraints we
+talked about in out chapter on constraints and assertions, though. The big
+difference between them is that Column integrity is checked when the SQL-data
+change statement starts, while explicit Constraints are checked when the SQL-
+data change statement ends. In other words, your DBMS vets your ``INSERT``\s
+and ``UPDATE``\s; it won't let utter garbage through no matter how you insist.
 
 **The "No Data" Condition**
 
-Any SQL-data change statement can be a perfect success -- and still affect zero 
-rows. ``INSERT``, ``UPDATE`` and ``DELETE`` all depend to some extent on 
-"search conditions", so it should be clear that sometimes there will be no rows 
-to insert or update or delete. In that case, the SQL-data change statement 
-hasn't failed -- it just hasn't found anything that fulfills your requirements 
-for a change. In such cases, your DBMS will return the ``SQLSTATE warning 02000 
-"no data."`` (If you're a programmer who'll want to know the exact number of 
-rows that any SQL-data change statement affects, see our discussion of the 
-``SQLRowCount`` function in our chapter on SQL/CLI diagnostics.) 
+Any SQL-data change statement can be a perfect success -- and still affect zero
+rows. ``INSERT``, ``UPDATE`` and ``DELETE`` all depend to some extent on
+"search conditions", so it should be clear that sometimes there will be no rows
+to insert or update or delete. In that case, the SQL-data change statement
+hasn't failed -- it just hasn't found anything that fulfills your requirements
+for a change. In such cases, your DBMS will return the ``SQLSTATE warning 02000
+"no data."`` (If you're a programmer who'll want to know the exact number of
+rows that any SQL-data change statement affects, see our discussion of the
+``SQLRowCount`` function in our chapter on SQL/CLI diagnostics.)
 
 **The "Data Change Object" Condition**
 
-For each SQL-data change statement, there is a syntax diagram that has "<Table 
-reference>" in a prominent place. This somewhat anticipates the conclusion of 
-the chapter, since a <Table reference> can include <Correlation name>s, 
-parentheses and various Table operators. As usual, we suggest that, until 
-you've read through the entire chapter, you should interpret <Table reference> 
-as <Table name>. 
+For each SQL-data change statement, there is a syntax diagram that has "<Table
+reference>" in a prominent place. This somewhat anticipates the conclusion of
+the chapter, since a <Table reference> can include <Correlation name>s,
+parentheses and various Table operators. As usual, we suggest that, until
+you've read through the entire chapter, you should interpret <Table reference>
+as <Table name>.
 
 **The "Tentative" Condition**
 
-Finally, you'll note that in the description of each SQL-data change statement, 
-we use the word "tentatively" when telling you what it does. This is not a 
-standard term -- we use it merely to indicate that any new row is "on 
-probation": it's not too late to take your move back until ``COMMIT`` time. 
+Finally, you'll note that in the description of each SQL-data change statement,
+we use the word "tentatively" when telling you what it does. This is not a
+standard term -- we use it merely to indicate that any new row is "on
+probation": it's not too late to take your move back until ``COMMIT`` time.
 
 INSERT Statement
 ================
@@ -138,39 +140,39 @@ target Table. The required syntax for the ``INSERT`` statement is:
     [ (<Column name> [ {,<Column name>} ... ]) ] <query expression> |
     DEFAULT VALUES
 
-The ``INSERT`` statement has two forms. The first evaluates a query to 
-construct one or more rows to be inserted into a Table. The second constructs 
-one row -- containing default values for every Column -- and inserts it into a 
-Table. The <Table reference> identifies your target Table: the Table that you 
-want ``INSERT`` to add rows to. The target Table must be updatable -- that is, 
-it must either be a Base table, or a View that is not a read-only Table. If 
-<Table reference> does not include a <Schema name> qualifier, your target Table 
-must belong to the SQL-session default Schema. If your target Table is a typed 
-Table, your ``INSERT`` statement may include the optional <keyword> ``ONLY``. 
+The ``INSERT`` statement has two forms. The first evaluates a query to
+construct one or more rows to be inserted into a Table. The second constructs
+one row -- containing default values for every Column -- and inserts it into a
+Table. The <Table reference> identifies your target Table: the Table that you
+want ``INSERT`` to add rows to. The target Table must be updatable -- that is,
+it must either be a Base table, or a View that is not a read-only Table. If
+<Table reference> does not include a <Schema name> qualifier, your target Table
+must belong to the SQL-session default Schema. If your target Table is a typed
+Table, your ``INSERT`` statement may include the optional <keyword> ``ONLY``.
 
-To execute ``INSERT``, your current <AuthorizationID> needs the ``INSERT`` 
-Privilege on every Column directly affected by the insert operation -- and, if 
-an object Column is a derived Column (as it is in the case of a View), your 
-current <AuthorizationID> also needs the ``INSERT`` Privilege on every 
-underlying Table that makes up your target Table. 
+To execute ``INSERT``, your current <AuthorizationID> needs the ``INSERT``
+Privilege on every Column directly affected by the insert operation -- and, if
+an object Column is a derived Column (as it is in the case of a View), your
+current <AuthorizationID> also needs the ``INSERT`` Privilege on every
+underlying Table that makes up your target Table.
 
 *INSERT Column List*
 --------------------
 
-In the first form of ``INSERT``, you can optionally specify a parenthesized 
-object Column list, wherein you provide your DBMS with the unqualified names of 
-the Columns that are the targets for each value returned by the <query 
-expression>. Each Column named must belong to the Table named in the ``INTO`` 
-clause; <Column name>s may not be repeated in the list but you may list the 
-Columns in any order; the number of Columns in the list must match the number 
-of result Columns returned by the query. ``INSERT`` places data into the 
-Columns of the target Table in the order that you list them in the ``INSERT`` 
-Column clause: the first value specified is assigned to the first Column named, 
-the second value is assigned to the second Column named, and so on. Any Columns 
-of the target Table that are omitted from the ``INSERT`` Column clause are 
-assigned their default value. For example, these SQL statements create a new 
-Table and insert one row of data into it (the default value for a Column that 
-is specifically defined with one is ``NULL``): 
+In the first form of ``INSERT``, you can optionally specify a parenthesized
+object Column list, wherein you provide your DBMS with the unqualified names of
+the Columns that are the targets for each value returned by the <query
+expression>. Each Column named must belong to the Table named in the ``INTO``
+clause; <Column name>s may not be repeated in the list but you may list the
+Columns in any order; the number of Columns in the list must match the number
+of result Columns returned by the query. ``INSERT`` places data into the
+Columns of the target Table in the order that you list them in the ``INSERT``
+Column clause: the first value specified is assigned to the first Column named,
+the second value is assigned to the second Column named, and so on. Any Columns
+of the target Table that are omitted from the ``INSERT`` Column clause are
+assigned their default value. For example, these SQL statements create a new
+Table and insert one row of data into it (the default value for a Column that
+is specifically defined with one is ``NULL``):
 
 ::
 
@@ -180,16 +182,16 @@ is specifically defined with one is ``NULL``):
    INSERT INTO Table_1 (column_3, column_1)
    VALUES (DATE '1996-12-31', 20);
 
-If a Column in the Column list is a self-referencing Column, your ``INSERT`` 
-statement must include the ``OVERRIDE SYSTEM GENERATED VALUES`` clause. 
+If a Column in the Column list is a self-referencing Column, your ``INSERT``
+statement must include the ``OVERRIDE SYSTEM GENERATED VALUES`` clause.
 
-If you omit the Column list clause from an ``INSERT`` statement, your DBMS will 
-assume you mean "all Columns in the Table, in their ordinal position order". In 
-this case, ``INSERT`` places data into the Columns of the target Table in the 
-implied order listed: the first value specified is assigned to the first Column 
-of the target Table, the second value is assigned to the second Column of the 
-target Table, and so on. For example, these SQL statements create a new Table 
-and insert one row of data into it: 
+If you omit the Column list clause from an ``INSERT`` statement, your DBMS will
+assume you mean "all Columns in the Table, in their ordinal position order". In
+this case, ``INSERT`` places data into the Columns of the target Table in the
+implied order listed: the first value specified is assigned to the first Column
+of the target Table, the second value is assigned to the second Column of the
+target Table, and so on. For example, these SQL statements create a new Table
+and insert one row of data into it:
 
 ::
 
@@ -202,28 +204,28 @@ and insert one row of data into it:
 *<query expression>*
 --------------------
 
-The <query expression> that makes up the first form of ``INSERT`` is usually a 
-``SELECT`` statement, but it's also common to see the Table constructor 
-"``VALUES`` (value commalist)" here (usually with only a single row). In this 
-latter case, you can use the specifications ``DEFAULT`` (for insert default 
-value), ``NULL`` (for insert null value), ``ARRAY??(??)`` or ``ARRAY[]`` (for 
-insert an empty array) within the "value commalist" to specify a value for a 
-Column. The order and number of the values must correspond to the order and 
-number of the Columns in the ``INSERT`` Column list. If you're using a <query 
-expression>, the ``INSERT``\'s <Table reference> may not identify a Table that 
-also appears in any ``FROM`` clause in that <query expression>. The <query 
-expression> provides zero or more rows of data values when it is evaluated: its 
-search conditions are effectively evaluated for each row before any rows are 
-added to the target Table. Here's an example: 
+The <query expression> that makes up the first form of ``INSERT`` is usually a
+``SELECT`` statement, but it's also common to see the Table constructor
+"``VALUES`` (value commalist)" here (usually with only a single row). In this
+latter case, you can use the specifications ``DEFAULT`` (for insert default
+value), ``NULL`` (for insert null value), ``ARRAY??(??)`` or ``ARRAY[]`` (for
+insert an empty array) within the "value commalist" to specify a value for a
+Column. The order and number of the values must correspond to the order and
+number of the Columns in the ``INSERT`` Column list. If you're using a <query
+expression>, the ``INSERT``\'s <Table reference> may not identify a Table that
+also appears in any ``FROM`` clause in that <query expression>. The <query
+expression> provides zero or more rows of data values when it is evaluated: its
+search conditions are effectively evaluated for each row before any rows are
+added to the target Table. Here's an example:
 
 ::
 
    INSERT INTO Table_1 (column_1, column_3)
       SELECT column_1, column_3 FROM Table_2;
 
-You can insert a null value into a Column either by placing the <keyword> 
-``NULL`` in the ``INSERT ... VALUES`` clause, or by omitting a Column that 
-has no defined default value from an explicit <Column name> clause. For 
+You can insert a null value into a Column either by placing the <keyword>
+``NULL`` in the ``INSERT ... VALUES`` clause, or by omitting a Column that
+has no defined default value from an explicit <Column name> clause. For
 example, given this Table definition:
 
 ::
@@ -231,7 +233,7 @@ example, given this Table definition:
    CREATE TABLE Table_1 (
       column_1 INTEGER, column_2 CHARACTER(7), column_3 DATE);
 
-these ``INSERT`` statements, which insert one row of data into ``TABLE_1`` 
+these ``INSERT`` statements, which insert one row of data into ``TABLE_1``
 using <literal>s and/or the <keyword> ``NULL``, are equivalent:
 
 ::
@@ -247,28 +249,28 @@ using <literal>s and/or the <keyword> ``NULL``, are equivalent:
 
 .. TIP::
 
-  All three of these examples result in a new record in ``TABLE_1``, with the 
-  specified values ``'GOODBYE'`` in ``COLUMN_2`` and ``'1996-12-31'`` in 
-  ``COLUMN_3``, and the null value in ``COLUMN_1``. 
+  All three of these examples result in a new record in ``TABLE_1``, with the
+  specified values ``'GOODBYE'`` in ``COLUMN_2`` and ``'1996-12-31'`` in
+  ``COLUMN_3``, and the null value in ``COLUMN_1``.
 
-* In the first example, the null value is implied since no explicit value is 
-  specified for ``COLUMN_1`` (this, of course, assumes that there is no other 
-  default value for ``COLUMN_1``). It is necessary to provide a <Column name> 
-  clause list of the Columns you want to assign the values to if your 
-  ``INSERT`` statement contains fewer source values than the target Table has 
-  Columns. 
+* In the first example, the null value is implied since no explicit value is
+  specified for ``COLUMN_1`` (this, of course, assumes that there is no other
+  default value for ``COLUMN_1``). It is necessary to provide a <Column name>
+  clause list of the Columns you want to assign the values to if your
+  ``INSERT`` statement contains fewer source values than the target Table has
+  Columns.
 
-* In the second and third examples, the null value is explicitly stated as the 
-  value to be assigned to ``TABLE_1.COLUMN_1`` and therefore the <Column name> 
-  clause can be (but does not have to be) omitted. The explicit use of the 
-  <keyword> ``NULL`` over-rides the assignment of a default value to a Column 
-  that is omitted from a <Column name> clause. This, of course, assumes that 
-  the Column has not been defined with a ``NOT NULL`` Constraint. 
+* In the second and third examples, the null value is explicitly stated as the
+  value to be assigned to ``TABLE_1.COLUMN_1`` and therefore the <Column name>
+  clause can be (but does not have to be) omitted. The explicit use of the
+  <keyword> ``NULL`` over-rides the assignment of a default value to a Column
+  that is omitted from a <Column name> clause. This, of course, assumes that
+  the Column has not been defined with a ``NOT NULL`` Constraint.
 
-You can insert a default value into a Column either by placing the <keyword> 
-``DEFAULT`` in the ``INSERT ... VALUES`` clause, or by omitting a Column that 
-has a defined default value from an explicit <Column name> clause. For example, 
-given this Table definition: 
+You can insert a default value into a Column either by placing the <keyword>
+``DEFAULT`` in the ``INSERT ... VALUES`` clause, or by omitting a Column that
+has a defined default value from an explicit <Column name> clause. For example,
+given this Table definition:
 
 ::
 
@@ -277,7 +279,7 @@ given this Table definition:
       column_2 CHARACTER(7),
       column_3 DATE);
 
-these ``INSERT`` statements, which insert one row of data into ``TABLE_1`` 
+these ``INSERT`` statements, which insert one row of data into ``TABLE_1``
 using <literal>s and/or the <keyword> ``DEFAULT``, are equivalent:
 
 ::
@@ -293,24 +295,24 @@ using <literal>s and/or the <keyword> ``DEFAULT``, are equivalent:
 
 .. TIP::
 
-  All three of these examples result in a new record in ``TABLE_1``, with the 
-  specified values ``'GOODBYE'`` in ``COLUMN_2`` and ``'1996-12-31'`` in 
-  ``COLUMN_3``, and the default value ``35`` in ``COLUMN_1``. 
+  All three of these examples result in a new record in ``TABLE_1``, with the
+  specified values ``'GOODBYE'`` in ``COLUMN_2`` and ``'1996-12-31'`` in
+  ``COLUMN_3``, and the default value ``35`` in ``COLUMN_1``.
 
-In the first example, the default value is implied since no explicit value is 
-specified for ``COLUMN_1``. 
+In the first example, the default value is implied since no explicit value is
+specified for ``COLUMN_1``.
 
-In the second and third examples, the default value is explicitly stated as 
-the value to be assigned to ``TABLE_1.COLUMN_1`` and therefore the <Column 
-name> clause can be (but does not have to be) omitted. 
+In the second and third examples, the default value is explicitly stated as
+the value to be assigned to ``TABLE_1.COLUMN_1`` and therefore the <Column
+name> clause can be (but does not have to be) omitted.
 
 *DEFAULT VALUES*
 ----------------
 
-You can write your ``INSERT`` statement with the <keyword>s ``DEFAULT VALUES`` 
-instead of with a <query expression> if every Column belonging to your target 
-Table is to get its default value for a single row. These two ``INSERT`` 
-statements are thus equivalent: 
+You can write your ``INSERT`` statement with the <keyword>s ``DEFAULT VALUES``
+instead of with a <query expression> if every Column belonging to your target
+Table is to get its default value for a single row. These two ``INSERT``
+statements are thus equivalent:
 
 ::
 
@@ -383,9 +385,9 @@ To add several rows at a time to ``AUTHORS_1``, we can do this:
           (6,DEFAULT),
           (7,NULL);
 
-The ``DEFAULT`` specification inserts the Column's default value (or ``NULL``, 
-if no default was defined). The ``NULL`` specification inserts a null value. At 
-this point, ``AUTHORS_1`` looks like this: 
+The ``DEFAULT`` specification inserts the Column's default value (or ``NULL``,
+if no default was defined). The ``NULL`` specification inserts a null value. At
+this point, ``AUTHORS_1`` looks like this:
 
 +----------------------+
 | AUTHORS_1            |
@@ -407,7 +409,7 @@ this point, ``AUTHORS_1`` looks like this:
 | 7      | ``NULL``    |
 +--------+-------------+
 
-To add all the rows in ``AUTHORS_1`` to ``AUTHORS_2``, we can do either of 
+To add all the rows in ``AUTHORS_1`` to ``AUTHORS_2``, we can do either of
 these:
 
 ::
@@ -467,34 +469,34 @@ At this point, ``AUTHORS_2`` looks like this (the first 7 rows come from
 *INSERT Physics*
 ----------------
 
-Most DBMSs simply append newly inserted rows to the end of the target Table. 
-But some (more sophisticated) DBMSs will put new rows wherever they can find 
-space (there might be gaps left by earlier ``DELETE`` statements). And a few 
-DBMSs will put new rows in order, according to the target Table's primary key 
-(this is called "clustering"; variants of *clustering* are practiced by DB2 and 
-Oracle). 
+Most DBMSs simply append newly inserted rows to the end of the target Table.
+But some (more sophisticated) DBMSs will put new rows wherever they can find
+space (there might be gaps left by earlier ``DELETE`` statements). And a few
+DBMSs will put new rows in order, according to the target Table's primary key
+(this is called "clustering"; variants of *clustering* are practiced by DB2 and
+Oracle).
 
-A general recommendation -- which we often ignore -- is that the optional 
-``INSERT`` Column list should always be explicitly stated. That way, if someday 
-the target Table is altered and a Column is dropped, the ``INSERT`` will fail 
-and you'll be reminded that you have to change that particular operation. 
+A general recommendation -- which we often ignore -- is that the optional
+``INSERT`` Column list should always be explicitly stated. That way, if someday
+the target Table is altered and a Column is dropped, the ``INSERT`` will fail
+and you'll be reminded that you have to change that particular operation.
 
-If you want to restrict your code to Core SQL, don't use a <query expression> 
-with ``EXCEPT``, ``INTERSECT`` or ``CORRESPONDING`` in an ``INSERT`` statement, 
-don't use a <query expression> that names an underlying Table of your target 
-Table in an ``INSERT`` statement, don't use the <query expression> ``TABLE`` 
-<Table name> in an ``INSERT`` statement, if you use the <query expression 
-``VALUES`` (value commalist) in an ``INSERT`` statement, make sure it 
-constructs only one new row, don't use the ``DEFAULT VALUES`` form of the 
-``INSERT`` statement and make sure all your ``INSERT`` <Table reference>s are 
-actually <Table name>s, with no <Correlation name>s or <derived Column list>s. 
+If you want to restrict your code to Core SQL, don't use a <query expression>
+with ``EXCEPT``, ``INTERSECT`` or ``CORRESPONDING`` in an ``INSERT`` statement,
+don't use a <query expression> that names an underlying Table of your target
+Table in an ``INSERT`` statement, don't use the <query expression> ``TABLE``
+<Table name> in an ``INSERT`` statement, if you use the <query expression
+``VALUES`` (value commalist) in an ``INSERT`` statement, make sure it
+constructs only one new row, don't use the ``DEFAULT VALUES`` form of the
+``INSERT`` statement and make sure all your ``INSERT`` <Table reference>s are
+actually <Table name>s, with no <Correlation name>s or <derived Column list>s.
 
 UPDATE Statement
 ================
 
-The ``UPDATE`` statement's job is to tentatively edit existing rows in a Table. 
-If ``UPDATE`` succeeds, there will be a number (zero or more) of changed rows 
-in your target Table. The required syntax for the ``UPDATE`` statement is: 
+The ``UPDATE`` statement's job is to tentatively edit existing rows in a Table.
+If ``UPDATE`` succeeds, there will be a number (zero or more) of changed rows
+in your target Table. The required syntax for the ``UPDATE`` statement is:
 
 ::
 
@@ -503,40 +505,40 @@ in your target Table. The required syntax for the ``UPDATE`` statement is:
     ROW=row_expression
     [ WHERE <search condition> ]
 
-``UPDATE`` works by changing one or more values in zero or more rows of the 
-target Table, Column by Column. The <Table reference> identifies your target 
-Table: the Table that you want ``UPDATE`` to change rows of. The target Table 
-must be updatable -- that is, it must either be a Base table, or a View that is 
-not a read-only Table. If <Table reference> does not include a <Schema name> 
-qualifier, your target Table must belong to the SQL-session default Schema. 
+``UPDATE`` works by changing one or more values in zero or more rows of the
+target Table, Column by Column. The <Table reference> identifies your target
+Table: the Table that you want ``UPDATE`` to change rows of. The target Table
+must be updatable -- that is, it must either be a Base table, or a View that is
+not a read-only Table. If <Table reference> does not include a <Schema name>
+qualifier, your target Table must belong to the SQL-session default Schema.
 
-There are two forms of ``UPDATE``: the first lets you specify multiple Column 
-changes that don't necessarily change every value in a row, the second lets you 
-specify changes to every value in a row with a single ``SET`` clause. To 
-execute ``UPDATE``, your current <AuthorizationID> needs the ``UPDATE`` 
-Privilege on every Column directly affected by the update operation -- and, if 
-an object Column is a derived Column (as it is in the case of a View), your 
-current <AuthorizationID> also needs the ``UPDATE`` Privilege on every 
-underlying Table that makes up your target Table -- or, if your target Table is 
-a <joined Table> made with ``LEFT OUTER JOIN``, ``RIGHT OUTER JOIN``, ``FULL 
-OUTER JOIN`` or ``UNION JOIN``, your current <AuthorizationID> also needs the 
-``INSERT`` Privilege on every underlying Table that makes up your target Table. 
+There are two forms of ``UPDATE``: the first lets you specify multiple Column
+changes that don't necessarily change every value in a row, the second lets you
+specify changes to every value in a row with a single ``SET`` clause. To
+execute ``UPDATE``, your current <AuthorizationID> needs the ``UPDATE``
+Privilege on every Column directly affected by the update operation -- and, if
+an object Column is a derived Column (as it is in the case of a View), your
+current <AuthorizationID> also needs the ``UPDATE`` Privilege on every
+underlying Table that makes up your target Table -- or, if your target Table is
+a <joined Table> made with ``LEFT OUTER JOIN``, ``RIGHT OUTER JOIN``, ``FULL
+OUTER JOIN`` or ``UNION JOIN``, your current <AuthorizationID> also needs the
+``INSERT`` Privilege on every underlying Table that makes up your target Table.
 
 *SET Column*
 ------------
 
-In the first form of ``UPDATE`` -- ``UPDATE`` <Table> ``SET`` <Column>=<value> 
--- you must specify at least one Column change expression. The Column named 
-must, of course, belong to your target Table; you can change multiple Columns 
-of the same Table (in any order), but you can't change the same Column more 
-than once in a single ``UPDATE`` statement. The ``scalar_expression`` you use 
-to assign a new value to a Column may be any expression (except one that 
-contains a set function) that evaluates to a single value that is assignable to 
-that Column's <data type>, including the specifications ``DEFAULT`` (for change 
-to default value), ``NULL`` (for change to null value), ``ARRAY??(??)`` or 
-``ARRAY[]`` (for change to an empty array). Most often, "scalar_expression" 
-will be a <literal>. For example, using the ``AUTHORS_1`` and ``AUTHORS_2`` 
-Tables from our discussion of the ``INSERT`` statement, we could do this: 
+In the first form of ``UPDATE`` -- ``UPDATE`` <Table> ``SET`` <Column>=<value>
+-- you must specify at least one Column change expression. The Column named
+must, of course, belong to your target Table; you can change multiple Columns
+of the same Table (in any order), but you can't change the same Column more
+than once in a single ``UPDATE`` statement. The ``scalar_expression`` you use
+to assign a new value to a Column may be any expression (except one that
+contains a set function) that evaluates to a single value that is assignable to
+that Column's <data type>, including the specifications ``DEFAULT`` (for change
+to default value), ``NULL`` (for change to null value), ``ARRAY??(??)`` or
+``ARRAY[]`` (for change to an empty array). Most often, "scalar_expression"
+will be a <literal>. For example, using the ``AUTHORS_1`` and ``AUTHORS_2``
+Tables from our discussion of the ``INSERT`` statement, we could do this:
 
 ::
 
@@ -544,21 +546,21 @@ Tables from our discussion of the ``INSERT`` statement, we could do this:
       name='Finch'
       WHERE id=7;
 
-This ``UPDATE`` statement changes the last row of ``AUTHORS_1`` from 
-{``7,NULL``} to {``7,'Finch'``} -- if you don't specify that a Column 
-should be changed, the DBMS leaves it alone; it keeps its original 
-value. 
+This ``UPDATE`` statement changes the last row of ``AUTHORS_1`` from
+{``7,NULL``} to {``7,'Finch'``} -- if you don't specify that a Column
+should be changed, the DBMS leaves it alone; it keeps its original
+value.
 
 *SET ROW*
 ---------
 
-In the second form of ``UPDATE`` -- ``UPDATE`` <Table> ``SET 
-ROW=row_expression`` -- you may specify only the one change expression: it will 
-change the entire applicable row. The "row_expression" may be any expression 
-that evaluates to a row of values, equal in number to, and <data type> 
-compatible with, every Column in your target Table (usually, this is a <row 
-value constructor, but it could also be a <row subquery>). For example, we 
-could change a whole row with either of these two statements: 
+In the second form of ``UPDATE`` -- ``UPDATE`` <Table> ``SET
+ROW=row_expression`` -- you may specify only the one change expression: it will
+change the entire applicable row. The "row_expression" may be any expression
+that evaluates to a row of values, equal in number to, and <data type>
+compatible with, every Column in your target Table (usually, this is a <row
+value constructor, but it could also be a <row subquery>). For example, we
+could change a whole row with either of these two statements:
 
 ::
 
@@ -571,17 +573,17 @@ could change a whole row with either of these two statements:
      name='Allan'
    WHERE id=7;
 
-As we've shown, you can add the optional ``WHERE`` clause in both forms of 
-``UPDATE``, to define the rows you want to change. If you omit the ``WHERE`` 
-clause, your DBMS will assume that the condition is ``TRUE`` for all rows (and 
-so ``UPDATE`` every row of the target Table). The ``WHERE`` clause's <search 
-condition> can be any condition at all, as long as it doesn't invoke an 
-SQL-invoked routine that possibly modifies SQL-data. The ``WHERE`` clause's 
-search condition is effectively evaluated for each row of the target Table 
-before any of the Table's rows are changed; each <subquery> in a ``WHERE`` 
-clause's search condition is effectively executed for each row of the target 
-Table and the results are then used to apply the search condition to the given 
-row. Here's some examples: 
+As we've shown, you can add the optional ``WHERE`` clause in both forms of
+``UPDATE``, to define the rows you want to change. If you omit the ``WHERE``
+clause, your DBMS will assume that the condition is ``TRUE`` for all rows (and
+so ``UPDATE`` every row of the target Table). The ``WHERE`` clause's <search
+condition> can be any condition at all, as long as it doesn't invoke an
+SQL-invoked routine that possibly modifies SQL-data. The ``WHERE`` clause's
+search condition is effectively evaluated for each row of the target Table
+before any of the Table's rows are changed; each <subquery> in a ``WHERE``
+clause's search condition is effectively executed for each row of the target
+Table and the results are then used to apply the search condition to the given
+row. Here's some examples:
 
 ::
 
@@ -600,7 +602,7 @@ row. Here's some examples:
 *UPDATE Examples*
 -----------------
 
-To change the last row in ``AUTHORS_1`` so that the ``ID`` Column is the 
+To change the last row in ``AUTHORS_1`` so that the ``ID`` Column is the
 last ``ID`` belonging to ``AUTHORS_2``, and the ``NAME`` Column is ``NULL``:
 
 ::
@@ -610,7 +612,7 @@ last ``ID`` belonging to ``AUTHORS_2``, and the ``NAME`` Column is ``NULL``:
      name = NULL
    WHERE id = 9;
 
-To add 1 to the ``ID`` Column and cast the ``ID`` value to a character 
+To add 1 to the ``ID`` Column and cast the ``ID`` value to a character
 string, putting the result in the ``NAME`` Column:
 
 ::
@@ -620,18 +622,18 @@ string, putting the result in the ``NAME`` Column:
      name = CAST(id AS VARCHAR(6))
    WHERE id =1;
 
-This example is even sillier than it looks, since real people very rarely 
-change the value in a primary key Column -- but we put it here to bring up an 
-important fact. Consider the result of this statement, which is the row: 
-{``2,'1'``}. Why isn't the result: {``2,'2'``}? Because the assignments in the 
-``SET`` clause happen all at once, rather than in a sequence -- so the ``ID`` 
-value in the ``CAST(id AS VARCHAR(6))`` expression is the original value 
-(``1``), rather than the value we're changing it to (``2``). This "all at once" 
-effect is typical of SQL. Because of it, Column value swaps are easy. 
+This example is even sillier than it looks, since real people very rarely
+change the value in a primary key Column -- but we put it here to bring up an
+important fact. Consider the result of this statement, which is the row:
+{``2,'1'``}. Why isn't the result: {``2,'2'``}? Because the assignments in the
+``SET`` clause happen all at once, rather than in a sequence -- so the ``ID``
+value in the ``CAST(id AS VARCHAR(6))`` expression is the original value
+(``1``), rather than the value we're changing it to (``2``). This "all at once"
+effect is typical of SQL. Because of it, Column value swaps are easy.
 
-Let's try to do some updates which will cause errors. The first ``UPDATE`` 
-statement in this set of examples will result in a "constraint violation" 
-error, the next two will result in a "syntax" error: 
+Let's try to do some updates which will cause errors. The first ``UPDATE``
+statement in this set of examples will result in a "constraint violation"
+error, the next two will result in a "syntax" error:
 
 ::
 
@@ -657,7 +659,7 @@ corresponding ``AUTHORS_2.NAME`` value:
    UPDATE Authors_1 SET
      name=(SELECT name FROM Authors_2 WHERE id<=7 and id=Authors_1.id);
 
-This example will only work if ``AUTHORS_2`` has a row, with a matching 
+This example will only work if ``AUTHORS_2`` has a row, with a matching
 ``ID``, for every applicable row in ``AUTHORS_1``.
 
 At this point, ``AUTHORS_1`` and ``AUTHORS_2`` look like this:
@@ -687,62 +689,62 @@ At this point, ``AUTHORS_1`` and ``AUTHORS_2`` look like this:
 *UPDATE Physics*
 ----------------
 
-Most DBMSs fit a changed row in the same place as the old one -- a good idea, 
-because if ``UPDATE``\s always caused changes in row location, there would be 
-much more disk activity (especially if there are indexes which point to the 
-original row location). But your DBMS might shift rows if you change the 
-primary key or if you change a variable size Column and it becomes longer. (In 
-the latter case, there might not be enough room to fit the changed row in the 
-original location.) These, of course, are "implementation-dependent" 
-considerations, but we suggest that you hesitate slightly before you change 
-primary key or variable size Columns. 
+Most DBMSs fit a changed row in the same place as the old one -- a good idea,
+because if ``UPDATE``\s always caused changes in row location, there would be
+much more disk activity (especially if there are indexes which point to the
+original row location). But your DBMS might shift rows if you change the
+primary key or if you change a variable size Column and it becomes longer. (In
+the latter case, there might not be enough room to fit the changed row in the
+original location.) These, of course, are "implementation-dependent"
+considerations, but we suggest that you hesitate slightly before you change
+primary key or variable size Columns.
 
-Some general recommendations -- try to group all updates for the same Table 
-into the same ``UPDATE`` statement, do not substitute a ``DELETE`` plus an 
-``INSERT`` for an ``UPDATE`` and keep in mind that ``UPDATE`` can be a 
-relatively slow operation. 
+Some general recommendations -- try to group all updates for the same Table
+into the same ``UPDATE`` statement, do not substitute a ``DELETE`` plus an
+``INSERT`` for an ``UPDATE`` and keep in mind that ``UPDATE`` can be a
+relatively slow operation.
 
-If you want to restrict your code to Core SQL, don't use a <search condition> 
-that names an underlying Table of your target Table in an ``UPDATE`` statement 
-and make sure all your ``UPDATE`` <Table reference>s are actually <Table 
-name>s, with no <Correlation name>s or <derived Column list>s. 
+If you want to restrict your code to Core SQL, don't use a <search condition>
+that names an underlying Table of your target Table in an ``UPDATE`` statement
+and make sure all your ``UPDATE`` <Table reference>s are actually <Table
+name>s, with no <Correlation name>s or <derived Column list>s.
 
 DELETE Statement
 ================
 
-The ``DELETE`` statement's job is to tentatively remove existing rows from a 
-Table. If ``DELETE`` succeeds, there will be a fewer number (zero or more) of 
-rows in your target Table. The required syntax for the ``DELETE`` statement is: 
+The ``DELETE`` statement's job is to tentatively remove existing rows from a
+Table. If ``DELETE`` succeeds, there will be a fewer number (zero or more) of
+rows in your target Table. The required syntax for the ``DELETE`` statement is:
 
 ::
 
     DELETE FROM <Table reference>
     [ WHERE <search condition> ]
 
-The rules for ``DELETE`` are analogous to the rules for ``UPDATE``\: 
+The rules for ``DELETE`` are analogous to the rules for ``UPDATE``\:
 
-* The <Table reference must identify an updatable Table that belongs to the 
-  SQL-session default Schema if you don't provide an explicit <Schema name> 
-  qualifier. 
+* The <Table reference must identify an updatable Table that belongs to the
+  SQL-session default Schema if you don't provide an explicit <Schema name>
+  qualifier.
 
-* If the ``WHERE`` clause is omitted, the DBMS will assume that the condition 
-  is ``TRUE`` for all rows (and so ``DELETE`` every row). 
+* If the ``WHERE`` clause is omitted, the DBMS will assume that the condition
+  is ``TRUE`` for all rows (and so ``DELETE`` every row).
 
-* The ``WHERE`` clause's <search condition> can be any condition at all, as 
-  long as it doesn't invoke an SQL-invoked routine that possibly modifies 
-  SQL-data. 
+* The ``WHERE`` clause's <search condition> can be any condition at all, as
+  long as it doesn't invoke an SQL-invoked routine that possibly modifies
+  SQL-data.
 
-* The ``WHERE`` clause's search condition is effectively evaluated for each row 
-  of the target Table before any of the Table's rows are marked for deletion. 
+* The ``WHERE`` clause's search condition is effectively evaluated for each row
+  of the target Table before any of the Table's rows are marked for deletion.
 
-* Each <subquery> in a ``WHERE`` clause's search condition is effectively 
-  executed for each row of the target Table and the results are then used to 
-  apply the search condition to the given row. 
+* Each <subquery> in a ``WHERE`` clause's search condition is effectively
+  executed for each row of the target Table and the results are then used to
+  apply the search condition to the given row.
 
-To execute ``DELETE``, your current <AuthorizationID> needs the ``DELETE`` 
-Privilege on the target Table -- and, if the target Table is a derived Table 
-(as it is in the case of a View), your current <AuthorizationID> also needs the 
-``DELETE`` Privilege on every underlying Table that makes up your target Table. 
+To execute ``DELETE``, your current <AuthorizationID> needs the ``DELETE``
+Privilege on the target Table -- and, if the target Table is a derived Table
+(as it is in the case of a View), your current <AuthorizationID> also needs the
+``DELETE`` Privilege on every underlying Table that makes up your target Table.
 
 *DELETE Examples*
 -----------------
@@ -769,32 +771,32 @@ Here's some examples of ``DELETE`` statements:
 *DELETE Physics*
 ----------------
 
-With most DBMSs, a deleted row disappears from view in the Table, but actually 
-remains in the underlying file for a while. Consider: if row #1 is at file 
-offset 0, row #2 is at file offset 100 and row#3 is file offset 200 -- and you 
-delete row #1 -- should your DBMS now move row #2 to file offset 0, move row #3 
-to file offset 100, change all indexes and truncate the file? That would take a 
-long time, so the typical response is to put a "record deleted" flag at file 
-offset 0 instead. 
+With most DBMSs, a deleted row disappears from view in the Table, but actually
+remains in the underlying file for a while. Consider: if row #1 is at file
+offset 0, row #2 is at file offset 100 and row#3 is file offset 200 -- and you
+delete row #1 -- should your DBMS now move row #2 to file offset 0, move row #3
+to file offset 100, change all indexes and truncate the file? That would take a
+long time, so the typical response is to put a "record deleted" flag at file
+offset 0 instead.
 
-There are some DBMSs which will eventually reclaim this space. Of course that's 
-usually good -- otherwise they wouldn't do it -- but it could cause trouble if 
-you use a non-standard "row id" address which is derived from a row's location. 
-If row ids can change without warning, you've got trouble. With such DBMSs, it 
-might be useful to put a row in limbo rather than delete it: set all Columns to 
-``NULL``. Once that's done, the row effectively disappears because most 
-searches are never ``TRUE`` for ``NULL`` Columns. But the row stays in 
-position, reserved, and won't be reclaimed. 
+There are some DBMSs which will eventually reclaim this space. Of course that's
+usually good -- otherwise they wouldn't do it -- but it could cause trouble if
+you use a non-standard "row id" address which is derived from a row's location.
+If row ids can change without warning, you've got trouble. With such DBMSs, it
+might be useful to put a row in limbo rather than delete it: set all Columns to
+``NULL``. Once that's done, the row effectively disappears because most
+searches are never ``TRUE`` for ``NULL`` Columns. But the row stays in
+position, reserved, and won't be reclaimed.
 
-If you want to restrict your code to Core SQL, don't use a <search condition> 
-that names an underlying Table of your target Table in a ``DELETE`` statement 
-and make sure all your ``DELETE`` <Table reference>s are actually <Table 
-name>s, with no <Correlation name>s or <derived Column list>s. 
+If you want to restrict your code to Core SQL, don't use a <search condition>
+that names an underlying Table of your target Table in a ``DELETE`` statement
+and make sure all your ``DELETE`` <Table reference>s are actually <Table
+name>s, with no <Correlation name>s or <derived Column list>s.
 
 Data Change Operations
 ======================
 
-Generalizing shamelessly, we compare here the steps required to do an 
+Generalizing shamelessly, we compare here the steps required to do an
 ``UPDATE`` with the step required to do a ``SELECT``:
 
 +------------------------------------------------+-----------------------+
@@ -813,14 +815,14 @@ Generalizing shamelessly, we compare here the steps required to do an
 | Write row back to file                         |                       |
 +------------------------------------------------+-----------------------+
 
-The bottom line is: changes cost more than queries. Be consoled by the thought 
-that updates are less frequent than reads (in a bank that we used to work for, 
-we measured the ratio as 1 to 1,000). In fact, both programmers and users are 
-willing to sacrifice a lot of extra trouble during data changes -- constructing 
-an index, say -- if the result is a little less trouble during queries. The 
-investment should not merely be to save speed, but to save trouble. That is why 
-there are many mechanisms for guaranteeing that the data is valid. The makers 
-of SQL were well aware that updates need care and protection. 
+The bottom line is: changes cost more than queries. Be consoled by the thought
+that updates are less frequent than reads (in a bank that we used to work for,
+we measured the ratio as 1 to 1,000). In fact, both programmers and users are
+willing to sacrifice a lot of extra trouble during data changes -- constructing
+an index, say -- if the result is a little less trouble during queries. The
+investment should not merely be to save speed, but to save trouble. That is why
+there are many mechanisms for guaranteeing that the data is valid. The makers
+of SQL were well aware that updates need care and protection.
 
 *Bulk Changes*
 --------------
@@ -831,10 +833,10 @@ extremely slow. There are some DBMS-specific ways to reduce the pain:
 
 * Use a vendor utility for multiple insertions (such as Oracle's SQLLOAD).
 
-* Pass and retrieve arrays of rows with one call (ODBC's 
+* Pass and retrieve arrays of rows with one call (ODBC's
   ``SQLBulkOperations``).
 
-* Access the underlying DBMS files directly (possible if the DBMS uses a 
+* Access the underlying DBMS files directly (possible if the DBMS uses a
   non-proprietary file format such as comma-delimited, or ``.dbf``).
 
 * Drop indexes and re-create them after the update.
@@ -862,10 +864,10 @@ And here's an equivalent ``UPDATE`` statement that might be a bit faster:
      column_1 = 'Jonson'
     WHERE column_1 <> 'Jonson' OR column_1 IS NULL;
 
-The reasoning here is that if ``COLUMN_1`` already has ``'Jonson'`` in it, 
-there's no point setting it to ``'Jonson'``. It's a mechanical process: just 
-look at what's in the ``SET`` clause, and put the reverse in the ``WHERE`` 
-clause. Here's another example: 
+The reasoning here is that if ``COLUMN_1`` already has ``'Jonson'`` in it,
+there's no point setting it to ``'Jonson'``. It's a mechanical process: just
+look at what's in the ``SET`` clause, and put the reverse in the ``WHERE``
+clause. Here's another example:
 
 ::
 
@@ -880,8 +882,8 @@ And here's an equivalent ``UPDATE`` statement that might be a bit faster:
      column_1 = column_1 * 1.1
    WHERE column_1 <> 0;
 
-The reasoning here is that if ``COLUMN_1`` is zero or ``NULL``, then 
-multiplication can't affect it. There are analogous observations for 
+The reasoning here is that if ``COLUMN_1`` is zero or ``NULL``, then
+multiplication can't affect it. There are analogous observations for
 addition, division and subtraction.
 
 **2 -- Do Multiple Updates in One Pass**
@@ -911,7 +913,7 @@ And here's how to do it faster, in one pass:
                  WHERE balance <> 0
                END;
 
-Often it's just a matter of anticipating what other jobs are likely to come 
+Often it's just a matter of anticipating what other jobs are likely to come
 up in the near future, for the same data.
 
 Dialects
@@ -920,17 +922,17 @@ Dialects
 Data change is a stable section of SQL. All vendors support it, few vendors
 offer any variations or extensions. The ones that you might run into are:
 
-* Dropped ``INTO`` clause, for example ``INSERT Employees VALUES (...);``, 
+* Dropped ``INTO`` clause, for example ``INSERT Employees VALUES (...);``,
   supported by Sybase.
 
-* Multi-column ``SET`` clauses, for example ``UPDATE Employees SET 
+* Multi-column ``SET`` clauses, for example ``UPDATE Employees SET
   (column1,column2) = (column3,column4)``, supported by Oracle.
 
-* ``TRUNCATE`` -- to delete all rows but leave definition intact, supported 
+* ``TRUNCATE`` -- to delete all rows but leave definition intact, supported
   by Oracle 7.
 
-At the time of writing, we know of no vendor with complete support for the SQL3 
-"update a join" feature. Many have partial support, though. This is the sort of 
-feature that attracts awed attention (it's hard to implement), but the 
-important things are before that: it's best to look for a clean, simple 
-implementation. 
+At the time of writing, we know of no vendor with complete support for the SQL3
+"update a join" feature. Many have partial support, though. This is the sort of
+feature that attracts awed attention (it's hard to implement), but the
+important things are before that: it's best to look for a clean, simple
+implementation.

--- a/docs/chapters/36.rst
+++ b/docs/chapters/36.rst
@@ -4,45 +4,47 @@
 Chapter 36 -- SQL Transactions
 ==============================
 
-*"An SQL-transaction (transaction) is a sequence of executions of 
-SQL-statements that is atomic with respect to recovery. That is to say: either 
-the execution result is completely successful, or it has no effect on any 
-SQL-schemas or SQL-data."* 
+.. include:: ../_include/note.rst
 
-*-- The SQL Standard* 
+*"An SQL-transaction (transaction) is a sequence of executions of
+SQL-statements that is atomic with respect to recovery. That is to say: either
+the execution result is completely successful, or it has no effect on any
+SQL-schemas or SQL-data."*
 
-A *transaction* is an ordered set of operations (of SQL statements). The 
-effects of a transaction -- the data changes and Catalog changes -- are 
-considered as an indivisible group. Either all the effects happen, or none of 
-them do. This all-or-nothing requirement is called *atomicity*. Atomicity is 
-actually one of four requirements of an ideal transaction: 
+*-- The SQL Standard*
+
+A *transaction* is an ordered set of operations (of SQL statements). The
+effects of a transaction -- the data changes and Catalog changes -- are
+considered as an indivisible group. Either all the effects happen, or none of
+them do. This all-or-nothing requirement is called *atomicity*. Atomicity is
+actually one of four requirements of an ideal transaction:
 
 1. **A**\tomic -- the group of operations can't be broken up.
 
-2. **C**\onsistent -- at transaction beginning and end, the database is 
+2. **C**\onsistent -- at transaction beginning and end, the database is
    consistent.
 
 3. **I**\solated -- other transactions have no affect on this transaction.
 
 4. **D**\urable -- once a change happens it's persistent (i.e.: permanent).
 
-From the initial letters of these requirements, these are called the ACID 
+From the initial letters of these requirements, these are called the ACID
 requirements.
 
-There are one to many operations in a transaction. There are one to many 
-transactions in an SQL-session. Transactions within an SQL-session do not 
-overlap each other. The initiation of a transaction happens (generally 
-speaking) with the first SQL data-access statement. The end of a transaction 
-happens with one of the two -- vitally important! -- "transaction terminator" 
-statements: ``COMMIT`` or ``ROLLBACK``. 
+There are one to many operations in a transaction. There are one to many
+transactions in an SQL-session. Transactions within an SQL-session do not
+overlap each other. The initiation of a transaction happens (generally
+speaking) with the first SQL data-access statement. The end of a transaction
+happens with one of the two -- vitally important! -- "transaction terminator"
+statements: ``COMMIT`` or ``ROLLBACK``.
 
-**A logical grouping of operations** -- Maybe dBASE and Paradox programmers (who 
-haven't encountered transactions before) will ask: why is Atomicity a 
-transaction requirement? We could answer: it is analogous to the way that SQL 
-deals with sets rather than individual rows and that we prefer to deal with 
-groups, it's policy. More cogently, we could answer: if a set of operations are 
-a logical unity, then they should also be a physical unity. Let us prove that 
-with a much-used conventional example, the bank transfer: 
+**A logical grouping of operations** -- Maybe dBASE and Paradox programmers (who
+haven't encountered transactions before) will ask: why is Atomicity a
+transaction requirement? We could answer: it is analogous to the way that SQL
+deals with sets rather than individual rows and that we prefer to deal with
+groups, it's policy. More cogently, we could answer: if a set of operations are
+a logical unity, then they should also be a physical unity. Let us prove that
+with a much-used conventional example, the bank transfer:
 
 ::
 
@@ -51,33 +53,33 @@ with a much-used conventional example, the bank transfer:
    Deposit $1000 to Joe's chequing account.
    [[ logical end of transaction ]]
 
-Now, suppose that some external event separated Joe's withdrawal from his 
-deposit -- a system crash, or a tick of the clock so that the operations take 
-place on two different days, or a separate overlapping transaction on the same 
-accounts. Any of these would cause us to end up with a bad "database state", 
-because the data will show a withdrawal that shouldn't happen according to 
-company rules or accounting principles -- to say nothing of what Joe will 
-think! 
+Now, suppose that some external event separated Joe's withdrawal from his
+deposit -- a system crash, or a tick of the clock so that the operations take
+place on two different days, or a separate overlapping transaction on the same
+accounts. Any of these would cause us to end up with a bad "database state",
+because the data will show a withdrawal that shouldn't happen according to
+company rules or accounting principles -- to say nothing of what Joe will
+think!
 
-In SQL, such a state of affairs is theoretically impossible. First of all, if 
-the system crashes and we bring it up again, we will not see any record of the 
-withdrawal -- that's what "atomic with respect to recovery" guarantees. Second, 
-the clock does not tick -- ``CURRENT_TIME`` and all other niladic datetime 
-function values are frozen throughout the life of a transaction. And third, 
-there can be no overlapping transaction -- due to the principle of *Isolation*, 
-which we'll examine in greater detail as part of multi-user and multi-tasking 
-considerations in our chapter on concurrency. 
+In SQL, such a state of affairs is theoretically impossible. First of all, if
+the system crashes and we bring it up again, we will not see any record of the
+withdrawal -- that's what "atomic with respect to recovery" guarantees. Second,
+the clock does not tick -- ``CURRENT_TIME`` and all other niladic datetime
+function values are frozen throughout the life of a transaction. And third,
+there can be no overlapping transaction -- due to the principle of *Isolation*,
+which we'll examine in greater detail as part of multi-user and multi-tasking
+considerations in our chapter on concurrency.
 
-The point of the example is to show that the withdrawal and the deposit must 
-succeed together, or fail together. The transaction criterion is that all SQL 
-statements within it must constitute a logical unit of work -- that is, a 
-sequence (ordered set) of operations (executions of SQL statements) that take 
-the DBMS from a consistent state to a consistent state (possibly by changing 
-nothing -- a transaction can consist of a series of ``SELECT`` statements). 
+The point of the example is to show that the withdrawal and the deposit must
+succeed together, or fail together. The transaction criterion is that all SQL
+statements within it must constitute a logical unit of work -- that is, a
+sequence (ordered set) of operations (executions of SQL statements) that take
+the DBMS from a consistent state to a consistent state (possibly by changing
+nothing -- a transaction can consist of a series of ``SELECT`` statements).
 
-It's your job to figure out what operations fit together as a logical unit of 
-work. It's the DBMS's job to ensure that the operations will all fail, or all 
-succeed, together. 
+It's your job to figure out what operations fit together as a logical unit of
+work. It's the DBMS's job to ensure that the operations will all fail, or all
+succeed, together.
 
 .. rubric:: Table of Contents
 
@@ -87,35 +89,35 @@ succeed, together.
 Initiating Transactions
 =======================
 
-A transaction begins, if it hasn't already begun, when one of these SQL 
+A transaction begins, if it hasn't already begun, when one of these SQL
 statements is executed:
 
-* Any SQL-Schema statement: ``ALTER``, ``CREATE``, ``DROP``, ``GRANT``, 
+* Any SQL-Schema statement: ``ALTER``, ``CREATE``, ``DROP``, ``GRANT``,
   ``REVOKE``.
 
-* The SQL-data statements ``OPEN``, ``CLOSE``, ``FETCH``, ``SELECT``, 
+* The SQL-data statements ``OPEN``, ``CLOSE``, ``FETCH``, ``SELECT``,
   ``INSERT``, ``UPDATE``, ``DELETE``, ``FREE LOCATOR``, ``HOLD LOCATOR``.
 
-* One of the new SQL3 statements ``START TRANSACTION``, ``COMMIT AND 
+* One of the new SQL3 statements ``START TRANSACTION``, ``COMMIT AND
   CHAIN``, ``ROLLBACK AND CHAIN``.
 
-* The SQL-control statement ``RETURN``, if it causes the evaluation of a 
+* The SQL-control statement ``RETURN``, if it causes the evaluation of a
   subquery when there is no current transaction.
 
-It's usually a bad idea to start a transaction with an SQL-Schema statement, 
-and usually you'll find that the new SQL3 statements aren't implemented yet, so 
-in practice: your DBMS initiates a transaction when you issue ``INSERT``, 
-``UPDATE``, ``DELETE`` or any variant of ``SELECT``. Once a transaction is 
-initiated, all subsequent SQL operations will be part of the same transaction 
-until an SQL termination (``COMMIT`` or ``ROLLBACK``) happens. 
+It's usually a bad idea to start a transaction with an SQL-Schema statement,
+and usually you'll find that the new SQL3 statements aren't implemented yet, so
+in practice: your DBMS initiates a transaction when you issue ``INSERT``,
+``UPDATE``, ``DELETE`` or any variant of ``SELECT``. Once a transaction is
+initiated, all subsequent SQL operations will be part of the same transaction
+until an SQL termination (``COMMIT`` or ``ROLLBACK``) happens.
 
-Here's an example of an SQL-session, showing transaction boundaries. It 
-contains two transactions, illustrated by a series of SQL statements 
-(technically, the SQL-session and transactions are executions of these 
-statements, not the statements themselves.) Not every SQL statement shown is 
-within a transaction -- ``CONNECT``, ``SET SESSION AUTHORIZATION`` and 
-``DISCONNECT`` are not transaction-initiating statements. (Look for 
-explanations of these statements in our chapter on SQL-sessions.) 
+Here's an example of an SQL-session, showing transaction boundaries. It
+contains two transactions, illustrated by a series of SQL statements
+(technically, the SQL-session and transactions are executions of these
+statements, not the statements themselves.) Not every SQL statement shown is
+within a transaction -- ``CONNECT``, ``SET SESSION AUTHORIZATION`` and
+``DISCONNECT`` are not transaction-initiating statements. (Look for
+explanations of these statements in our chapter on SQL-sessions.)
 
 ::
 
@@ -136,74 +138,74 @@ explanations of these statements in our chapter on SQL-sessions.)
 Terminating Transactions
 ========================
 
-There are two transaction-terminating statements: ``COMMIT`` and ``ROLLBACK``. 
-The first saves all changes, while the second destroys all changes. Although 
-they don't do exactly the same thing, they both have several similar effects on 
-your SQL-data. We'll talk about these similarities first. 
+There are two transaction-terminating statements: ``COMMIT`` and ``ROLLBACK``.
+The first saves all changes, while the second destroys all changes. Although
+they don't do exactly the same thing, they both have several similar effects on
+your SQL-data. We'll talk about these similarities first.
 
-When ``COMMIT`` or ``ROLLBACK`` are executed, the transaction ends. There is no 
-Privilege for ``COMMIT`` or ``ROLLBACK``: any <AuthorizationID> can issue a 
-``COMMIT`` statement or a ``ROLLBACK`` statement; they are always legal. 
+When ``COMMIT`` or ``ROLLBACK`` are executed, the transaction ends. There is no
+Privilege for ``COMMIT`` or ``ROLLBACK``: any <AuthorizationID> can issue a
+``COMMIT`` statement or a ``ROLLBACK`` statement; they are always legal.
 
-[Obscure Rule] -- we'll talk about Cursors in our chapters on binding styles, 
-prepared statements in our chapter on SQL/CLI statements and locks in our 
-chapter on concurrency. 
+[Obscure Rule] -- we'll talk about Cursors in our chapters on binding styles,
+prepared statements in our chapter on SQL/CLI statements and locks in our
+chapter on concurrency.
 
-* The effect of a ``COMMIT`` statement or a ``ROLLBACK`` statement on any 
-  Cursors that are open at the time is that those Cursors are normally closed. 
-  This means that, if you've instructed your DBMS to retrieve some rows and are 
-  going through those rows with a ``FETCH`` statement, you'll have to instruct 
-  your DBMS to get those rows for you again -- the rule is that ``COMMIT`` and 
-  ``ROLLBACK`` cause destruction of result sets. The exception to this rule is 
-  that some advanced DBMSs have an option, called the *holdable Cursor*, which 
-  allows Cursor work to go on after ``COMMIT``, at considerable cost in 
-  performance. Even holdable Cursors are destroyed by ``ROLLBACK``. 
+* The effect of a ``COMMIT`` statement or a ``ROLLBACK`` statement on any
+  Cursors that are open at the time is that those Cursors are normally closed.
+  This means that, if you've instructed your DBMS to retrieve some rows and are
+  going through those rows with a ``FETCH`` statement, you'll have to instruct
+  your DBMS to get those rows for you again -- the rule is that ``COMMIT`` and
+  ``ROLLBACK`` cause destruction of result sets. The exception to this rule is
+  that some advanced DBMSs have an option, called the *holdable Cursor*, which
+  allows Cursor work to go on after ``COMMIT``, at considerable cost in
+  performance. Even holdable Cursors are destroyed by ``ROLLBACK``.
 
-* The effect of a ``COMMIT`` statement or a ``ROLLBACK`` statement on 
-  prepared SQL statements is that they might become unprepared. This is one of 
-  the few "implementation-dependent" behaviour characteristics which has real 
-  significance to programmers. It simply means that if you have prepared SQL 
-  statements, you might have to prepare them again. 
+* The effect of a ``COMMIT`` statement or a ``ROLLBACK`` statement on
+  prepared SQL statements is that they might become unprepared. This is one of
+  the few "implementation-dependent" behaviour characteristics which has real
+  significance to programmers. It simply means that if you have prepared SQL
+  statements, you might have to prepare them again.
 
-* The effect of a ``COMMIT`` statement or a ``ROLLBACK`` statement on locks 
-  is that they are released. 
+* The effect of a ``COMMIT`` statement or a ``ROLLBACK`` statement on locks
+  is that they are released.
 
-Any information that you gained in the last transaction might have become 
-untrue for the next transaction -- transactions are supposed to be isolated 
-from each other. So it's understandable that the transaction terminators cause 
-Cursors to be closed, statements to be unprepared and locks to be released. If 
-you want to be sure what the exact behaviour of a particular DBMS is, there's a 
-CLI function -- ``SQLGetInfo`` -- that gives that information. But the easy way 
-to write portable code is to assume the worst: always close all Cursors before 
-``COMMIT`` or ``ROLLBACK`` and always re-prepare all SQL statements after 
-``COMMIT`` or ``ROLLBACK``. 
+Any information that you gained in the last transaction might have become
+untrue for the next transaction -- transactions are supposed to be isolated
+from each other. So it's understandable that the transaction terminators cause
+Cursors to be closed, statements to be unprepared and locks to be released. If
+you want to be sure what the exact behaviour of a particular DBMS is, there's a
+CLI function -- ``SQLGetInfo`` -- that gives that information. But the easy way
+to write portable code is to assume the worst: always close all Cursors before
+``COMMIT`` or ``ROLLBACK`` and always re-prepare all SQL statements after
+``COMMIT`` or ``ROLLBACK``.
 
 *COMMIT Statement*
 ------------------
 
-The ``COMMIT`` statement ends a transaction, saving any changes to SQL-data so 
-that they become visible to subsequent transactions. The required syntax for 
-the ``COMMIT`` statement is: 
+The ``COMMIT`` statement ends a transaction, saving any changes to SQL-data so
+that they become visible to subsequent transactions. The required syntax for
+the ``COMMIT`` statement is:
 
 ::
 
     COMMIT [ WORK ] [ AND [ NO ] CHAIN ]
 
-``COMMIT`` is the more important transaction terminator, as well as the more 
-interesting one. (Though some would use the word "troublesome" rather than 
-"interesting" here.) The basic form of the ``COMMIT`` statement is its SQL-92 
-syntax: simply the <keyword> ``COMMIT`` (the <keyword> ``WORK`` is simply noise 
-and can be omitted without changing the effect). 
+``COMMIT`` is the more important transaction terminator, as well as the more
+interesting one. (Though some would use the word "troublesome" rather than
+"interesting" here.) The basic form of the ``COMMIT`` statement is its SQL-92
+syntax: simply the <keyword> ``COMMIT`` (the <keyword> ``WORK`` is simply noise
+and can be omitted without changing the effect).
 
-The optional ``AND CHAIN`` clause is a convenience for initiating a new 
-transaction as soon as the old transaction terminates. If ``AND CHAIN`` is 
-specified, then there is effectively nothing between the old and new 
-transactions, although they remain separate. The characteristics of the new 
-transaction will be the same as the characteristics of the old one -- that is, 
-the new transaction will have the same access mode, isolation level and 
-diagnostics area size (we'll discuss all of these shortly) as the transaction 
-just terminated. The ``AND NO CHAIN`` option just tells your DBMS to end the 
-transaction -- that is, these four SQL statements are equivalent: 
+The optional ``AND CHAIN`` clause is a convenience for initiating a new
+transaction as soon as the old transaction terminates. If ``AND CHAIN`` is
+specified, then there is effectively nothing between the old and new
+transactions, although they remain separate. The characteristics of the new
+transaction will be the same as the characteristics of the old one -- that is,
+the new transaction will have the same access mode, isolation level and
+diagnostics area size (we'll discuss all of these shortly) as the transaction
+just terminated. The ``AND NO CHAIN`` option just tells your DBMS to end the
+transaction -- that is, these four SQL statements are equivalent:
 
 ::
 
@@ -212,7 +214,7 @@ transaction -- that is, these four SQL statements are equivalent:
    COMMIT AND NO CHAIN;
    COMMIT WORK AND NO CHAIN;
 
-All of them end a transaction without saving any transaction 
+All of them end a transaction without saving any transaction
 characteristics. The only other options, the equivalent statements:
 
 ::
@@ -220,70 +222,70 @@ characteristics. The only other options, the equivalent statements:
    COMMIT AND CHAIN;
    COMMIT WORK AND CHAIN;
 
-both tell your DBMS to end a transaction, but to save that transaction's 
-characteristics for the next transaction. If you want to restrict your code to 
-Core SQL, don't use ``AND CHAIN`` or ``AND NO CHAIN`` with ``COMMIT``. 
+both tell your DBMS to end a transaction, but to save that transaction's
+characteristics for the next transaction. If you want to restrict your code to
+Core SQL, don't use ``AND CHAIN`` or ``AND NO CHAIN`` with ``COMMIT``.
 
 What's supposed to happen with ``COMMIT`` is:
 
-* SQL Cursors are closed, SQL statements are unprepared and locks are 
-  released, as noted earlier. Any savepoints established in the current 
+* SQL Cursors are closed, SQL statements are unprepared and locks are
+  released, as noted earlier. Any savepoints established in the current
   transaction are also destroyed.
 
-* Any temporary Table whose definition includes ``ON COMMIT DELETE ROWS`` gets 
+* Any temporary Table whose definition includes ``ON COMMIT DELETE ROWS`` gets
   its rows deleted.
 
-* All deferred Constraints are checked. Any Constraint that is found to be 
-  violated will cause a "failed ``COMMIT``": your DBMS will implicitly and 
+* All deferred Constraints are checked. Any Constraint that is found to be
+  violated will cause a "failed ``COMMIT``": your DBMS will implicitly and
   automatically do a ``ROLLBACK``.
 
-* If all goes well, any changes to your SQL-data -- whether they are 
-  changes to Objects or to data values -- become "persistent", and thus 
+* If all goes well, any changes to your SQL-data -- whether they are
+  changes to Objects or to data values -- become "persistent", and thus
   visible to subsequent transactions.
 
-Once a change is committed, you've reached the point of no turning back (or no 
-rolling back, to carry on with SQL terms). The most important effects are that 
-committed changes are no longer isolated (other transactions can "see" them 
-now), and they are durable -- if you turn all your computers off, then turn 
-them back on again, then look at your data, you will still see the changes. If 
-your computers are conventional, there's an easy explanation for that: the DBMS 
-must write to disk files. 
+Once a change is committed, you've reached the point of no turning back (or no
+rolling back, to carry on with SQL terms). The most important effects are that
+committed changes are no longer isolated (other transactions can "see" them
+now), and they are durable -- if you turn all your computers off, then turn
+them back on again, then look at your data, you will still see the changes. If
+your computers are conventional, there's an easy explanation for that: the DBMS
+must write to disk files.
 
-For once the easy explanation is the true one, but the mechanics aren't as easy 
-as you might think. For one thing, during a transaction, your DBMS can't simply 
-overwrite the information in the current database files because if it did, the 
-"before" state of the database (before the transaction started) would become 
-unknown. In that case, how could ``ROLLBACK`` happen? So instead of writing 
-changes as they happen, your DBMS has to keep information about the before and 
-after states as long as the transaction is going on. There are two ways to do 
-this: with a backup copy and with a log file. 
+For once the easy explanation is the true one, but the mechanics aren't as easy
+as you might think. For one thing, during a transaction, your DBMS can't simply
+overwrite the information in the current database files because if it did, the
+"before" state of the database (before the transaction started) would become
+unknown. In that case, how could ``ROLLBACK`` happen? So instead of writing
+changes as they happen, your DBMS has to keep information about the before and
+after states as long as the transaction is going on. There are two ways to do
+this: with a backup copy and with a log file.
 
-The backup copy solution is familiar to anyone who has ever made a ``.BAK`` 
-file with a text editor. All the DBMS has to do is make a copy of the database 
-files when the transaction starts, make changes to the copied files when SQL 
-statements that change something are executed and then, at ``COMMIT`` time, 
-destroy the original files and rename the copies. (And if ``ROLLBACK`` happens 
-instead, it simply destroys the copies.) Though the plan is simple, the backup 
-copy solution has always suffered from the problem that database files can be 
-large, and therefore in practice a DBMS can only back up certain parts of 
-certain files -- which makes tracking the changes complex. And the complexities 
-grow in SQL3, because "savepoints" -- which we'll discuss shortly -- require 
-the existence of an indefinite number of backup copies. So this solution will 
-probably be abandoned soon. 
+The backup copy solution is familiar to anyone who has ever made a ``.BAK``
+file with a text editor. All the DBMS has to do is make a copy of the database
+files when the transaction starts, make changes to the copied files when SQL
+statements that change something are executed and then, at ``COMMIT`` time,
+destroy the original files and rename the copies. (And if ``ROLLBACK`` happens
+instead, it simply destroys the copies.) Though the plan is simple, the backup
+copy solution has always suffered from the problem that database files can be
+large, and therefore in practice a DBMS can only back up certain parts of
+certain files -- which makes tracking the changes complex. And the complexities
+grow in SQL3, because "savepoints" -- which we'll discuss shortly -- require
+the existence of an indefinite number of backup copies. So this solution will
+probably be abandoned soon.
 
-The log file solution is therefore what most serious DBMSs use today. Every 
-change to the database is written to a log file, in the form of a copy of the 
-new row contents. For example, suppose that there is a Table called 
-``SAVINGS``, containing three rows (Sam, Joe, Mary) with balances of ($1000, 
-$2000, $3000) respectively. If you issue this SQL statement: 
+The log file solution is therefore what most serious DBMSs use today. Every
+change to the database is written to a log file, in the form of a copy of the
+new row contents. For example, suppose that there is a Table called
+``SAVINGS``, containing three rows (Sam, Joe, Mary) with balances of ($1000,
+$2000, $3000) respectively. If you issue this SQL statement:
 
 ::
 
    UPDATE savings SET balance = balance + 1000.00 WHERE client = 'Joe';
 
-a DBMS that uses log files will write a new row in the log file to reflect the 
-required change: it won't make any changes (yet) in the original database file. 
-It then has a situation that looks something like this: 
+a DBMS that uses log files will write a new row in the log file to reflect the
+required change: it won't make any changes (yet) in the original database file.
+It then has a situation that looks something like this:
 
 +--------------------------+--------------------------------------------------------------------+
 | ``SAVINGS`` Table        | LOG                                                                |
@@ -297,10 +299,10 @@ It then has a situation that looks something like this:
 | Mary       | 3000.00     |            |           |                |            |             |
 +------------+-------------+------------+-----------+----------------+------------+-------------+
 
-This is called a write-ahead log, because the write to the log file occurs 
-before the write to the database. Specifically, it's a by-row write-ahead log, 
-because the entries in the log are copies of rows. The plan now, for any later 
-accesses during this transaction, is: 
+This is called a write-ahead log, because the write to the log file occurs
+before the write to the database. Specifically, it's a by-row write-ahead log,
+because the entries in the log are copies of rows. The plan now, for any later
+accesses during this transaction, is:
 
 * If a ``SELECT`` happens, then the search must include a search of the log
   file as well as the main file. Any entries in log will override the
@@ -314,156 +316,156 @@ accesses during this transaction, is:
 
 * Most conveniently, if the system crashes, then the log is cleared.
 
-There is a different log for each user and the file IO can get busy. One thing 
-to emphasize about this system is that the log file is constantly growing: 
-every data change operation requires additional disk space. And after each data 
-change, the next selection will be a tiny bit slower, because there are more 
-log-file records to look aside at. For efficiency reasons, some DBMSs offer 
-options for batched operations: you can suppress log-file writing and write 
-directly to the main database files, and/or you can clear the log at the end of 
-every transaction. If log-file writing is suppressed, performance improves but 
-safety declines and transaction management becomes impossible. 
+There is a different log for each user and the file IO can get busy. One thing
+to emphasize about this system is that the log file is constantly growing:
+every data change operation requires additional disk space. And after each data
+change, the next selection will be a tiny bit slower, because there are more
+log-file records to look aside at. For efficiency reasons, some DBMSs offer
+options for batched operations: you can suppress log-file writing and write
+directly to the main database files, and/or you can clear the log at the end of
+every transaction. If log-file writing is suppressed, performance improves but
+safety declines and transaction management becomes impossible.
 
-Let us say that a ``COMMIT`` at last happens, and it's time to "terminate the 
-transaction while making all data changes persistent". The DBMS now has to 
-issue an "OS commit", then read all the rows from the log file and put them in 
-the database, then issue another "OS commit". We're using the phrase "OS 
-commit" (operating-system commit) for what Microsoft usually calls "flushing of 
-write buffers". The DBMS must ensure that the log file is physically written to 
-the disk before the changes start, and ensure that the database changes are 
-physically written to the disk after the changes start. If it cannot ensure 
-these things, then crash recovery may occasionally be impossible. Some 
-operating systems will refuse to co-operate here because safety considerations 
-get in the way of clever tricks like "write-ahead caching" and "elevator 
-seeking". The DBMS won't detect OS chicanery, so you should run this 
-experiment: 
+Let us say that a ``COMMIT`` at last happens, and it's time to "terminate the
+transaction while making all data changes persistent". The DBMS now has to
+issue an "OS commit", then read all the rows from the log file and put them in
+the database, then issue another "OS commit". We're using the phrase "OS
+commit" (operating-system commit) for what Microsoft usually calls "flushing of
+write buffers". The DBMS must ensure that the log file is physically written to
+the disk before the changes start, and ensure that the database changes are
+physically written to the disk after the changes start. If it cannot ensure
+these things, then crash recovery may occasionally be impossible. Some
+operating systems will refuse to co-operate here because safety considerations
+get in the way of clever tricks like "write-ahead caching" and "elevator
+seeking". The DBMS won't detect OS chicanery, so you should run this
+experiment:
 
 1. ``UPDATE`` a large number of rows (at least ten thousand).
 
 2. Issue a ``COMMIT``.
 
-3. Run to the main fuse box and cut off power to all computers in the 
+3. Run to the main fuse box and cut off power to all computers in the
    building. Make sure the cutoff happens before the ``COMMIT`` finishes.
 
-4. Restore power and bring your system back up. Look around for temporary 
-   files, inconsistent data or corrupt indexes.  If you find them, then your 
-   OS is not co-operating with your DBMS, so be sure to always give both 
-   your DBMS and your OS plenty of time to write all changes. NOTE: Since 
+4. Restore power and bring your system back up. Look around for temporary
+   files, inconsistent data or corrupt indexes.  If you find them, then your
+   OS is not co-operating with your DBMS, so be sure to always give both
+   your DBMS and your OS plenty of time to write all changes. NOTE: Since
    this test usually fails, you should backup your database first!
 
-Adding up all the operations, we can see that a secure DBMS data change plus 
-``COMMIT`` is quite a slow job. At a minimum -- ignoring the effect on 
-``SELECT``\s -- there is one write to a log file, one read of a log file and 
-one write to a DBMS file. If the OS co-operates, this is done with full 
-flushing, so these are physical uncached file IO operations. The temptation is 
-to skip some of the onerous activity, in order to make the DBMS run faster. 
-Since most magazine reviews include benchmarks of speed but not of security, 
-the DBMS vendor is subject to this temptation too. 
+Adding up all the operations, we can see that a secure DBMS data change plus
+``COMMIT`` is quite a slow job. At a minimum -- ignoring the effect on
+``SELECT``\s -- there is one write to a log file, one read of a log file and
+one write to a DBMS file. If the OS co-operates, this is done with full
+flushing, so these are physical uncached file IO operations. The temptation is
+to skip some of the onerous activity, in order to make the DBMS run faster.
+Since most magazine reviews include benchmarks of speed but not of security,
+the DBMS vendor is subject to this temptation too.
 
 The Two-Phase COMMIT
 ____________________
 
-In an ordinary situation, ``COMMIT`` is an instruction to the DBMS, and it's 
-been convenient to say that the DBMS is handling all the necessary operations 
-(with the dubious help of the operating system, of course). That convenient 
-assumption becomes untrue if we consider very large systems. To be precise, we 
-have to take into account these possibilities: 
+In an ordinary situation, ``COMMIT`` is an instruction to the DBMS, and it's
+been convenient to say that the DBMS is handling all the necessary operations
+(with the dubious help of the operating system, of course). That convenient
+assumption becomes untrue if we consider very large systems. To be precise, we
+have to take into account these possibilities:
 
-* there are multiple DBMS servers; 
+* there are multiple DBMS servers;
 
-* there is a DBMS server, and some other program which also needs to "commit". 
+* there is a DBMS server, and some other program which also needs to "commit".
 
-In such environments, the ``COMMIT`` job must be handled by some higher 
-authority -- call it a *transaction manager* -- whose job is to coordinate the 
-various jobs which want the commit to happen. The transaction manager then 
-becomes responsible for the guarantee that all transactions are atomic, since 
-it alone can ensure that all programs commit together, or not at all. 
+In such environments, the ``COMMIT`` job must be handled by some higher
+authority -- call it a *transaction manager* -- whose job is to coordinate the
+various jobs which want the commit to happen. The transaction manager then
+becomes responsible for the guarantee that all transactions are atomic, since
+it alone can ensure that all programs commit together, or not at all.
 
-The coordination requires that all ``COMMIT``\s take place in two phases -- 
-first lining up the ducks, then shooting them. The transaction manager in Phase 
-One will poll all the programs, asking: are you ready? If any of the responses 
-is no, or any response is missing, the system-wide commit fails. Meanwhile, all 
-the polled programs are gearing up, refusing other requests for attention, and 
-standing ready for the final order to fire. In Phase Two, the transaction 
-manager issues a final instruction, system-wide, and the synchronized commit 
-actually happens. In this scenario, there is one global transaction which 
-encompasses several subordinate transactions. It will always be possible that 
-the encompassing transaction can fail even though any given DBMS server is 
-ready to proceed. In such a case -- once again -- you might get a ``ROLLBACK`` 
-when you ask for a ``COMMIT``. 
+The coordination requires that all ``COMMIT``\s take place in two phases --
+first lining up the ducks, then shooting them. The transaction manager in Phase
+One will poll all the programs, asking: are you ready? If any of the responses
+is no, or any response is missing, the system-wide commit fails. Meanwhile, all
+the polled programs are gearing up, refusing other requests for attention, and
+standing ready for the final order to fire. In Phase Two, the transaction
+manager issues a final instruction, system-wide, and the synchronized commit
+actually happens. In this scenario, there is one global transaction which
+encompasses several subordinate transactions. It will always be possible that
+the encompassing transaction can fail even though any given DBMS server is
+ready to proceed. In such a case -- once again -- you might get a ``ROLLBACK``
+when you ask for a ``COMMIT``.
 
-And that is what two-phase commit is. It's strictly a problem for very large 
-and secure environments, but it's reassuring to know there are mechanisms for 
-coordinating different and heterogeneous servers. 
+And that is what two-phase commit is. It's strictly a problem for very large
+and secure environments, but it's reassuring to know there are mechanisms for
+coordinating different and heterogeneous servers.
 
 *SAVEPOINT Statement*
 ---------------------
 
-The ``SAVEPOINT`` statement establishes a savepoint at the current point in the 
+The ``SAVEPOINT`` statement establishes a savepoint at the current point in the
 current transaction. The required syntax for the ``SAVEPOINT`` statement is:
 
 ::
 
     SAVEPOINT <savepoint name> | <simple target specification>
 
-You can establish multiple savepoints for a single transaction (up to some 
-maximum defined by your DBMS). You specify a savepoint either with a simple 
-target specification that has an integer data type -- that is, with a <host 
-parameter name> (e.g.: ``SAVEPOINT :savepoint_integer_variable``), an <SQL 
-parameter name> (e.g.: ``SAVEPOINT savepoint_integer``) or a "known not 
-nullable" <Column reference> (e.g.: ``SAVEPOINT Table_1.integer_column``) -- or 
-with a <savepoint name>. 
+You can establish multiple savepoints for a single transaction (up to some
+maximum defined by your DBMS). You specify a savepoint either with a simple
+target specification that has an integer data type -- that is, with a <host
+parameter name> (e.g.: ``SAVEPOINT :savepoint_integer_variable``), an <SQL
+parameter name> (e.g.: ``SAVEPOINT savepoint_integer``) or a "known not
+nullable" <Column reference> (e.g.: ``SAVEPOINT Table_1.integer_column``) -- or
+with a <savepoint name>.
 
-If you use a <simple target specification> your DBMS will make up an integer 
-(greater than zero) and assign it to the target. For example, ``SAVEPOINT :x`` 
-will get a value for ``x`` which you can use in subsequent savepoint-related 
-statements. 
+If you use a <simple target specification> your DBMS will make up an integer
+(greater than zero) and assign it to the target. For example, ``SAVEPOINT :x``
+will get a value for ``x`` which you can use in subsequent savepoint-related
+statements.
 
-The modern convention is to label with names rather than numbers, so we suggest 
-that you concentrate on <savepoint name>, which must be an unqualified <regular 
-identifier> or <delimited identifier> and has a scope that includes the entire 
-transaction that you define it in. An example of a savepoint specification 
-using a savepoint name is: 
+The modern convention is to label with names rather than numbers, so we suggest
+that you concentrate on <savepoint name>, which must be an unqualified <regular
+identifier> or <delimited identifier> and has a scope that includes the entire
+transaction that you define it in. An example of a savepoint specification
+using a savepoint name is:
 
 ::
 
    SAVEPOINT point_we_may_wish_to_rollback_to;
 
-Savepoint names must be unique within their transaction. If there is 
-already a ``SAVEPOINT`` statement with the same name in the transaction, it 
+Savepoint names must be unique within their transaction. If there is
+already a ``SAVEPOINT`` statement with the same name in the transaction, it
 will be overwritten.
 
-If you want to restrict your code to Core SQL, don't use the ``SAVEPOINT`` 
+If you want to restrict your code to Core SQL, don't use the ``SAVEPOINT``
 statement.
 
 *ROLLBACK Statement*
 --------------------
 
-The ``ROLLBACK`` statement rolls back ends a transaction, destroying any 
-changes to SQL-data so that they never become visible to subsequent 
-transactions. The required syntax for the ``ROLLBACK`` statement is: 
+The ``ROLLBACK`` statement rolls back ends a transaction, destroying any
+changes to SQL-data so that they never become visible to subsequent
+transactions. The required syntax for the ``ROLLBACK`` statement is:
 
 ::
 
     ROLLBACK [ WORK ] [ AND [ NO ] CHAIN ]
     [ TO SAVEPOINT {<savepoint name> | <simple target specification>} ]
 
-The ``ROLLBACK`` statement will either end a transaction, destroying all data 
-changes that happened during any of the transaction, or it will just destroy 
-any data changes that happened since you established a savepoint. The basic 
-form of the ``ROLLBACK`` statement is its SQL-92 syntax: simply the <keyword> 
-``ROLLBACK`` (the <keyword> ``WORK`` is simply noise and can be omitted without 
-changing the effect). 
+The ``ROLLBACK`` statement will either end a transaction, destroying all data
+changes that happened during any of the transaction, or it will just destroy
+any data changes that happened since you established a savepoint. The basic
+form of the ``ROLLBACK`` statement is its SQL-92 syntax: simply the <keyword>
+``ROLLBACK`` (the <keyword> ``WORK`` is simply noise and can be omitted without
+changing the effect).
 
-The optional ``AND CHAIN`` clause is a convenience for initiating a new 
-transaction as soon as the old transaction terminates. If ``AND CHAIN`` is 
-specified, then there is effectively nothing between the old and new 
-transactions, although they remain separate. The characteristics of the new 
-transaction will be the same as the characteristics of the old one -- that is, 
-the new transaction will have the same access mode, isolation level and 
-diagnostics area size (we'll discuss all of these shortly) as the transaction 
-just terminated. The ``AND NO CHAIN`` option just tells your DBMS to end the 
-transaction -- that is, these four SQL statements are equivalent: 
+The optional ``AND CHAIN`` clause is a convenience for initiating a new
+transaction as soon as the old transaction terminates. If ``AND CHAIN`` is
+specified, then there is effectively nothing between the old and new
+transactions, although they remain separate. The characteristics of the new
+transaction will be the same as the characteristics of the old one -- that is,
+the new transaction will have the same access mode, isolation level and
+diagnostics area size (we'll discuss all of these shortly) as the transaction
+just terminated. The ``AND NO CHAIN`` option just tells your DBMS to end the
+transaction -- that is, these four SQL statements are equivalent:
 
 ::
 
@@ -472,7 +474,7 @@ transaction -- that is, these four SQL statements are equivalent:
    ROLLBACK AND NO CHAIN;
    ROLLBACK WORK AND NO CHAIN;
 
-All of them end a transaction without saving any transaction 
+All of them end a transaction without saving any transaction
 characteristics. The only other options, the equivalent statements:
 
 ::
@@ -480,34 +482,34 @@ characteristics. The only other options, the equivalent statements:
    ROLLBACK AND CHAIN;
    ROLLBACK WORK AND CHAIN;
 
-both tell your DBMS to end a transaction, but to save that transaction's 
+both tell your DBMS to end a transaction, but to save that transaction's
 characteristics for the next transaction.
 
-``ROLLBACK`` is much simpler than ``COMMIT``: it may involve no more than a few 
-deletions (of Cursors, locks, prepared SQL statements and log-file entries). 
-It's usually assumed that ``ROLLBACK`` can't fail, although such a thing is 
-conceivable (for example, an encompassing transaction might reject an attempt 
-to ``ROLLBACK`` because it's lining up for a ``COMMIT``). 
+``ROLLBACK`` is much simpler than ``COMMIT``: it may involve no more than a few
+deletions (of Cursors, locks, prepared SQL statements and log-file entries).
+It's usually assumed that ``ROLLBACK`` can't fail, although such a thing is
+conceivable (for example, an encompassing transaction might reject an attempt
+to ``ROLLBACK`` because it's lining up for a ``COMMIT``).
 
-``ROLLBACK`` cancels all effects of a transaction. It does not cancel effects 
-on objects outside the DBMS's control (for example the values in host program 
-variables or the settings made by some SQL/CLI function calls). But in general, 
-it is a convenient statement for those situations when you say "oops, this 
-isn't working" or when you simply don't care whether your temporary work 
-becomes permanent or not. 
+``ROLLBACK`` cancels all effects of a transaction. It does not cancel effects
+on objects outside the DBMS's control (for example the values in host program
+variables or the settings made by some SQL/CLI function calls). But in general,
+it is a convenient statement for those situations when you say "oops, this
+isn't working" or when you simply don't care whether your temporary work
+becomes permanent or not.
 
-Here is a moot question. If all you've been doing is ``SELECT``\s, so that 
-there have been no data changes, should you end the transaction with 
-``ROLLBACK`` or ``COMMIT``? It shouldn't really matter because both 
-``ROLLBACK`` and ``COMMIT`` do the same transaction-terminating job. However, 
-the popular conception is that ``ROLLBACK`` implies failure, so after a 
-successful series of ``SELECT`` statements the convention is to end the 
-transaction with ``COMMIT`` rather than ``ROLLBACK``. 
+Here is a moot question. If all you've been doing is ``SELECT``\s, so that
+there have been no data changes, should you end the transaction with
+``ROLLBACK`` or ``COMMIT``? It shouldn't really matter because both
+``ROLLBACK`` and ``COMMIT`` do the same transaction-terminating job. However,
+the popular conception is that ``ROLLBACK`` implies failure, so after a
+successful series of ``SELECT`` statements the convention is to end the
+transaction with ``COMMIT`` rather than ``ROLLBACK``.
 
-Some DBMSs support rollback of SQL-data change statements, but not of SQL- 
-Schema statements. This means that if you use any of (``CREATE``, ``ALTER``, 
-``DROP``, ``GRANT``, ``REVOKE``), you are implicitly committing at execution 
-time. Therefore, this sequence of operations is ambiguous: 
+Some DBMSs support rollback of SQL-data change statements, but not of SQL-
+Schema statements. This means that if you use any of (``CREATE``, ``ALTER``,
+``DROP``, ``GRANT``, ``REVOKE``), you are implicitly committing at execution
+time. Therefore, this sequence of operations is ambiguous:
 
 ::
 
@@ -515,73 +517,73 @@ time. Therefore, this sequence of operations is ambiguous:
    DROP TABLE Table_3 CASCADE;
    ROLLBACK;
 
-With a few DBMSs, the result of this sequence is that nothing permanent happens 
-because of the ``ROLLBACK``. With other DBMSs -- the majority -- the result 
-will be that both the ``INSERT`` and the ``DROP`` will go through as separate 
-transactions so the ``ROLLBACK`` will have no effect. Both results are valid 
-according to the SQL Standard -- this is just one of those 
-implementation-defined things that you have to be alert for. The best policy is 
-to assume that an SQL-Schema statement implies a new transaction, and so cannot 
-be rolled back. 
+With a few DBMSs, the result of this sequence is that nothing permanent happens
+because of the ``ROLLBACK``. With other DBMSs -- the majority -- the result
+will be that both the ``INSERT`` and the ``DROP`` will go through as separate
+transactions so the ``ROLLBACK`` will have no effect. Both results are valid
+according to the SQL Standard -- this is just one of those
+implementation-defined things that you have to be alert for. The best policy is
+to assume that an SQL-Schema statement implies a new transaction, and so cannot
+be rolled back.
 
 ROLLBACK ... TO SAVEPOINT
 _________________________
 
-The most beneficial new SQL3 feature, in transaction contexts, is the ability 
-to limit how much will be rolled back by ``ROLLBACK``. With savepoints, you can 
-specify from what point the changes will be cancelled. In underlying terms, 
-this means you can specify where to truncate the log file. First, though, you 
-have to establish a savepoint somewhere in your transaction. You do it with the 
-``SAVEPOINT`` statement. 
+The most beneficial new SQL3 feature, in transaction contexts, is the ability
+to limit how much will be rolled back by ``ROLLBACK``. With savepoints, you can
+specify from what point the changes will be cancelled. In underlying terms,
+this means you can specify where to truncate the log file. First, though, you
+have to establish a savepoint somewhere in your transaction. You do it with the
+``SAVEPOINT`` statement.
 
-If you've established a savepoint for a transaction, you can roll all 
-operations that have happened in that transaction back to that point with the 
-``ROLLBACK`` statement's optional TO ``SAVEPOINT`` clause. For example, to 
-``ROLLBACK`` to the savepoint established in the previous example, you would 
-issue this SQL statement: 
+If you've established a savepoint for a transaction, you can roll all
+operations that have happened in that transaction back to that point with the
+``ROLLBACK`` statement's optional TO ``SAVEPOINT`` clause. For example, to
+``ROLLBACK`` to the savepoint established in the previous example, you would
+issue this SQL statement:
 
 ::
 
    ROLLBACK TO SAVEPOINT point_we_may_wish_to_rollback_to;
 
-This form of ``ROLLBACK`` is not a transaction terminator statement: it merely 
-causes a restoration of state. A ``ROLLBACK`` statement that contains the ``AND 
-CHAIN`` clause may not also contain a ``TO SAVEPOINT`` clause. 
+This form of ``ROLLBACK`` is not a transaction terminator statement: it merely
+causes a restoration of state. A ``ROLLBACK`` statement that contains the ``AND
+CHAIN`` clause may not also contain a ``TO SAVEPOINT`` clause.
 
-If you want to restrict your code to Core SQL, don't use ``AND CHAIN``, ``AND 
-NO CHAIN`` or ``TO SAVEPOINT`` with ``ROLLBACK``. 
+If you want to restrict your code to Core SQL, don't use ``AND CHAIN``, ``AND
+NO CHAIN`` or ``TO SAVEPOINT`` with ``ROLLBACK``.
 
 *RELEASE SAVEPOINT Statement*
 -----------------------------
 
-The ``RELEASE SAVEPOINT`` statement destroys one or more savepoints in the 
-current transaction. The required syntax for the ``RELEASE SAVEPOINT`` 
+The ``RELEASE SAVEPOINT`` statement destroys one or more savepoints in the
+current transaction. The required syntax for the ``RELEASE SAVEPOINT``
 statement is:
 
 ::
 
     RELEASE SAVEPOINT <savepoint name> | <simple target specification>
 
-The ``RELEASE SAVEPOINT`` statement removes the specified savepoint, as well as 
-any subsequent savepoints you established for the current transaction. For 
+The ``RELEASE SAVEPOINT`` statement removes the specified savepoint, as well as
+any subsequent savepoints you established for the current transaction. For
 example, this SQL statement:
 
 ::
 
    RELEASE SAVEPOINT point_we_may_wish_to_rollback_to;
 
-removes the savepoint we established earlier. If we had established any 
-other savepoints after ``point_we_may_wish_to_rollback_to``, those savepoints 
+removes the savepoint we established earlier. If we had established any
+other savepoints after ``point_we_may_wish_to_rollback_to``, those savepoints
 would also disappear.
 
-If you want to restrict your code to Core SQL, don't use the ``RELEASE 
+If you want to restrict your code to Core SQL, don't use the ``RELEASE
 SAVEPOINT`` statement.
 
 Using Savepoints
 ================
 
-A savepoint may be thought of as a label of a moment between operations. 
-For illustration, suppose a transaction that consists of these SQL 
+A savepoint may be thought of as a label of a moment between operations.
+For illustration, suppose a transaction that consists of these SQL
 statements:
 
 ::
@@ -598,29 +600,29 @@ At this point in the transaction, the SQL statement:
 
    ROLLBACK TO SAVEPOINT after_update;
 
-will cause the DBMS to cancel the effects of the ``DELETE`` statement, the SQL 
+will cause the DBMS to cancel the effects of the ``DELETE`` statement, the SQL
 statement:
 
 ::
 
    ROLLBACK TO SAVEPOINT after_insert;
 
-will cause the DBMS to cancel the effects of both the ``DELETE`` statement and 
+will cause the DBMS to cancel the effects of both the ``DELETE`` statement and
 the ``UPDATE`` statement and the SQL statement:
 
 ::
 
    ROLLBACK;
 
-will cause the DBMS to cancel the effects of the entire transaction, as well as 
-to end the transaction. When a transaction ends, all savepoints are destroyed. 
+will cause the DBMS to cancel the effects of the entire transaction, as well as
+to end the transaction. When a transaction ends, all savepoints are destroyed.
 
-The savepoint option is good for tentative branching. We can follow some line 
-of DBMS activity, and if it doesn't work we can go back a few steps, then 
-pursue a different course. The option's also good for separating 
-``ROLLBACK``\'s two tasks, "transaction terminate" and "cancel", from each 
-other. The incidental effects (such as closing of Cursors) happen regardless of 
-whether ``ROLLBACK`` alone or ``ROLLBACK TO SAVEPOINT`` is used. 
+The savepoint option is good for tentative branching. We can follow some line
+of DBMS activity, and if it doesn't work we can go back a few steps, then
+pursue a different course. The option's also good for separating
+``ROLLBACK``\'s two tasks, "transaction terminate" and "cancel", from each
+other. The incidental effects (such as closing of Cursors) happen regardless of
+whether ``ROLLBACK`` alone or ``ROLLBACK TO SAVEPOINT`` is used.
 
 Transaction Tips
 ================
@@ -629,82 +631,82 @@ The following tips are viable only if the DBMS is alone, is following the SQL
 Standard's specifications and uses logs as we have described them. But if not,
 there shouldn't be much harm done by at least considering them.
 
-* ``COMMIT`` or ``ROLLBACK`` quickly after ``INSERT``, ``UPDATE`` or 
-  ``DELETE``. A quick transaction end will flush the log, and thus speed up 
+* ``COMMIT`` or ``ROLLBACK`` quickly after ``INSERT``, ``UPDATE`` or
+  ``DELETE``. A quick transaction end will flush the log, and thus speed up
   most accesses.
 
-* ``COMMIT`` or ``ROLLBACK`` slowly after ``SELECT``. Transaction 
-  terminators tend to wipe out items that might be reusable (prepared 
-  statements, Cursors and locks). It's convenient to get maximum use from 
+* ``COMMIT`` or ``ROLLBACK`` slowly after ``SELECT``. Transaction
+  terminators tend to wipe out items that might be reusable (prepared
+  statements, Cursors and locks). It's convenient to get maximum use from
   these items before releasing them.
 
-* Use temporary Tables. If you're making temporary data, no matter how 
-  much, the place to store temporary data is in temporary tables with ``ON 
-  COMMIT DELETE ROWS``. Since there is no need to worry about recovering 
-  any data in such Tables, your DBMS might be able to optimize by doing 
+* Use temporary Tables. If you're making temporary data, no matter how
+  much, the place to store temporary data is in temporary tables with ``ON
+  COMMIT DELETE ROWS``. Since there is no need to worry about recovering
+  any data in such Tables, your DBMS might be able to optimize by doing
   direct writes to the database files without a log.
 
-* ``SELECT`` first. Since ``SELECT`` can be slower after an ``UPDATE`` than 
-  before an  ``UPDATE``, it might help to get selections out of the way 
+* ``SELECT`` first. Since ``SELECT`` can be slower after an ``UPDATE`` than
+  before an  ``UPDATE``, it might help to get selections out of the way
   before doing data changes.
 
-* Keep out non-database work. If there are lengthy calculations to do in 
-  your host program, they should happen outside the SQL transaction. Do them 
+* Keep out non-database work. If there are lengthy calculations to do in
+  your host program, they should happen outside the SQL transaction. Do them
   before the transaction initiator, and after the transaction terminator.
-  The same applies for the SQL statements that don't access SQL data, such as 
+  The same applies for the SQL statements that don't access SQL data, such as
   the SQL-session ``SET`` statements.
 
-A final piece of advice, which is not a tip but a concession to reality, is 
-that you will occasionally have to break up logical units of work because 
-they're too big. For example, if you're going through every row in a huge 
-Table, adding 1 to a particular Column, you might want to break up the 
-transaction so that there's a ``COMMIT`` after every few changes. This, though, 
-is only safe because you can keep track of where you left off, and you can 
-write your own "rollback" (subtracting 1) if necessary. The primary rule should 
-remain that the logical unit of work should be the physical unit (transaction) 
-too. Departures from that rule are not the stuff of everyday programming work. 
-Security (consistency) first, performance second. 
+A final piece of advice, which is not a tip but a concession to reality, is
+that you will occasionally have to break up logical units of work because
+they're too big. For example, if you're going through every row in a huge
+Table, adding 1 to a particular Column, you might want to break up the
+transaction so that there's a ``COMMIT`` after every few changes. This, though,
+is only safe because you can keep track of where you left off, and you can
+write your own "rollback" (subtracting 1) if necessary. The primary rule should
+remain that the logical unit of work should be the physical unit (transaction)
+too. Departures from that rule are not the stuff of everyday programming work.
+Security (consistency) first, performance second.
 
 See Also
 ========
 
-All SQL operations have something to do with transactions. This chapter has 
-singled out only the major points, with particular attention to the ``COMMIT`` 
-and the ``ROLLBACK`` statements. There is more relevant information in our 
-chapter on constraints and assertions (where we talk about deferred 
-Constraints), in our chapter on concurrency (particularly with regard to the 
-``SET TRANSACTION`` statement) and throughout our chapters on binding styles. 
+All SQL operations have something to do with transactions. This chapter has
+singled out only the major points, with particular attention to the ``COMMIT``
+and the ``ROLLBACK`` statements. There is more relevant information in our
+chapter on constraints and assertions (where we talk about deferred
+Constraints), in our chapter on concurrency (particularly with regard to the
+``SET TRANSACTION`` statement) and throughout our chapters on binding styles.
 
 Dialects
 ========
 
-SQL has supported transaction work since the early days (SQL-86). There are 
-some packages which graft SQL-like statements onto non-SQL environments (dBASE 
-III contained an example), but if you are using a true SQL DBMS then you at 
-least can depend on the essentials of ``COMMIT [WORK];`` or ``ROLLBACK 
-[WORK]``. The main differences between DBMSs are in the areas of: 
+SQL has supported transaction work since the early days (SQL-86). There are
+some packages which graft SQL-like statements onto non-SQL environments (dBASE
+III contained an example), but if you are using a true SQL DBMS then you at
+least can depend on the essentials of ``COMMIT [WORK];`` or ``ROLLBACK
+[WORK]``. The main differences between DBMSs are in the areas of:
 
 * What incidental items are destroyed by transaction termination.
 
 * Whether SQL-Schema statements form transactions of their own.
 
-* Whether ``CHAIN`` and ``SAVEPOINT`` features are supported (both of these are 
+* Whether ``CHAIN`` and ``SAVEPOINT`` features are supported (both of these are
   SQL3, neither is a Core SQL requirement, so support should not be expected.
 
-Sybase has been refining "Log work" for several years. This was one of the 
-first DBMSs to feature "savepoints". The log is visible as a table. There is an 
-option for suspending logging. 
+Sybase has been refining "Log work" for several years. This was one of the
+first DBMSs to feature "savepoints". The log is visible as a table. There is an
+option for suspending logging.
 
-The ODBC specification is that auto-commit should happen. This requirement can 
-be turned off (to what Microsoft calls "manual commit" mode), but auto-commit 
-is the default so ODBC programmers should either turn it off (which looks like 
-a good idea!) or get used to the quirks that auto-commit brings on. Namely, in 
-auto-commit mode every statement gets committed, so ``ROLLBACK`` is 
-meaningless. However, it appears that execution of a ``SELECT`` statement is 
-not followed by an automatic commit -- ODBC's documentation is unclear about 
-this, but it would make little sense to ``SELECT`` (which usually opens a 
-cursor) and immediately ``COMMIT`` (which usually closes all cursors). Also -- 
-apparently -- the ODBC function ``SQLCloseCursor`` implies a ``COMMIT``. ODBC's 
-"auto-commit" default mode is a departure from the SQL Standard, but we must 
-understand that ODBC is designed to accommodate a wide variety of data sources. 
-It is usually not prescriptive. 
+The ODBC specification is that auto-commit should happen. This requirement can
+be turned off (to what Microsoft calls "manual commit" mode), but auto-commit
+is the default so ODBC programmers should either turn it off (which looks like
+a good idea!) or get used to the quirks that auto-commit brings on. Namely, in
+auto-commit mode every statement gets committed, so ``ROLLBACK`` is
+meaningless. However, it appears that execution of a ``SELECT`` statement is
+not followed by an automatic commit -- ODBC's documentation is unclear about
+this, but it would make little sense to ``SELECT`` (which usually opens a
+cursor) and immediately ``COMMIT`` (which usually closes all cursors). Also --
+apparently -- the ODBC function ``SQLCloseCursor`` implies a ``COMMIT``. ODBC's
+"auto-commit" default mode is a departure from the SQL Standard, but we must
+understand that ODBC is designed to accommodate a wide variety of data sources.
+It is usually not prescriptive.

--- a/docs/chapters/37.rst
+++ b/docs/chapters/37.rst
@@ -4,37 +4,39 @@
 Chapter 37 -- SQL Transaction Concurrency
 =========================================
 
-Although there is never more than one current SQL transaction between your DBMS 
-and your application program at any point in time, the operational problem -- 
-although perhaps we should call it a "challenge" or an "opportunity" -- is that 
-many DBMSs run in multi-tasking or multi-user scenarios. These may range from 
-the fairly simple (for example, an MS-Windows background task running in 
-conjunction with a foreground task) to the fairly complex (for example a 
-heterogeneous mix of computers connected over a network via TCP/IP). The 
-problem/challenge/opportunity has grown larger in recent years, with the demand 
-for "24x7" (twenty-four hour by seven-day) accessibility, and with the demand 
-for DBMS servers that can operate on Internet hosts (especially with WindowsNT 
-and Linux operating systems). 
+.. include:: ../_include/note.rst
 
-In SQL, the primary unit of work is the "transaction", as we saw in the 
-previous chapter. The interesting difficulties lie with transaction 
-concurrency, which we define as: 
+Although there is never more than one current SQL transaction between your DBMS
+and your application program at any point in time, the operational problem --
+although perhaps we should call it a "challenge" or an "opportunity" -- is that
+many DBMSs run in multi-tasking or multi-user scenarios. These may range from
+the fairly simple (for example, an MS-Windows background task running in
+conjunction with a foreground task) to the fairly complex (for example a
+heterogeneous mix of computers connected over a network via TCP/IP). The
+problem/challenge/opportunity has grown larger in recent years, with the demand
+for "24x7" (twenty-four hour by seven-day) accessibility, and with the demand
+for DBMS servers that can operate on Internet hosts (especially with WindowsNT
+and Linux operating systems).
 
-**Concurrency.** The running together of two transactions, which may access the 
-same database rows during overlapping time periods. Such simultaneous accesses, 
-called *collisions*, may result in errors or inconsistencies if not handled 
-properly. The more overlapping that is possible, the greater the concurrency. 
+In SQL, the primary unit of work is the "transaction", as we saw in the
+previous chapter. The interesting difficulties lie with transaction
+concurrency, which we define as:
 
-The proper handling of collisions requires some work on the part of the 
-application programmer. It is possible to leave the whole matter in the hands 
-of the DBMS, but that would almost certainly lead to performance which everyone 
-would call unacceptable. Therefore your requirement for this part of the job is 
-to understand how errors or inconsistencies can arise during collisions, to use 
-the somewhat paucous SQL options which can increase concurrency, and to help 
+**Concurrency.** The running together of two transactions, which may access the
+same database rows during overlapping time periods. Such simultaneous accesses,
+called *collisions*, may result in errors or inconsistencies if not handled
+properly. The more overlapping that is possible, the greater the concurrency.
+
+The proper handling of collisions requires some work on the part of the
+application programmer. It is possible to leave the whole matter in the hands
+of the DBMS, but that would almost certainly lead to performance which everyone
+would call unacceptable. Therefore your requirement for this part of the job is
+to understand how errors or inconsistencies can arise during collisions, to use
+the somewhat paucous SQL options which can increase concurrency, and to help
 the DBMS* along with a variety of settings or application plans.
 
-\* Though we use the singular word "DBMS", we note once again that there may in 
-fact be several co-operating agencies responsible for transaction management. 
+\* Though we use the singular word "DBMS", we note once again that there may in
+fact be several co-operating agencies responsible for transaction management.
 
 .. rubric:: Table of Contents
 
@@ -44,16 +46,16 @@ fact be several co-operating agencies responsible for transaction management.
 Isolation Phenomena
 ===================
 
-What sort of errors and inconsistencies can creep in during concurrent 
-operations? Database groupies generally use four categories, which they call -- 
-in order by seriousness -- Lost Update, Dirty Read, Non-Repeatable Read and 
-Phantom. 
+What sort of errors and inconsistencies can creep in during concurrent
+operations? Database groupies generally use four categories, which they call --
+in order by seriousness -- Lost Update, Dirty Read, Non-Repeatable Read and
+Phantom.
 
-In the descriptions that follow, the conventions are that "Txn#1" and "Txn#2" 
-are two concurrent transactions, that "change" has its usual sense of "an 
-``INSERT`` or ``UPDATE`` or ``DELETE``", and "read" means "``FETCH``" or some 
-close equivalent. The charts are time lines with time points, so that events 
-shown lower down in the chart are taking place later in time. 
+In the descriptions that follow, the conventions are that "Txn#1" and "Txn#2"
+are two concurrent transactions, that "change" has its usual sense of "an
+``INSERT`` or ``UPDATE`` or ``DELETE``", and "read" means "``FETCH``" or some
+close equivalent. The charts are time lines with time points, so that events
+shown lower down in the chart are taking place later in time.
 
 **LOST UPDATE**
 
@@ -73,8 +75,8 @@ shown lower down in the chart are taking place later in time.
 | ...        | Commit    |
 +------------+-----------+
 
-The "lost update" is the change made by Txn#1. Since Txn#2 makes a later 
-change, it supersedes Txn#1's change. The result is as if Txn#1's change 
+The "lost update" is the change made by Txn#1. Since Txn#2 makes a later
+change, it supersedes Txn#1's change. The result is as if Txn#1's change
 never happened.
 
 **DIRTY READ**
@@ -93,11 +95,11 @@ never happened.
 | ...        | Rollback  |
 +------------+-----------+
 
-Here the key is that Txn#2 "reads" after Txn#1 "changes", and so Txn#2 "sees" 
-the new data that Txn#1 changed to. That change was ephemeral though: Txn#1 
-rolled back the change. So Txn#1's change really never happened, but Txn#2 
-based its work on that change anyway. The old name for the Dirty Read 
-phenomenon is "uncommitted dependency". 
+Here the key is that Txn#2 "reads" after Txn#1 "changes", and so Txn#2 "sees"
+the new data that Txn#1 changed to. That change was ephemeral though: Txn#1
+rolled back the change. So Txn#1's change really never happened, but Txn#2
+based its work on that change anyway. The old name for the Dirty Read
+phenomenon is "uncommitted dependency".
 
 **NON-REPEATABLE READ**
 
@@ -117,10 +119,10 @@ phenomenon is "uncommitted dependency".
 | Commit    | ...        |
 +-----------+------------+
 
-The supposition here is that Txn#1 will "read" the same row twice. The second 
-time, though, the values in the row will be different. This is by no means as 
-serious an inconsistency (usually) as Lost Update or Dirty Read, but it does 
-certainly break the requirements of an ACID transaction. 
+The supposition here is that Txn#1 will "read" the same row twice. The second
+time, though, the values in the row will be different. This is by no means as
+serious an inconsistency (usually) as Lost Update or Dirty Read, but it does
+certainly break the requirements of an ACID transaction.
 
 **PHANTOM**
 
@@ -136,20 +138,20 @@ certainly break the requirements of an ACID transaction.
 | ``SELECT FROM t WHERE col=5;``      | ...                                    |
 +-------------------------------------+----------------------------------------+
 
-This now-you-don't-see-it-now-you-do phenomenon is one that often slips 
-through, especially with older or dBASE-like DBMSs. The reason is that DBMSs 
-might notice concurrent access to rows, but fail to notice concurrent access to 
-the *paths* to those rows. Phantoms can affect transactions which contain at 
-least two <search condition>s which in some way overlap or depend on one 
-another. Phantoms are rare and are usually tolerable, but can cause surprise 
-errors because even some good DBMSs let them through, unless you take explicit 
-measures to signal "no phantoms please". 
+This now-you-don't-see-it-now-you-do phenomenon is one that often slips
+through, especially with older or dBASE-like DBMSs. The reason is that DBMSs
+might notice concurrent access to rows, but fail to notice concurrent access to
+the *paths* to those rows. Phantoms can affect transactions which contain at
+least two <search condition>s which in some way overlap or depend on one
+another. Phantoms are rare and are usually tolerable, but can cause surprise
+errors because even some good DBMSs let them through, unless you take explicit
+measures to signal "no phantoms please".
 
 Pessimistic Concurrency: LOCKING
 ================================
 
-The most common and best-known way to eliminate some or all of the 
-transaction concurrency phenomena is locking. Typically, a lock works like 
+The most common and best-known way to eliminate some or all of the
+transaction concurrency phenomena is locking. Typically, a lock works like
 this:
 
 +-------------------------------+----------------------------------+
@@ -168,33 +170,33 @@ this:
 | ...                           | "LOCK" the desired object        |
 +-------------------------------+----------------------------------+
 
-Here, the Object being locked might be a Column, a row, a page, a Table or the 
-entire database. Incidentally, when a lock is on a Column, locks are said to be 
-"finely granular"; when a lock is on a page or Table or database, locks are 
-said to be "coarsely granular". DBMSs with coarse-granularity locking have less 
-concurrency (because a lock on row#1 causes an unnecessary lock on other rows 
-as well), but are efficient despite that because: the coarser the granularity, 
-the fewer locks exist, and therefore searching the list of locks is quicker. At 
-this moment, it appears that the majority of important DBMSs support locking by 
-row, with some (non-standard) optional syntax that allows locking by Table. 
+Here, the Object being locked might be a Column, a row, a page, a Table or the
+entire database. Incidentally, when a lock is on a Column, locks are said to be
+"finely granular"; when a lock is on a page or Table or database, locks are
+said to be "coarsely granular". DBMSs with coarse-granularity locking have less
+concurrency (because a lock on row#1 causes an unnecessary lock on other rows
+as well), but are efficient despite that because: the coarser the granularity,
+the fewer locks exist, and therefore searching the list of locks is quicker. At
+this moment, it appears that the majority of important DBMSs support locking by
+row, with some (non-standard) optional syntax that allows locking by Table.
 
-A lock is much like a reservation in a restaurant. If you find that your 
-desired seat has already been taken by someone who came before you, you must 
-either wait or go elsewhere. 
+A lock is much like a reservation in a restaurant. If you find that your
+desired seat has already been taken by someone who came before you, you must
+either wait or go elsewhere.
 
-Usually an SQL DBMS supports at least two kinds of locks: "shared locks" and 
-"exclusive locks". A *shared lock* exists because there is nothing wrong with 
-letting two transactions read the same row; concurrency can only cause trouble 
-if one transaction or the other is updating. Therefore, at retrieval time, a 
-shared lock is made, and this shared lock does not block other transactions 
-from accessing the same row (with another retrieval). At change time, the 
-shared lock is upgraded to an *exclusive lock*, which blocks both reads and 
-writes by other transactions. The use of different kinds of locks is something 
-that distinguishes an SQL DBMS from a DBMS that depends on the operating system 
-(operating systems like MS-DOS support exclusive locks only). 
+Usually an SQL DBMS supports at least two kinds of locks: "shared locks" and
+"exclusive locks". A *shared lock* exists because there is nothing wrong with
+letting two transactions read the same row; concurrency can only cause trouble
+if one transaction or the other is updating. Therefore, at retrieval time, a
+shared lock is made, and this shared lock does not block other transactions
+from accessing the same row (with another retrieval). At change time, the
+shared lock is upgraded to an *exclusive lock*, which blocks both reads and
+writes by other transactions. The use of different kinds of locks is something
+that distinguishes an SQL DBMS from a DBMS that depends on the operating system
+(operating systems like MS-DOS support exclusive locks only).
 
-The famous irritant with a lock-based concurrency resolution mechanism is the 
-"deadlock" (or deadly embrace), which goes like this: 
+The famous irritant with a lock-based concurrency resolution mechanism is the
+"deadlock" (or deadly embrace), which goes like this:
 
 +---------------------------------+---------------------------------+
 | Txn#1                           | Txn#2                           |
@@ -214,56 +216,56 @@ The famous irritant with a lock-based concurrency resolution mechanism is the
 | WAIT                            | WAIT                            |
 +---------------------------------+---------------------------------+
 
-Since Txn#1 is waiting for Txn#2 to release its lock, but Txn#2 is waiting for 
-Txn#1 to release its lock, there can be no progress. The DBMS must detect 
-situations like this and force one transaction or the other to "rollback" with 
-an error. 
+Since Txn#1 is waiting for Txn#2 to release its lock, but Txn#2 is waiting for
+Txn#1 to release its lock, there can be no progress. The DBMS must detect
+situations like this and force one transaction or the other to "rollback" with
+an error.
 
-Locking is reliable and popular. However, it is sometimes criticized for being 
-based on an excessively pessimistic assumption: that something which you read 
-could be something that you will change. The result is a profusion of "shared 
-locks", the great majority of which turn out to be unnecessary because only a 
-relatively small number of rows are actually updated. 
+Locking is reliable and popular. However, it is sometimes criticized for being
+based on an excessively pessimistic assumption: that something which you read
+could be something that you will change. The result is a profusion of "shared
+locks", the great majority of which turn out to be unnecessary because only a
+relatively small number of rows are actually updated.
 
 Optimistic Concurrency: TIMESTAMPING
 ====================================
 
-There are several ways to control concurrency without locking. The most common 
-ones can be grouped together as the "optimistic assumption" ways, and the most 
-common of those ways is timestamping. With timestamping, there are no locks but 
-there are two situations which cause transaction failure: 
+There are several ways to control concurrency without locking. The most common
+ones can be grouped together as the "optimistic assumption" ways, and the most
+common of those ways is timestamping. With timestamping, there are no locks but
+there are two situations which cause transaction failure:
 
-* If a younger transaction has "read" the row, then an attempt by an older 
+* If a younger transaction has "read" the row, then an attempt by an older
   transaction to "change" that row will fail.
 
-* If a younger transaction has "changed" the row, then an attempt by an 
+* If a younger transaction has "changed" the row, then an attempt by an
   older transaction to "read" that row will fail.
 
-The general effect of these rules is that concurrency is high, but failure is 
-frequent. Indeed, it is quite possible that a transaction will fail many times. 
-But what the heck, one can put the transaction in a loop and keep retrying 
-until it goes through. 
+The general effect of these rules is that concurrency is high, but failure is
+frequent. Indeed, it is quite possible that a transaction will fail many times.
+But what the heck, one can put the transaction in a loop and keep retrying
+until it goes through.
 
-Some DBMSs enhance the concurrency further by actually "reading" a row which 
-has been changed by another transaction, and deciding whether the change is 
-significant. For example, it often happens that the same Column is being 
-updated so that it has the same value for both transactions. In that case, 
-there may be no need to abort. 
+Some DBMSs enhance the concurrency further by actually "reading" a row which
+has been changed by another transaction, and deciding whether the change is
+significant. For example, it often happens that the same Column is being
+updated so that it has the same value for both transactions. In that case,
+there may be no need to abort.
 
-Most optimistic concurrency mechanisms are not particularly good for detecting 
-Non-Repeatable Reads or Phantoms. 
+Most optimistic concurrency mechanisms are not particularly good for detecting
+Non-Repeatable Reads or Phantoms.
 
 SET TRANSACTION statement
 =========================
 
-By now, we've come to expect that SQL statements aren't used to specify 
-methods. Instead, they state what the requirements are. That's the idea behind 
-the ``SET TRANSACTION`` statement. It tells the DBMS -- somewhat indirectly -- 
-what sort of concurrency phenomena are intolerable for the next transaction, 
-but it does not say how they are to be prevented. That detail is left up to the 
-DBMS itself -- that is, the choice of concurrency protocol (locking, 
-timestamping or some other method) is implementation-defined. The required 
-syntax for the ``SET TRANSACTION`` statement is: 
+By now, we've come to expect that SQL statements aren't used to specify
+methods. Instead, they state what the requirements are. That's the idea behind
+the ``SET TRANSACTION`` statement. It tells the DBMS -- somewhat indirectly --
+what sort of concurrency phenomena are intolerable for the next transaction,
+but it does not say how they are to be prevented. That detail is left up to the
+DBMS itself -- that is, the choice of concurrency protocol (locking,
+timestamping or some other method) is implementation-defined. The required
+syntax for the ``SET TRANSACTION`` statement is:
 
 ::
 
@@ -286,23 +288,23 @@ syntax for the ``SET TRANSACTION`` statement is:
 
              <number of conditions> ::= <simple value specification>
 
-The ``SET TRANSACTION`` statement sets certain characteristics for the next 
-transaction. There are three options, any or all of which can be set by a 
-single ``SET TRANSACTION`` statement. 
+The ``SET TRANSACTION`` statement sets certain characteristics for the next
+transaction. There are three options, any or all of which can be set by a
+single ``SET TRANSACTION`` statement.
 
-The first transaction characteristic is its access mode: a transaction can 
-either be a ``READ ONLY`` transaction or a ``READ WRITE`` transaction. The 
-second transaction characteristic is its isolation level: a transaction can 
-either allow ``READ UNCOMMITTED``, ``READ COMMITTED``, ``REPEATABLE READ`` or 
-``SERIALIZABLE`` operations. The final transaction characteristic is the size 
-of its diagnostics area: you set this to the number of conditions you want your 
-DBMS to be able to provide you with information on (it must be at least one). 
-The <diagnostics size> is a transaction characteristic which has nothing to do 
-with concurrency, so we won't discuss it further here -- look for it in our 
-chapters on binding styles. That leaves us with the choice of specifying ``READ 
-ONLY`` versus ``READ WRITE``, and the choice of specifying one of: ``READ 
-UNCOMMITTED``, ``READ COMMITTED``, ``REPEATABLE READ`` or ``SERIALIZABLE`` for 
-a transaction. Here's some example SQL statements: 
+The first transaction characteristic is its access mode: a transaction can
+either be a ``READ ONLY`` transaction or a ``READ WRITE`` transaction. The
+second transaction characteristic is its isolation level: a transaction can
+either allow ``READ UNCOMMITTED``, ``READ COMMITTED``, ``REPEATABLE READ`` or
+``SERIALIZABLE`` operations. The final transaction characteristic is the size
+of its diagnostics area: you set this to the number of conditions you want your
+DBMS to be able to provide you with information on (it must be at least one).
+The <diagnostics size> is a transaction characteristic which has nothing to do
+with concurrency, so we won't discuss it further here -- look for it in our
+chapters on binding styles. That leaves us with the choice of specifying ``READ
+ONLY`` versus ``READ WRITE``, and the choice of specifying one of: ``READ
+UNCOMMITTED``, ``READ COMMITTED``, ``REPEATABLE READ`` or ``SERIALIZABLE`` for
+a transaction. Here's some example SQL statements:
 
 ::
 
@@ -314,13 +316,13 @@ a transaction. Here's some example SQL statements:
       READ ONLY
       ISOLATION LEVEL READ UNCOMMITTED;
 
-As the name suggests, ``SET TRANSACTION`` is only good for setting the 
-characteristics of one transaction (though there are a few exceptions to this 
-rule when we add the optional <keyword> ``LOCAL``, a SQL3 feature). Unless 
-you're using the SQL3 ``START TRANSACTION`` statement (which we'll discuss 
-later in this chapter), the ``SET TRANSACTION`` statement should precede all 
-other statements in a transaction. If you don't specify it, the default 
-situation is: 
+As the name suggests, ``SET TRANSACTION`` is only good for setting the
+characteristics of one transaction (though there are a few exceptions to this
+rule when we add the optional <keyword> ``LOCAL``, a SQL3 feature). Unless
+you're using the SQL3 ``START TRANSACTION`` statement (which we'll discuss
+later in this chapter), the ``SET TRANSACTION`` statement should precede all
+other statements in a transaction. If you don't specify it, the default
+situation is:
 
 ::
 
@@ -331,194 +333,194 @@ situation is:
 *Access Mode*
 -------------
 
-If the transaction's isolation level is ``READ UNCOMMITTED``, then ``READ 
-ONLY`` is the default (and only legal) access mode option. For all other 
-isolation levels, either ``READ ONLY`` or ``READ WRITE`` are legal options, and 
-the default is ``READ WRITE``. 
+If the transaction's isolation level is ``READ UNCOMMITTED``, then ``READ
+ONLY`` is the default (and only legal) access mode option. For all other
+isolation levels, either ``READ ONLY`` or ``READ WRITE`` are legal options, and
+the default is ``READ WRITE``.
 
-The declaration ``READ ONLY`` tells the DBMS that all statements in the 
-upcoming transactions will be "read" statements: they only read SQL data, they 
-don't make any changes. The declaration ``READ WRITE`` tells the DBMS that 
-there may be either "read" or "change" statements in the upcoming transaction. 
+The declaration ``READ ONLY`` tells the DBMS that all statements in the
+upcoming transactions will be "read" statements: they only read SQL data, they
+don't make any changes. The declaration ``READ WRITE`` tells the DBMS that
+there may be either "read" or "change" statements in the upcoming transaction.
 
 .. NOTE::
 
-  Changes to ``TEMPORARY`` Tables don't count as "changes", since 
-  ``TEMPORARY`` Tables aren't shared between different transactions anyway. 
-  So regardless of what you   do with ``TEMPORARY`` Tables, as long as you 
-  make no changes to SQL-data or   persistent SQL Objects (e.g.: Schemas, 
-  Tables, Domains and so on), you can   declare a transaction's access mode 
+  Changes to ``TEMPORARY`` Tables don't count as "changes", since
+  ``TEMPORARY`` Tables aren't shared between different transactions anyway.
+  So regardless of what you   do with ``TEMPORARY`` Tables, as long as you
+  make no changes to SQL-data or   persistent SQL Objects (e.g.: Schemas,
+  Tables, Domains and so on), you can   declare a transaction's access mode
   to be ``READ ONLY``.
 
-There are no guarantees that specifying ``READ ONLY`` will do any good at all, 
-but it certainly won't hurt -- and it might result in performance gains. Here's 
-why: If your DBMS sees that all transactions are ``READ ONLY``, then it doesn't 
-have to set any locks at all -- no isolation phenomena can arise when all jobs 
-are doing nothing but reading. If only one transaction is ``READ ONLY``, there 
-is still a good strategy available: the DBMS can make a temporary copy of the 
-Tables that you ``SELECT`` from (or at least of the rows in the result sets). 
-Following that, all ``FETCH`` statements are operating on the temporary copy, 
-instead of on the original Table, and therefore collisions are impossible. 
-Typical application situations where ``READ ONLY`` is called for include: 
-report writers, screen displayers, file dumps. The option might have a 
-particularly good effect if the transaction contains statements which contain 
-set functions. 
+There are no guarantees that specifying ``READ ONLY`` will do any good at all,
+but it certainly won't hurt -- and it might result in performance gains. Here's
+why: If your DBMS sees that all transactions are ``READ ONLY``, then it doesn't
+have to set any locks at all -- no isolation phenomena can arise when all jobs
+are doing nothing but reading. If only one transaction is ``READ ONLY``, there
+is still a good strategy available: the DBMS can make a temporary copy of the
+Tables that you ``SELECT`` from (or at least of the rows in the result sets).
+Following that, all ``FETCH`` statements are operating on the temporary copy,
+instead of on the original Table, and therefore collisions are impossible.
+Typical application situations where ``READ ONLY`` is called for include:
+report writers, screen displayers, file dumps. The option might have a
+particularly good effect if the transaction contains statements which contain
+set functions.
 
 *Isolation Level*
 -----------------
 
-The <isolation level> characteristic you specify in a ``SET TRANSACTION`` 
-statement determines the degree of "isolation" of the upcoming transaction. 
-This effectively means that the value you choose will tell your DBMS which 
-concurrency phenomena are tolerable or intolerable for the transaction. It's up 
-to the DBMS to decide how precisely it will follow your instruction -- the 
-Standard allows it to upgrade the specification (but never to downgrade it, 
-you're always guaranteed at least the isolation level you've asked for). For 
-example, your DBMS could take a ``READ UNCOMMITTED`` specification and set the 
-next transaction's isolation level to ``SERIALIZABLE`` (a higher level of 
-isolation) instead. But since your DBMS cannot downgrade the specification, 
-there is no harm in setting the <isolation level> as precisely as possible. 
+The <isolation level> characteristic you specify in a ``SET TRANSACTION``
+statement determines the degree of "isolation" of the upcoming transaction.
+This effectively means that the value you choose will tell your DBMS which
+concurrency phenomena are tolerable or intolerable for the transaction. It's up
+to the DBMS to decide how precisely it will follow your instruction -- the
+Standard allows it to upgrade the specification (but never to downgrade it,
+you're always guaranteed at least the isolation level you've asked for). For
+example, your DBMS could take a ``READ UNCOMMITTED`` specification and set the
+next transaction's isolation level to ``SERIALIZABLE`` (a higher level of
+isolation) instead. But since your DBMS cannot downgrade the specification,
+there is no harm in setting the <isolation level> as precisely as possible.
 
 READ UNCOMMITTED
 ________________
 
-``READ UNCOMMITTED`` is the lowest level of transaction isolation. If you 
-specify ``READ UNCOMMITTED``, you are risking that the transaction -- no matter 
-what it is doing -- might deliver a "wrong" answer. Because it is always 
-unacceptable for the database itself to contain wrong data, it is illegal to 
-execute any "change" statements during a ``READ UNCOMMITTED`` transaction. That 
-is, ``READ UNCOMMITTED`` implies ``READ ONLY``. 
+``READ UNCOMMITTED`` is the lowest level of transaction isolation. If you
+specify ``READ UNCOMMITTED``, you are risking that the transaction -- no matter
+what it is doing -- might deliver a "wrong" answer. Because it is always
+unacceptable for the database itself to contain wrong data, it is illegal to
+execute any "change" statements during a ``READ UNCOMMITTED`` transaction. That
+is, ``READ UNCOMMITTED`` implies ``READ ONLY``.
 
-``READ UNCOMMITTED`` means "allow reading of rows which have been written by 
-other transactions, but not committed" -- so Dirty Reads, Non-Repeatable Reads 
-and Phantoms are all possible with this type of transaction. However, Lost 
-Update is not possible for the simple reason that, as already stated, changes 
-of any kind are illegal. Lost Updates are, in fact, prevented in all the 
-standard SQL isolation levels. The concurrency level is as high as it can be -- 
-in a locking situation, no locks would be issued and no locks would be checked 
-for. We could say that, for this transaction, concurrency checking is turned 
-off. 
+``READ UNCOMMITTED`` means "allow reading of rows which have been written by
+other transactions, but not committed" -- so Dirty Reads, Non-Repeatable Reads
+and Phantoms are all possible with this type of transaction. However, Lost
+Update is not possible for the simple reason that, as already stated, changes
+of any kind are illegal. Lost Updates are, in fact, prevented in all the
+standard SQL isolation levels. The concurrency level is as high as it can be --
+in a locking situation, no locks would be issued and no locks would be checked
+for. We could say that, for this transaction, concurrency checking is turned
+off.
 
-The ``READ UNCOMMITTED`` level is a good choice if *(a)* the transaction is 
-usually slow, *(b)* errors are likely to be small and *(c)* errors are likely 
-to cancel each other out. The most certain example of such a situation is a 
-single ``SELECT`` statement containing a set function such as ``COUNT(*)``. Any 
-"report" where the user isn't likely to care about details, is also a good 
-candidate. You tolerate a huge degree of error every time they use a search 
-engine on the World Wide Web. 
+The ``READ UNCOMMITTED`` level is a good choice if *(a)* the transaction is
+usually slow, *(b)* errors are likely to be small and *(c)* errors are likely
+to cancel each other out. The most certain example of such a situation is a
+single ``SELECT`` statement containing a set function such as ``COUNT(*)``. Any
+"report" where the user isn't likely to care about details, is also a good
+candidate. You tolerate a huge degree of error every time they use a search
+engine on the World Wide Web.
 
 READ COMMITTED
 ______________
 
-``READ COMMITTED`` is the next level of transaction isolation. ``READ 
-COMMITTED`` means "allow reading of rows written by other transactions only 
-after they have been committed" -- so Non-Repeatable Reads or Phantoms are both 
-possible with this type of transaction, but Update and Dirty Read are not. The 
-``READ COMMITTED`` level allows for a reasonably high level of concurrency -- 
-in a locking situation, shared locks must be made, but they can be released 
-again before the transaction ends. For any "optimistic" concurrency resolution 
-mechanism, ``READ COMMITTED`` is the favored level. Conventional wisdom says 
-that concurrency based on optimistic assumptions gets very slow if the 
-isolation level is high. 
+``READ COMMITTED`` is the next level of transaction isolation. ``READ
+COMMITTED`` means "allow reading of rows written by other transactions only
+after they have been committed" -- so Non-Repeatable Reads or Phantoms are both
+possible with this type of transaction, but Update and Dirty Read are not. The
+``READ COMMITTED`` level allows for a reasonably high level of concurrency --
+in a locking situation, shared locks must be made, but they can be released
+again before the transaction ends. For any "optimistic" concurrency resolution
+mechanism, ``READ COMMITTED`` is the favored level. Conventional wisdom says
+that concurrency based on optimistic assumptions gets very slow if the
+isolation level is high.
 
-The ``READ COMMITTED`` level is always safe if there is only one SQL statement 
-in the transaction. Logic tells us that there will be no Repeatable Read errors 
-if there is only one "read". 
+The ``READ COMMITTED`` level is always safe if there is only one SQL statement
+in the transaction. Logic tells us that there will be no Repeatable Read errors
+if there is only one "read".
 
 REPEATABLE READ
 _______________
 
-``REPEATABLE READ`` is the next level of transaction isolation. By specifying 
-``REPEATABLE READ``, you are saying to your DBMS: don't tolerate Non-Repeatable 
-Reads (or, for that matter, Dirty Reads or Lost Updates) for the next 
-transaction. Phantoms continue to be tolerated. With ``REPEATABLE READ``, the 
-concurrency drops sharply. In a locking situation, the DBMS will be obliged to 
-put a "shared lock" on every row it fetches, and keep the lock throughout the 
-transaction. From the DBMS's point of view, the difference between this level 
-and the previous one is: with ``READ COMMITTED`` the locks can be released 
-before the transaction ends, with ``REPEATABLE READ`` they can't be. 
+``REPEATABLE READ`` is the next level of transaction isolation. By specifying
+``REPEATABLE READ``, you are saying to your DBMS: don't tolerate Non-Repeatable
+Reads (or, for that matter, Dirty Reads or Lost Updates) for the next
+transaction. Phantoms continue to be tolerated. With ``REPEATABLE READ``, the
+concurrency drops sharply. In a locking situation, the DBMS will be obliged to
+put a "shared lock" on every row it fetches, and keep the lock throughout the
+transaction. From the DBMS's point of view, the difference between this level
+and the previous one is: with ``READ COMMITTED`` the locks can be released
+before the transaction ends, with ``REPEATABLE READ`` they can't be.
 
-The ``REPEATABLE READ`` level is what most programmers prefer for 
-multi-statement transactions that involve "changes". Examples would be bank 
-transfers or library book checkouts. 
+The ``REPEATABLE READ`` level is what most programmers prefer for
+multi-statement transactions that involve "changes". Examples would be bank
+transfers or library book checkouts.
 
 SERIALIZABLE
 ____________
 
-``SERIALIZABLE`` is the highest level of transaction isolation. At the 
-``SERIALIZABLE`` isolation level, no concurrency phenomena -- even Phantoms -- 
-can arise to plague the programmer. This is the lowest level for concurrency. 
-Often the DBMS must respond by coarsening the granularity, and locking whole 
-Tables at once. Because the result is likely to be poor performance, this is 
-usually not the isolation level that the DBMS vendor manuals suggest -- they'll 
-steer you to ``REPEATABLE READ``. But ``SERIALIZABLE`` is the default isolation 
-level in standard SQL and it's the only level that all standards-compliant 
-vendors are guaranteed to support (theoretically a vendor could ignore the 
-lower levels and just "upgrade" all <isolation level> specifications to 
-``SERIALIZABLE``). 
+``SERIALIZABLE`` is the highest level of transaction isolation. At the
+``SERIALIZABLE`` isolation level, no concurrency phenomena -- even Phantoms --
+can arise to plague the programmer. This is the lowest level for concurrency.
+Often the DBMS must respond by coarsening the granularity, and locking whole
+Tables at once. Because the result is likely to be poor performance, this is
+usually not the isolation level that the DBMS vendor manuals suggest -- they'll
+steer you to ``REPEATABLE READ``. But ``SERIALIZABLE`` is the default isolation
+level in standard SQL and it's the only level that all standards-compliant
+vendors are guaranteed to support (theoretically a vendor could ignore the
+lower levels and just "upgrade" all <isolation level> specifications to
+``SERIALIZABLE``).
 
-Since the ``SERIALIZABLE`` level won't tolerate Phantoms, it's especially 
-indicated for transactions which contain multiple ``SELECT`` statements, or for 
-when you don't know what the statements will be, as in dynamic SQL. It is the 
-only level which assures safe, error-free transactions every time. If your 
-application consists wholly of short (i.e. fast-executing) statements which 
-affect only a few records at a time, don't get fancy -- leave everything at the 
-default ``SERIALIZABLE`` level. Nevertheless, we suspect that ``SERIALIZABLE`` 
-is used somewhat more often than appropriate. The choice of isolation level is 
-something you should at least give a moment's thought to, on a case-by-case 
-basis. 
+Since the ``SERIALIZABLE`` level won't tolerate Phantoms, it's especially
+indicated for transactions which contain multiple ``SELECT`` statements, or for
+when you don't know what the statements will be, as in dynamic SQL. It is the
+only level which assures safe, error-free transactions every time. If your
+application consists wholly of short (i.e. fast-executing) statements which
+affect only a few records at a time, don't get fancy -- leave everything at the
+default ``SERIALIZABLE`` level. Nevertheless, we suspect that ``SERIALIZABLE``
+is used somewhat more often than appropriate. The choice of isolation level is
+something you should at least give a moment's thought to, on a case-by-case
+basis.
 
-The word ``SERIALIZABLE`` reflects the idea that, given two overlapping 
-transactions -- Txn#1 and Txn#2 -- we can get the same results as we would get 
-if the transactions were "serial" rather than "overlapping" -- that is, if 
-Txn#1 followed Txn#2, or Txn#2 followed Txn#1, in time the end result would be 
-the same. This does not mean that the transactions are replayable, though. The 
-DBMS can only take responsibility for data stored in the database. It can not 
-guarantee that a transaction's statements are replayable if the parameter 
-values from the host (application) program change or if the SQL statements 
-contain niladic functions such as ``CURRENT_DATE``, ``CURRENT_TIME``, 
-``CURRENT_TIMESTAMP`` or ``CURRENT_USER``. 
+The word ``SERIALIZABLE`` reflects the idea that, given two overlapping
+transactions -- Txn#1 and Txn#2 -- we can get the same results as we would get
+if the transactions were "serial" rather than "overlapping" -- that is, if
+Txn#1 followed Txn#2, or Txn#2 followed Txn#1, in time the end result would be
+the same. This does not mean that the transactions are replayable, though. The
+DBMS can only take responsibility for data stored in the database. It can not
+guarantee that a transaction's statements are replayable if the parameter
+values from the host (application) program change or if the SQL statements
+contain niladic functions such as ``CURRENT_DATE``, ``CURRENT_TIME``,
+``CURRENT_TIMESTAMP`` or ``CURRENT_USER``.
 
 *SET LOCAL TRANSACTION*
 -----------------------
 
-If your DBMS supports transaction that may affect more than one SQL-server, you 
-can use the <keyword> ``LOCAL`` (new to SQL with SQL3) to set the transaction 
-characteristics for the next local transaction. If you omit ``LOCAL``, you're 
-instructing your DBMS to set the transaction characteristics for the next 
-transaction executed by the program, regardless of location. If ``LOCAL`` is 
-specified, then you may not also specify the size of the transaction's 
-diagnostics area. 
+If your DBMS supports transaction that may affect more than one SQL-server, you
+can use the <keyword> ``LOCAL`` (new to SQL with SQL3) to set the transaction
+characteristics for the next local transaction. If you omit ``LOCAL``, you're
+instructing your DBMS to set the transaction characteristics for the next
+transaction executed by the program, regardless of location. If ``LOCAL`` is
+specified, then you may not also specify the size of the transaction's
+diagnostics area.
 
-Certain errors can arise when you try to use the ``SET TRANSACTION`` statement: 
+Certain errors can arise when you try to use the ``SET TRANSACTION`` statement:
 
-* If you try to issue it when a transaction has already begun, ``SET 
-  TRANSACTION`` will fail: your DBMS will return the ``SQLSTATE error 25001 
-  "invalid transaction state-active SQL-transaction"``. 
+* If you try to issue it when a transaction has already begun, ``SET
+  TRANSACTION`` will fail: your DBMS will return the ``SQLSTATE error 25001
+  "invalid transaction state-active SQL-transaction"``.
 
-* If you issue it when there are holdable-cursors still open from the previous 
-  transaction and the isolation level of that transaction is not the same as 
-  the isolation level you're specifying for the next transaction, ``SET 
-  TRANSACTION`` will fail: your DBMS will return the ``SQLSTATE error 25008 
-  "invalid transaction state-held cursor requires same isolation level"``. 
+* If you issue it when there are holdable-cursors still open from the previous
+  transaction and the isolation level of that transaction is not the same as
+  the isolation level you're specifying for the next transaction, ``SET
+  TRANSACTION`` will fail: your DBMS will return the ``SQLSTATE error 25008
+  "invalid transaction state-held cursor requires same isolation level"``.
 
-* If you issue ``SET LOCAL TRANSACTION`` and your DBMS doesn't support 
-  transactions that affect multiple SQL-servers, ``SET LOCAL TRANSACTION`` will 
-  fail: your DBMS will return the ``SQLSTATE error 0A001 "feature not 
-  supported-multiple server transactions"``. 
+* If you issue ``SET LOCAL TRANSACTION`` and your DBMS doesn't support
+  transactions that affect multiple SQL-servers, ``SET LOCAL TRANSACTION`` will
+  fail: your DBMS will return the ``SQLSTATE error 0A001 "feature not
+  supported-multiple server transactions"``.
 
-If you want to restrict your code to Core SQL, don't use ``SET LOCAL 
-TRANSACTION`` and don't set any transaction's isolation level to anything but 
-``SERIALIZABLE``. 
+If you want to restrict your code to Core SQL, don't use ``SET LOCAL
+TRANSACTION`` and don't set any transaction's isolation level to anything but
+``SERIALIZABLE``.
 
 START TRANSACTION Statement
 ===========================
 
-In SQL3, you don't need the ``SET TRANSACTION`` statement, except for setting 
-the characteristics of local transactions. Instead, you can use the ``START 
-TRANSACTION`` statement to both initiate the start of a new transaction and to 
-set that transaction's characteristics. The required syntax for the ``START 
-TRANSACTION`` statement is: 
+In SQL3, you don't need the ``SET TRANSACTION`` statement, except for setting
+the characteristics of local transactions. Instead, you can use the ``START
+TRANSACTION`` statement to both initiate the start of a new transaction and to
+set that transaction's characteristics. The required syntax for the ``START
+TRANSACTION`` statement is:
 
 ::
 
@@ -529,73 +531,73 @@ TRANSACTION`` statement is:
        <transaction access mode> |
        <diagnostics size>
 
-Each of the transaction characteristics -- <isolation level>, <transaction 
-access mode> and <diagnostics size> -- works the same, and has the same options 
-as those we discussed for the ``SET TRANSACTION`` statement. The only real 
-difference between the two statements is that ``SET TRANSACTION`` is considered 
-to be outside of a transaction -- it defines the characteristics for the next 
-transaction coming up -- while ``START TRANSACTION`` is considered as the 
-beginning of a transaction -- it defines the characteristics of the transaction 
-it begins. 
+Each of the transaction characteristics -- <isolation level>, <transaction
+access mode> and <diagnostics size> -- works the same, and has the same options
+as those we discussed for the ``SET TRANSACTION`` statement. The only real
+difference between the two statements is that ``SET TRANSACTION`` is considered
+to be outside of a transaction -- it defines the characteristics for the next
+transaction coming up -- while ``START TRANSACTION`` is considered as the
+beginning of a transaction -- it defines the characteristics of the transaction
+it begins.
 
-One other thing of note: The characteristics of a transaction that you start 
-with a ``START TRANSACTION`` statement are as specified in that statement -- 
-even if the specification is implicit because you leave out one or more of the 
-transaction mode options. That is, even if one or more characteristics are 
-omitted from ``START TRANSACTION``, they will default to the appropriate values 
--- they will not take on any non-default characteristics even if you issue a 
-``SET TRANSACTION`` statement that includes other specifications for those 
-characteristics just before you begin the transaction. 
+One other thing of note: The characteristics of a transaction that you start
+with a ``START TRANSACTION`` statement are as specified in that statement --
+even if the specification is implicit because you leave out one or more of the
+transaction mode options. That is, even if one or more characteristics are
+omitted from ``START TRANSACTION``, they will default to the appropriate values
+-- they will not take on any non-default characteristics even if you issue a
+``SET TRANSACTION`` statement that includes other specifications for those
+characteristics just before you begin the transaction.
 
-If you want to restrict your code to Core SQL, don't use the ``START 
-TRANSACTION`` statement. 
+If you want to restrict your code to Core SQL, don't use the ``START
+TRANSACTION`` statement.
 
 Special Problems
 ================
 
-The SQL-Schema change statements (``CREATE``, ``ALTER``, ``DROP``, ``GRANT``, 
-``REVOKE``) require drastic solutions to ensure concurrency. Typically, a DBMS 
-must lock all the ``INFORMATION_CATALOG`` descriptors. That means that 
-SQL-Schema statements cannot run concurrently with anything else. 
+The SQL-Schema change statements (``CREATE``, ``ALTER``, ``DROP``, ``GRANT``,
+``REVOKE``) require drastic solutions to ensure concurrency. Typically, a DBMS
+must lock all the ``INFORMATION_CATALOG`` descriptors. That means that
+SQL-Schema statements cannot run concurrently with anything else.
 
-The ``INSERT`` statement is more concurrent than the ``UPDATE`` or ``DELETE`` 
-statements. By definition, any "new" row is a not-yet-committed row and 
-therefore is invisible to all other transactions (except transactions which are 
-running at the ``READ UNCOMMITTED`` isolation level). Where ``INSERT`` will 
-have problems is in cases where the target Table includes a Column with a 
-serial data type (which is non-standard) -- in such cases, the DBMS cannot 
-guarantee that the value will truly be serial unless the isolation level of all 
-transactions is ``SERIALIZABLE``. 
+The ``INSERT`` statement is more concurrent than the ``UPDATE`` or ``DELETE``
+statements. By definition, any "new" row is a not-yet-committed row and
+therefore is invisible to all other transactions (except transactions which are
+running at the ``READ UNCOMMITTED`` isolation level). Where ``INSERT`` will
+have problems is in cases where the target Table includes a Column with a
+serial data type (which is non-standard) -- in such cases, the DBMS cannot
+guarantee that the value will truly be serial unless the isolation level of all
+transactions is ``SERIALIZABLE``.
 
-It is fairly easy to lock a "row" in a Base table, since there is usually some 
-fixed physical file address which corresponds to the row. However, an "index 
-key" in an index file is a slipperier thing. Index keys can move, as anyone who 
-has studied B+trees can tell you. So, when you update a row, remember that you 
-may be locking not only the row, but an entire page of an index. 
+It is fairly easy to lock a "row" in a Base table, since there is usually some
+fixed physical file address which corresponds to the row. However, an "index
+key" in an index file is a slipperier thing. Index keys can move, as anyone who
+has studied B+trees can tell you. So, when you update a row, remember that you
+may be locking not only the row, but an entire page of an index.
 
-Regardless of isolation level, none of the isolation phenomena should occur 
-during: *(a)* implied reading of Schema definitions (that is, while finding 
-Objects during the "prepare" phase ... as opposed to "explicit" reading, which 
-is what happens if you ``SELECT ... FROM INFORMATION_SCHEMA``.<Table name>); 
-*(b)* processing of integrity Constraints (but not Triggers). The implication 
-is that standard SQL DBMSs have to lock the whole database when preparing a 
-statement, and at the end of a statement's execution phase. This is a difficult 
-requirement. 
+Regardless of isolation level, none of the isolation phenomena should occur
+during: *(a)* implied reading of Schema definitions (that is, while finding
+Objects during the "prepare" phase ... as opposed to "explicit" reading, which
+is what happens if you ``SELECT ... FROM INFORMATION_SCHEMA``.<Table name>);
+*(b)* processing of integrity Constraints (but not Triggers). The implication
+is that standard SQL DBMSs have to lock the whole database when preparing a
+statement, and at the end of a statement's execution phase. This is a difficult
+requirement.
 
 Transactions and Constraint Checking
 ====================================
 
-There is one other SQL transaction management statement: ``SET CONSTRAINTS``. 
-We talked about ``SET CONSTRAINTS`` a bit in our chapter on constraints and 
-assertions; basically, it allows you to tell the DBMS when you want it to check 
-any deferrable Constraints that were affected during a transaction. A 
-transaction always begins with an initial default constraint mode for every 
-Constraint that is used during the course of the transaction. A Constraint's 
-initial constraint mode, specified when the Constraint was created, determines 
-when the Constraint will be checked for violation of its rule: immediately at 
-the end of each SQL statement executed, or later on in the transaction. The 
-``SET CONSTRAINTS`` statement is used to specify a different constraint mode 
-for one or more ``DEFERRABLE`` Constraints during the course of a transaction. 
+There is one other SQL transaction management statement: ``SET CONSTRAINTS``.
+We talked about ``SET CONSTRAINTS`` a bit in our chapter on constraints and
+assertions; basically, it allows you to tell the DBMS when you want it to check
+any deferrable Constraints that were affected during a transaction. A
+transaction always begins with an initial default constraint mode for every
+Constraint that is used during the course of the transaction. A Constraint's
+initial constraint mode, specified when the Constraint was created, determines
+when the Constraint will be checked for violation of its rule: immediately at
+the end of each SQL statement executed, or later on in the transaction. The
+``SET CONSTRAINTS`` statement is used to specify a different constraint mode
+for one or more ``DEFERRABLE`` Constraints during the course of a transaction.
 
 *SET CONSTRAINTS Statement*
 ---------------------------
@@ -610,33 +612,33 @@ The required syntax for the ``SET CONSTRAINTS`` statement is:
        ALL |
        <Constraint name> [ {,<Constraint name>}... ]
 
-Remember that all Constraints and Assertions are defined with a deferral mode 
-of either ``NOT DEFERRABLE`` or ``DEFERRABLE``. A deferral mode of ``NOT 
-DEFERRABLE`` means that the Constraint must be checked for violation as soon as 
-the SQL statement that affects it is executed -- this type of Constraint can't 
-be affected by the ``SET CONSTRAINTS`` statement and we'll ignore it here. A 
-deferral mode of ``DEFERRABLE``, on the other hand, allows you to specify when 
-you want your DBMS to check the Constraint for violation -- the choices are at 
-statement end or at transaction end -- and such Constraints may be affected by 
-the ``SET CONSTRAINTS`` statement. 
+Remember that all Constraints and Assertions are defined with a deferral mode
+of either ``NOT DEFERRABLE`` or ``DEFERRABLE``. A deferral mode of ``NOT
+DEFERRABLE`` means that the Constraint must be checked for violation as soon as
+the SQL statement that affects it is executed -- this type of Constraint can't
+be affected by the ``SET CONSTRAINTS`` statement and we'll ignore it here. A
+deferral mode of ``DEFERRABLE``, on the other hand, allows you to specify when
+you want your DBMS to check the Constraint for violation -- the choices are at
+statement end or at transaction end -- and such Constraints may be affected by
+the ``SET CONSTRAINTS`` statement.
 
-Every transaction has a constraint mode for each integrity Constraint affected 
-by that transaction. If the Constraint is a ``NOT DEFERRABLE`` Constraint, the 
-constraint mode is always ``IMMEDIATE``. But if the Constraint is a 
-``DEFERRABLE`` Constraint, then its constraint mode at the beginning of a 
-transaction will either be ``IMMEDIATE`` or ``DEFERRED``, depending on the way 
-you defined the Constraint -- if you defined it as ``DEFERRABLE INITIALLY 
-IMMEDIATE``, the Constraint's constraint mode at transaction start will be 
-``IMMEDIATE`` and if you defined it as ``DEFERRABLE INITIALLY DEFERRED``, the 
-Constraint's constraint mode at transaction start will be ``DEFERRED``. You can 
-use the ``SET CONSTRAINTS`` statement to change these default constraint mode 
-settings for one or more Constraints -- but only for the duration of the 
-transaction that you use it in. (You can actually issue ``SET CONSTRAINTS`` at 
-two different times. If you issue it during a transaction, you're changing the 
-constraint mode of only those Constraints that are affected during that same 
-transaction. If you issue it when there is no current transaction, you're 
-changing the constraint mode of only those Constraints that are affected during 
-the very next transaction.) 
+Every transaction has a constraint mode for each integrity Constraint affected
+by that transaction. If the Constraint is a ``NOT DEFERRABLE`` Constraint, the
+constraint mode is always ``IMMEDIATE``. But if the Constraint is a
+``DEFERRABLE`` Constraint, then its constraint mode at the beginning of a
+transaction will either be ``IMMEDIATE`` or ``DEFERRED``, depending on the way
+you defined the Constraint -- if you defined it as ``DEFERRABLE INITIALLY
+IMMEDIATE``, the Constraint's constraint mode at transaction start will be
+``IMMEDIATE`` and if you defined it as ``DEFERRABLE INITIALLY DEFERRED``, the
+Constraint's constraint mode at transaction start will be ``DEFERRED``. You can
+use the ``SET CONSTRAINTS`` statement to change these default constraint mode
+settings for one or more Constraints -- but only for the duration of the
+transaction that you use it in. (You can actually issue ``SET CONSTRAINTS`` at
+two different times. If you issue it during a transaction, you're changing the
+constraint mode of only those Constraints that are affected during that same
+transaction. If you issue it when there is no current transaction, you're
+changing the constraint mode of only those Constraints that are affected during
+the very next transaction.)
 
 The SQL statement:
 
@@ -644,10 +646,10 @@ The SQL statement:
 
    SET CONSTRAINTS ALL IMMEDIATE;
 
-has the effect of setting the constraint mode of every ``DEFERRABLE`` 
-Constraint to ``IMMEDIATE``. ``IMMEDIATE`` means that the Constraints must be 
-checked for violation after the execution of every SQL statement -- including 
-after ``SET CONSTRAINTS``. 
+has the effect of setting the constraint mode of every ``DEFERRABLE``
+Constraint to ``IMMEDIATE``. ``IMMEDIATE`` means that the Constraints must be
+checked for violation after the execution of every SQL statement -- including
+after ``SET CONSTRAINTS``.
 
 The SQL statement:
 
@@ -655,16 +657,16 @@ The SQL statement:
 
    SET CONSTRAINTS ALL DEFERRED;
 
-has the effect of setting the constraint mode of every ``DEFERRABLE`` 
-Constraint to ``DEFERRED``. ``DEFERRED`` means that the Constraints should not 
-be checked for violation after the execution of every SQL statement, but should 
-instead be checked at some later time, but no later than the end of the current 
-transaction. (``COMMIT`` includes an implied ``SET CONSTRAINTS ALL IMMEDIATE`` 
-statement, so that all Constraints are checked at transaction end.) 
+has the effect of setting the constraint mode of every ``DEFERRABLE``
+Constraint to ``DEFERRED``. ``DEFERRED`` means that the Constraints should not
+be checked for violation after the execution of every SQL statement, but should
+instead be checked at some later time, but no later than the end of the current
+transaction. (``COMMIT`` includes an implied ``SET CONSTRAINTS ALL IMMEDIATE``
+statement, so that all Constraints are checked at transaction end.)
 
-If you provide a list of <Constraint name>s instead of using the <keyword> 
-``ALL``, the constraint mode of only those Constraints is affected. For 
-example, if you have these Constraints: 
+If you provide a list of <Constraint name>s instead of using the <keyword>
+``ALL``, the constraint mode of only those Constraints is affected. For
+example, if you have these Constraints:
 
 ::
 
@@ -681,45 +683,45 @@ and you issue this SQL statement:
 
    SET CONSTRAINTS Constraint_1,Constraint_3,Constraint_4 DEFERRED;
 
-the result is that ``Constraint_1``, ``Constraint_3``, ``Constraint_4``, 
-``Constraint_5`` and ``Constraint_6`` will all have a constraint mode of 
-``DEFERRED`` and ``Constraint_2`` will continue to have a constraint mode of 
-``IMMEDIATE``. 
+the result is that ``Constraint_1``, ``Constraint_3``, ``Constraint_4``,
+``Constraint_5`` and ``Constraint_6`` will all have a constraint mode of
+``DEFERRED`` and ``Constraint_2`` will continue to have a constraint mode of
+``IMMEDIATE``.
 
-All Constraints with a constraint mode of ``IMMEDIATE`` are checked for 
-violation at SQL statement. Constraints with a constraint mode of deferred, on 
-the other hand, are not checked until transaction end. This let's you do 
-operations which temporarily puts your data into an unsound state and can thus 
-be very useful. 
+All Constraints with a constraint mode of ``IMMEDIATE`` are checked for
+violation at SQL statement. Constraints with a constraint mode of deferred, on
+the other hand, are not checked until transaction end. This let's you do
+operations which temporarily puts your data into an unsound state and can thus
+be very useful.
 
 Dialects
 ========
 
-Some DBMSs support locking, some support timestamping, some support both. 
-Beyond that fundamental point of difference, there are many 
-implementation-dependent features. For example: the granularity (by Column or 
-row or page or Table or database), the number of distinct isolation levels that 
-are actually supported (remember that pseudo-support is possible by simply 
-upgrading to the next level), and whether to support SQL-92 or SQL3 syntax. 
-Regrettably, most DBMSs are still idiosyncratic with respect to support for the 
-``SET TRANSACTION`` statement. 
+Some DBMSs support locking, some support timestamping, some support both.
+Beyond that fundamental point of difference, there are many
+implementation-dependent features. For example: the granularity (by Column or
+row or page or Table or database), the number of distinct isolation levels that
+are actually supported (remember that pseudo-support is possible by simply
+upgrading to the next level), and whether to support SQL-92 or SQL3 syntax.
+Regrettably, most DBMSs are still idiosyncratic with respect to support for the
+``SET TRANSACTION`` statement.
 
-IBM's DB2 and its imitators have explicit statements for locking Tables: ``LOCK 
-TABLE`` <name> ``IN {EXCLUSIVE|SHARED} MODE;``. This reduces the total number 
-of locks, and actually enhances concurrency if your intention is to access 
-every row in the Table. 
+IBM's DB2 and its imitators have explicit statements for locking Tables: ``LOCK
+TABLE`` <name> ``IN {EXCLUSIVE|SHARED} MODE;``. This reduces the total number
+of locks, and actually enhances concurrency if your intention is to access
+every row in the Table.
 
-ODBC specifies a variety of options which essentially are options for row 
-identifiers used in scrolling. There are also CLI-specific commands for setting 
-transaction isolation or other concurrency-related characteristics. 
+ODBC specifies a variety of options which essentially are options for row
+identifiers used in scrolling. There are also CLI-specific commands for setting
+transaction isolation or other concurrency-related characteristics.
 
-Oracle has Locks Display and other utilities that help administrators to 
-monitor concurrency. 
+Oracle has Locks Display and other utilities that help administrators to
+monitor concurrency.
 
 Goodies
 =======
 
-The OCELOT DBMS that comes with this book supports concurrency. These are 
+The OCELOT DBMS that comes with this book supports concurrency. These are
 the specifications:
 
 +---------------------------------------------+------------------+

--- a/docs/chapters/38.rst
+++ b/docs/chapters/38.rst
@@ -4,6 +4,8 @@
 Chapter 38 -- SQL Sessions
 ==========================
 
+.. include:: ../_include/note.rst
+
 An SQL-session spans the execution of one or more consecutive SQL statements by
 a single user. In order to execute any SQL statements, your DBMS has to
 establish an SQL-Connection (using the ``CONNECT`` statement) -- the

--- a/docs/chapters/39.rst
+++ b/docs/chapters/39.rst
@@ -4,6 +4,8 @@
 Chapter 39 -- Embedded SQL Binding Style
 ========================================
 
+.. include:: ../_include/note.rst
+
 SQL DBMSs communicate with SQL applications through a common programming
 language interface that is invoked through one of the SQL Standard-defined
 binding styles, or interface options. The programming language used -- either

--- a/docs/chapters/40.rst
+++ b/docs/chapters/40.rst
@@ -4,31 +4,33 @@
 Chapter 40 -- SQL/CLI Binding Style
 ===================================
 
+.. include:: ../_include/note.rst
+
 SQL DBMSs communicate with SQL applications through a common programming
 language interface that is invoked through one of the SQL Standard-defined
 binding styles, or interface options. There are three main approaches to
 writing complete programs with SQL:
 
-1. With embedded SQL, you can put SQL statements directly into host 
+1. With embedded SQL, you can put SQL statements directly into host
    programs. We described this binding style in the last chapter.
 
 2. With the Module binding style, you can dispense with host programs
-   and write entire Modules in SQL. You'll still have to call these Modules 
-   from one of the standard host languages though. We'll describe this 
+   and write entire Modules in SQL. You'll still have to call these Modules
+   from one of the standard host languages though. We'll describe this
    binding style last.
 
-3. With SQL/CLI, you can call a SQL DBMS's library from a host program. The SQL 
-   statements you want to execute are parameters of the call. Because SQL's 
-   *modus operandi* won't quite match the host language's, helper functions are 
-   required for the interface definition. This binding style is the subject of 
-   the next several chapters. 
+3. With SQL/CLI, you can call a SQL DBMS's library from a host program. The SQL
+   statements you want to execute are parameters of the call. Because SQL's
+   *modus operandi* won't quite match the host language's, helper functions are
+   required for the interface definition. This binding style is the subject of
+   the next several chapters.
 
 The SQL/CLI, or Call-level Interface binding style, is defined in part three
-of the SQL Standard. In this chapter, we'll give you an introduction to 
+of the SQL Standard. In this chapter, we'll give you an introduction to
 this SQL binding style.
 
 Embedded SQL used to be the most important way of putting SQL statements into
-application programs. Nowadays, the CLI is the most important. Not because 
+application programs. Nowadays, the CLI is the most important. Not because
 it's simpler -- far from it! The CLI's real advantages are:
 
 * There's no precompiler (this makes debugging easier).
@@ -41,7 +43,7 @@ Onward, then, to the CLI essentials. CLI stands for *Call Level Interface*. You
 have probably heard of an API (Application Programming Interface), which is a
 non-SQL name for the same sort of thing. The CLI defines a set of public
 functions which can be called from a host language. Each function has a name,
-a parameter list and a required algorithm (what the DBMS must do when you 
+a parameter list and a required algorithm (what the DBMS must do when you
 call it using this function).
 
 .. rubric:: Table of Contents
@@ -73,23 +75,23 @@ examples that follow throughout our description of the CLI are all in C):
       SQLFreeHandle(SQL_HANDLE_DBC,hdbc);
       SQLFreeHandle(SQL_HANDLE_ENV,henv); }
 
-This sample program has all the necessary CLI ingredients. It will take several 
-pages to say how they all work, but the main points are noted in the code as 
-follows: 
+This sample program has all the necessary CLI ingredients. It will take several
+pages to say how they all work, but the main points are noted in the code as
+follows:
 
-``[Note 1]`` Include the SQL/CLI header file. The standard name is 
-``"sqlcli.h"`` but you might see this statement -- ``#include "sql.h"`` -- 
-instead. The header file has the prototypes of all the CLI functions and 
-``#defines`` for all the constants. The function names begin with ``SQL`` and 
-the constant names begin with ``SQL_`` -- that's the convention in C programs. 
-You can program standard SQL without following this convention, but it seems 
-reasonable to follow it. 
+``[Note 1]`` Include the SQL/CLI header file. The standard name is
+``"sqlcli.h"`` but you might see this statement -- ``#include "sql.h"`` --
+instead. The header file has the prototypes of all the CLI functions and
+``#defines`` for all the constants. The function names begin with ``SQL`` and
+the constant names begin with ``SQL_`` -- that's the convention in C programs.
+You can program standard SQL without following this convention, but it seems
+reasonable to follow it.
 
-``[Note 2]`` Variable declarations. The convention this time is: ``h`` stands 
-for handle -- so a ``henv`` is a handle of an ``env``, a ``hdbc`` is a handle 
-of a ``dbc`` and a ``hstmt`` is a handle of a ``stmt``. And now, since those 
-abbreviated words will appear many times in the next 200 pages, we'd advise you 
-to memorize them: 
+``[Note 2]`` Variable declarations. The convention this time is: ``h`` stands
+for handle -- so a ``henv`` is a handle of an ``env``, a ``hdbc`` is a handle
+of a ``dbc`` and a ``hstmt`` is a handle of a ``stmt``. And now, since those
+abbreviated words will appear many times in the next 200 pages, we'd advise you
+to memorize them:
 
 * ``env`` is an "allocated thing [resource] used for an environment".
 
@@ -97,39 +99,39 @@ to memorize them:
 
 * ``stmt`` is an "allocated thing [resource] used for a statement".
 
-For the record, the Standard's usual names for ``env``, ``dbc`` and ``stmt`` 
-are "allocated SQL-environment", "allocated SQL-connection" and "allocated 
-SQL-statement", respectively. We will always use the abbreviations because they 
-are what appear in ``sqlcli.h``, and in all programs. Besides, we believe it's 
-crazy to call a ``stmt`` a statement -- a ``stmt`` is a ``RESOURCE``; a 
-statement is a ``STRING``. Let's not confuse the peanut with the shell. As it 
-happens, the ``sqlcli.h`` header file has "``typedef``"s for ``SQLHENV`` and 
-the other handles: they're all 32-bit integers. Other important typedefs are 
-``SQLINTEGER`` ("long int"), ``SQLSMALLINT`` ("short int"), ``SQLCHAR`` 
-("char") and ``SQLRETURN`` ("short int", used for return codes only). Using, 
-say, "``SQLINTEGER x``" in a program rather than "long int x" helps make it 
-clear that "x" will see use in an SQL function. 
+For the record, the Standard's usual names for ``env``, ``dbc`` and ``stmt``
+are "allocated SQL-environment", "allocated SQL-connection" and "allocated
+SQL-statement", respectively. We will always use the abbreviations because they
+are what appear in ``sqlcli.h``, and in all programs. Besides, we believe it's
+crazy to call a ``stmt`` a statement -- a ``stmt`` is a ``RESOURCE``; a
+statement is a ``STRING``. Let's not confuse the peanut with the shell. As it
+happens, the ``sqlcli.h`` header file has "``typedef``"s for ``SQLHENV`` and
+the other handles: they're all 32-bit integers. Other important typedefs are
+``SQLINTEGER`` ("long int"), ``SQLSMALLINT`` ("short int"), ``SQLCHAR``
+("char") and ``SQLRETURN`` ("short int", used for return codes only). Using,
+say, "``SQLINTEGER x``" in a program rather than "long int x" helps make it
+clear that "x" will see use in an SQL function.
 
-``[Note 3]`` Setup functions. The bare minimum procedure involves making an 
-``env``, making a ``dbc``, connecting using the ``dbc`` and making a ``stmt``. 
-Notice the &s in the program code: these are "output" parameters ("output" from 
-the DBMS point of view). They're passed by address because the DBMS fills in 
-the values for them. 
+``[Note 3]`` Setup functions. The bare minimum procedure involves making an
+``env``, making a ``dbc``, connecting using the ``dbc`` and making a ``stmt``.
+Notice the &s in the program code: these are "output" parameters ("output" from
+the DBMS point of view). They're passed by address because the DBMS fills in
+the values for them.
 
-``[Note 4]`` Meat. The only actual SQL-language statement in our program is a 
-string argument for a CLI function call. This is the actual database work. 
+``[Note 4]`` Meat. The only actual SQL-language statement in our program is a
+string argument for a CLI function call. This is the actual database work.
 
-``[Note 5]`` Tear-down functions. In a reverse of the setup procedure, we call 
-functions for destroying a ``stmt``, disconnecting using the ``dbc``, 
-destroying the ``dbc`` and destroying the ``env``. Notice that every function 
-call used a handle -- that's normal. Doubtless the DBMS is merely malloc'ing a 
-bit of memory for each of our "allocated things", but we can't access the 
-fields directly. Instead, we use a ``henv`` or a ``hdbc`` or a ``hstmt``. 
+``[Note 5]`` Tear-down functions. In a reverse of the setup procedure, we call
+functions for destroying a ``stmt``, disconnecting using the ``dbc``,
+destroying the ``dbc`` and destroying the ``env``. Notice that every function
+call used a handle -- that's normal. Doubtless the DBMS is merely malloc'ing a
+bit of memory for each of our "allocated things", but we can't access the
+fields directly. Instead, we use a ``henv`` or a ``hdbc`` or a ``hstmt``.
 
 SQLCHAR, SQLINTEGER and Other Typedefs
 ======================================
 
-Here are the type definitions in the ``sqlcli.h`` header file. We use these 
+Here are the type definitions in the ``sqlcli.h`` header file. We use these
 names for declarations of C variables in all our examples.
 
 ::
@@ -147,15 +149,15 @@ names for declarations of C variables in all our examples.
 
 .. NOTE::
 
-   In the ODBC 3.0 header file, ``SQLHENV`` and ``SQLHDBC`` and ``SQLHSTMT`` 
-   and ``SQLHDESC`` are all ``typedef void*`` instead of ``typedef long int``. 
-   In older versions of the ODBC header file, the names were ``HENV``, 
-   ``HDBC``, ``HSTMT``, etc. 
+   In the ODBC 3.0 header file, ``SQLHENV`` and ``SQLHDBC`` and ``SQLHSTMT``
+   and ``SQLHDESC`` are all ``typedef void*`` instead of ``typedef long int``.
+   In older versions of the ODBC header file, the names were ``HENV``,
+   ``HDBC``, ``HSTMT``, etc.
 
 SQLRETURN
 =========
 
-All CLI functions return a 16-bit value. We refer to this value as the 
+All CLI functions return a 16-bit value. We refer to this value as the
 ``SQLRETURN`` value because ``sqlcli.h`` contains this line:
 
 ::
@@ -178,17 +180,17 @@ In standard SQL there are only six possible ``SQLRETURN`` values:
 | ``100`` | "no data".                 |
 +---------+----------------------------+
 
-Programs should check these values, but for space reasons we leave 
-``SQLRETURN`` out of many of our examples. 
+Programs should check these values, but for space reasons we leave
+``SQLRETURN`` out of many of our examples.
 
 Handle Relationships
 ====================
 
-A handle is a 32-bit integer which can be used as a unique identifier of a 
-"resource". The following chart shows all the resources which have handles. The 
-relationships between resources are either optional ("zero-to-many" -- shown 
-with double arrows) or mandatory (either "one-to-one" or "zero-to-one" -- shown 
-with single arrows). 
+A handle is a 32-bit integer which can be used as a unique identifier of a
+"resource". The following chart shows all the resources which have handles. The
+relationships between resources are either optional ("zero-to-many" -- shown
+with double arrows) or mandatory (either "one-to-one" or "zero-to-one" -- shown
+with single arrows).
 
 ::
 
@@ -212,15 +214,15 @@ How to Run Example Programs
 This book contains several example programs that we use to illustrate the
 SQL/CLI. Each example program is also included on the CD that came with this
 book, numbered in order of appearance (for example the "example C program"
-shown earlier is ``example1.c``). To try out any of the example programs, 
+shown earlier is ``example1.c``). To try out any of the example programs,
 follow these steps.
 
 If you use Microsoft Windows 3.x:
 
-* Copy these files from the CD to your working directory: ``OCELOT16.DLL``, 
+* Copy these files from the CD to your working directory: ``OCELOT16.DLL``,
   ``OCELOT16.LIB``, ``SQLCLI.H`` and the C program file.
 
-* Using a standard-C package, compile and link. For eample, this is a 
+* Using a standard-C package, compile and link. For eample, this is a
   sequence for Borland C++ version 3.1 (with the MS-DOS command line):
 
 ::
@@ -232,10 +234,10 @@ If you use Microsoft Windows 3.x:
 
 If you use Microsoft Windows 95:
 
-* Copy these files from the diskette to your working directory: 
+* Copy these files from the diskette to your working directory:
   ``OCELOT32.DLL``, ``OCELOT32.LIB``, ``SQLCLI.H`` and the C program file.
 
-* Using a standard-C package, compile and link. For example, this is a 
+* Using a standard-C package, compile and link. For example, this is a
   sequence for Symantec C++ version 7.0 (with the MS-DOS command line):
 
 ::
@@ -250,28 +252,28 @@ If you use Microsoft Windows 95:
    Add your own screen-display statements so you'll see the
    values of program variables when you run the program. If there's a CLI
    function that you want to get experience with, put it into your own program,
-   link with the library supplied with this book, and run. As well as being 
-   good practice, this will help you learn what is NOT standard SQL, since 
-   we deliberately kept out "implementation-defined" features when we wrote 
+   link with the library supplied with this book, and run. As well as being
+   good practice, this will help you learn what is NOT standard SQL, since
+   we deliberately kept out "implementation-defined" features when we wrote
    this DBMS.
 
 "Standard SQL CLI" Equals "Core ODBC API"
 =========================================
 
-History: Microsoft published the ODBC 1.0 specification in 1992. It became 
-popular. Soon there were supporting interfaces for all the major DBMSs that 
-worked under Microsoft Windows. ODBC became a *de facto* standard specification 
-for calling SQL from host programs without a precompiler. The ISO Standard CLI 
-came out in 1995. The influence of ODBC on the standard CLI is apparent in 
-almost every routine. Indeed, it sometimes is hard to understand the official 
-Standard document without studying Microsoft's ODBC manual too. On its part, 
-Microsoft made major changes in ODBC 3.0 (1998). They added several new 
-functions and deprecated several old ones, in order to get closer to the SQL 
-Standard. Microsoft's ODBC 3.0 manual makes these claims: 
+History: Microsoft published the ODBC 1.0 specification in 1992. It became
+popular. Soon there were supporting interfaces for all the major DBMSs that
+worked under Microsoft Windows. ODBC became a *de facto* standard specification
+for calling SQL from host programs without a precompiler. The ISO Standard CLI
+came out in 1995. The influence of ODBC on the standard CLI is apparent in
+almost every routine. Indeed, it sometimes is hard to understand the official
+Standard document without studying Microsoft's ODBC manual too. On its part,
+Microsoft made major changes in ODBC 3.0 (1998). They added several new
+functions and deprecated several old ones, in order to get closer to the SQL
+Standard. Microsoft's ODBC 3.0 manual makes these claims:
 
-"ODBC aligns with the following specifications and standards that deal with the 
-Call-Level Interface (CLI). (ODBC's features are a superset of each of these 
-standards.) 
+"ODBC aligns with the following specifications and standards that deal with the
+Call-Level Interface (CLI). (ODBC's features are a superset of each of these
+standards.)
 
 * The X/Open CAE Specification "Data Management: SQL Call-Level Interface (CLI)
 
@@ -279,85 +281,85 @@ standards.)
 
 As a result of this alignment, the following are true:
 
-* An application written to the X/Open and ISO CLI specifications will work 
-  with an ODBC 3.0 driver or a standards-compliant driver when it is compiled 
-  with the ODBC 3.0 header files and linked with ODBC 3.0 libraries, and when 
-  it gains access to the driver through the ODBC 3.0 Driver Manager. 
+* An application written to the X/Open and ISO CLI specifications will work
+  with an ODBC 3.0 driver or a standards-compliant driver when it is compiled
+  with the ODBC 3.0 header files and linked with ODBC 3.0 libraries, and when
+  it gains access to the driver through the ODBC 3.0 Driver Manager.
 
-* A driver written to the X/Open and ISO CLI specifications will work with an 
-  ODBC 3.0 application or a standards-compliant application when it is compiled 
-  with the ODBC 3.0 header files and linked with ODBC 3.0 libraries, and when 
-  the application gains access to the driver through the ODBC 3.0 Driver 
-  Manager. 
+* A driver written to the X/Open and ISO CLI specifications will work with an
+  ODBC 3.0 application or a standards-compliant application when it is compiled
+  with the ODBC 3.0 header files and linked with ODBC 3.0 libraries, and when
+  the application gains access to the driver through the ODBC 3.0 Driver
+  Manager.
 
-The Core interface conformance level encompasses all the features in the ISO 
-CLI and all the non-optional features in the X/Open CLI. Optional features of 
-the X/Open CLI appear in higher interface conformance levels. Because all ODBC 
-3.0 drivers are required to support the features in the Core interface 
-conformance level, the following are true: 
+The Core interface conformance level encompasses all the features in the ISO
+CLI and all the non-optional features in the X/Open CLI. Optional features of
+the X/Open CLI appear in higher interface conformance levels. Because all ODBC
+3.0 drivers are required to support the features in the Core interface
+conformance level, the following are true:
 
-* An ODBC 3.0 driver will support all the features used by a 
+* An ODBC 3.0 driver will support all the features used by a
   standards-compliant application.
 
-* An ODBC 3.0 application using only the features in ISO CLI and the 
-  non-optional features of the X/Open CLI will work with any 
+* An ODBC 3.0 application using only the features in ISO CLI and the
+  non-optional features of the X/Open CLI will work with any
   standards-compliant driver."
 
-Whoa! The SQL Standard CLI isn't quite as close to Core ODBC as Microsoft is 
-suggesting. There are a few incompatibilities in names, there are two 
-differences in prototype definitions (of ``SQLColumnAttr`` and ``SQLGetInfo``) 
-and ODBC's default behaviour for "commits" is *sui generis*. But we'll note 
-those bugs as we step on them. Once you know what they are, you'll be able to 
-adjust. 
+Whoa! The SQL Standard CLI isn't quite as close to Core ODBC as Microsoft is
+suggesting. There are a few incompatibilities in names, there are two
+differences in prototype definitions (of ``SQLColumnAttr`` and ``SQLGetInfo``)
+and ODBC's default behaviour for "commits" is *sui generis*. But we'll note
+those bugs as we step on them. Once you know what they are, you'll be able to
+adjust.
 
-Since this is a book on the SQL Standard, our chapters on the CLI won't show 
-you the various extra features that appear in ODBC but not in the standard CLI. 
-And we note only once -- now -- that any feature which is marked "SQL3" is a 
-feature of the standard CLI but not necessarily of ODBC. 
+Since this is a book on the SQL Standard, our chapters on the CLI won't show
+you the various extra features that appear in ODBC but not in the standard CLI.
+And we note only once -- now -- that any feature which is marked "SQL3" is a
+feature of the standard CLI but not necessarily of ODBC.
 
 How Each CLI Function Will Be Described
 =======================================
 
-In these chapters, we will describe each CLI function separately. We've put 
-them in order according to this rule: if we can't describe A without knowing 
-about B, then B should come before A. This means that some tedious minor 
-functions precede some important ones, but the advantage is that you can read 
-from front to back. Better to slog, rather than jump around. 
+In these chapters, we will describe each CLI function separately. We've put
+them in order according to this rule: if we can't describe A without knowing
+about B, then B should come before A. This means that some tedious minor
+functions precede some important ones, but the advantage is that you can read
+from front to back. Better to slog, rather than jump around.
 
-The structure of each CLI-function description is semi-rigid. You can expect to 
-find these things, in this order: 
+The structure of each CLI-function description is semi-rigid. You can expect to
+find these things, in this order:
 
-1. Function prototype. This is the prototype as it appears in the header file, 
-   ``sqlcli.h``. It gives a quick idea of what the function's name is and what 
-   <data type>s the parameters have. There is a comment beside each parameter 
-   indicating whether it's an "input" parameter (its value goes from the 
-   application to the DBMS) or an "output" parameter (its value goes from the 
-   DBMS to the application). 
+1. Function prototype. This is the prototype as it appears in the header file,
+   ``sqlcli.h``. It gives a quick idea of what the function's name is and what
+   <data type>s the parameters have. There is a comment beside each parameter
+   indicating whether it's an "input" parameter (its value goes from the
+   application to the DBMS) or an "output" parameter (its value goes from the
+   DBMS to the application).
 
-2. Job. A one-sentence description of what the function is for. This may be 
-   followed by an indication of whether the function is essential or not. 
-   Several functions are obsolete or redundant, so you can skip the details on 
-   your first pass through these chapters. 
+2. Job. A one-sentence description of what the function is for. This may be
+   followed by an indication of whether the function is essential or not.
+   Several functions are obsolete or redundant, so you can skip the details on
+   your first pass through these chapters.
 
-3. Algorithm. Exactly what does the DBMS do with this function? This section is 
-   in a sort of pseudocode. We're trying to make the instructions readable, but 
-   we won't spare you from mind-numbing (but necessary) details. 
+3. Algorithm. Exactly what does the DBMS do with this function? This section is
+   in a sort of pseudocode. We're trying to make the instructions readable, but
+   we won't spare you from mind-numbing (but necessary) details.
 
-4. Notes. Whatever strikes us as worthy of remark about a function. 
+4. Notes. Whatever strikes us as worthy of remark about a function.
 
-5. Example. A code snippet written in C. Usually the example will be an 
-   incomplete program, with ... to indicate that we haven't repeated stuff 
-   which doesn't advance the story. Most commonly, we leave out the "setup" and 
-   "tear- down" phases illustrated in the example program shown at the 
-   beginning of this chapter. 
+5. Example. A code snippet written in C. Usually the example will be an
+   incomplete program, with ... to indicate that we haven't repeated stuff
+   which doesn't advance the story. Most commonly, we leave out the "setup" and
+   "tear- down" phases illustrated in the example program shown at the
+   beginning of this chapter.
 
-6. ODBC. Anything that relates specifically to ODBC, but not to the standard 
-   CLI. If a standard CLI procedure doesn't exactly match the ODBC spec, it 
-   gets noted here. If ODBC has a truly significant feature that is not in the 
-   standard CLI, we mention it curtly. 
+6. ODBC. Anything that relates specifically to ODBC, but not to the standard
+   CLI. If a standard CLI procedure doesn't exactly match the ODBC spec, it
+   gets noted here. If ODBC has a truly significant feature that is not in the
+   standard CLI, we mention it curtly.
 
-Having said that, let's get on with the descriptions. Here's a quick list of 
-the 62 standard CLI functions: 
+Having said that, let's get on with the descriptions. Here's a quick list of
+the 62 standard CLI functions:
 
 ::
 
@@ -427,7 +429,7 @@ the 62 standard CLI functions:
 
 And that concludes our brief introduction to the CLI. Before we begin
 describing each of the functions in this list in detail, though, we'll show
-you a sample function description, using a common CLI function subroutine 
+you a sample function description, using a common CLI function subroutine
 -- ``CharacterStringRetrieval``.
 
 CharacterStringRetrieval
@@ -444,10 +446,10 @@ CharacterStringRetrieval
       SQLINTEGER *SourceOctetLength     /* 32-bit output */
       );
 
-**Job:** The common subroutine for Character String Retrieval appears in 24 CLI 
-functions. You don't directly call it, but you see the effects. We thought this 
-would be a good way to introduce the format we use for CLI function 
-descriptions. 
+**Job:** The common subroutine for Character String Retrieval appears in 24 CLI
+functions. You don't directly call it, but you see the effects. We thought this
+would be a good way to introduce the format we use for CLI function
+descriptions.
 
 **Algorithm:**
 
@@ -481,22 +483,22 @@ descriptions.
 
 **Notes:**
 
-* The idea is simply to copy the ``*Source`` string to the ``*Target`` string, 
-  but there's a safeguard against overflowing ``*Target`` (that's why we pass 
-  ``MaxTargetOctetLength``) and there's a place to store the original size 
-  (that's why we pass ``*ReturnedOctetLength``). 
+* The idea is simply to copy the ``*Source`` string to the ``*Target`` string,
+  but there's a safeguard against overflowing ``*Target`` (that's why we pass
+  ``MaxTargetOctetLength``) and there's a place to store the original size
+  (that's why we pass ``*ReturnedOctetLength``).
 
-* The ``*Target`` string will always be null-terminated, unless 
-  ``TargetOctetLength=0``. 
+* The ``*Target`` string will always be null-terminated, unless
+  ``TargetOctetLength=0``.
 
-* There are variations of this routine where ``...OctetLength`` is 16-bit. 
+* There are variations of this routine where ``...OctetLength`` is 16-bit.
 
-* There is a slight variation of this routine for ``BLOB`` retrieval: it works 
-  the same way, but ignores anything to do with null terminators. 
+* There is a slight variation of this routine for ``BLOB`` retrieval: it works
+  the same way, but ignores anything to do with null terminators.
 
-* ``CharacterStringRetrieval(target,source,max,&sourcelength)`` is expressible 
-  using the standard-C <string.h> function ``strxfrm: sourcelength = 
-  strxfrm(target,source,max);`` 
+* ``CharacterStringRetrieval(target,source,max,&sourcelength)`` is expressible
+  using the standard-C <string.h> function ``strxfrm: sourcelength =
+  strxfrm(target,source,max);``
 
 **Example:**
 
@@ -514,5 +516,5 @@ descriptions.
       /* Now target has: AB\0 and returnsize = 2. */
 
 **ODBC:** In ODBC 1.0's documentation there was some contradictory information
-about the workings of Character String Retrieval, but everything is settled 
+about the workings of Character String Retrieval, but everything is settled
 now.

--- a/docs/chapters/41.rst
+++ b/docs/chapters/41.rst
@@ -4,12 +4,14 @@
 Chapter 41 -- SQL/CLI: env Functions
 ====================================
 
-In this chapter, we'll describe the first essential CLI resource: the ``env``. 
-For CLI programs, the ``env`` is the all-encompassing context area -- all CLI 
-programs begin by establishing an ``env``. The ``env`` contains some 
-information directly ("attributes" and "diagnostics"), but what's important is 
-that an ``env`` contains zero or more ``dbcs`` (although there's no point in 
-having an ``env`` without a ``dbc``). Here's a closeup view of an ``env``: 
+.. include:: ../_include/note.rst
+
+In this chapter, we'll describe the first essential CLI resource: the ``env``.
+For CLI programs, the ``env`` is the all-encompassing context area -- all CLI
+programs begin by establishing an ``env``. The ``env`` contains some
+information directly ("attributes" and "diagnostics"), but what's important is
+that an ``env`` contains zero or more ``dbcs`` (although there's no point in
+having an ``env`` without a ``dbc``). Here's a closeup view of an ``env``:
 
 ::
 
@@ -34,41 +36,41 @@ Traditionally, there have been three ways to define character strings:
 
 1. They are fixed length. Example: a COBOL ``PIC X(5)`` variable.
 
-2. They are variable length and a separate variable tells us the size. Example: 
-   the 16-bit octet-length -- ``SIZE%`` -- in a BASIC string ``var$``, or the 
-   8-bit octet-length which is the first byte of a Turbo Pascal string. 
+2. They are variable length and a separate variable tells us the size. Example:
+   the 16-bit octet-length -- ``SIZE%`` -- in a BASIC string ``var$``, or the
+   8-bit octet-length which is the first byte of a Turbo Pascal string.
 
-3. They are variable length and the end is marked by a termination code. 
-   Example: the 8-bit byte ``= '\0'`` which ends strings in C programs. This 
-   code, which in a wide-character string would be a 16-bit word ``0x0000``, is 
-   the null terminator. Inprise Pascal (Delphi) uses the same convention for 
-   ``PChar`` variables. 
+3. They are variable length and the end is marked by a termination code.
+   Example: the 8-bit byte ``= '\0'`` which ends strings in C programs. This
+   code, which in a wide-character string would be a 16-bit word ``0x0000``, is
+   the null terminator. Inprise Pascal (Delphi) uses the same convention for
+   ``PChar`` variables.
 
-We've assumed that any DBMS which supports C/Pascal interfaces will go with 
-null termination. That affects the CLI in only one way: you can receive 
-null-terminated strings from the DBMS whenever Character String Retrieval is 
-called for. Going the other way -- passing null-terminated strings to the DBMS 
--- is legal regardless of the setting of ``NULL TERMINATION``. That's because 
-you indicate null termination of input strings using ``SQL_NTS`` for "size". 
+We've assumed that any DBMS which supports C/Pascal interfaces will go with
+null termination. That affects the CLI in only one way: you can receive
+null-terminated strings from the DBMS whenever Character String Retrieval is
+called for. Going the other way -- passing null-terminated strings to the DBMS
+-- is legal regardless of the setting of ``NULL TERMINATION``. That's because
+you indicate null termination of input strings using ``SQL_NTS`` for "size".
 
-Sixteen of the CLI functions accept an input-string parameter. In these 
-functions, the parameter immediately following the input-string parameter is 
-the *input-string length* -- for example: 
+Sixteen of the CLI functions accept an input-string parameter. In these
+functions, the parameter immediately following the input-string parameter is
+the *input-string length* -- for example:
 
 ::
 
    <function name> (... input_string, input_string_length);
 
-The input length should be the number of octets in the input string, not 
-including the null termination octet(s). However, you can pass ``SQL_NTS 
-(-3)`` instead -- this stands for "null terminated string" -- and let 
-the DBMS calculate the string size. Remember, though, that programs 
-which pass ``SQL_NTS`` are many nanoseconds slower than programs which 
-pass an absolute length. 
+The input length should be the number of octets in the input string, not
+including the null termination octet(s). However, you can pass ``SQL_NTS
+(-3)`` instead -- this stands for "null terminated string" -- and let
+the DBMS calculate the string size. Remember, though, that programs
+which pass ``SQL_NTS`` are many nanoseconds slower than programs which
+pass an absolute length.
 
-There are six CLI functions for creating ``envs``, dropping ``envs``, 
-getting ``env`` attributes and setting ``env`` attributes. Their 
-descriptions follow. 
+There are six CLI functions for creating ``envs``, dropping ``envs``,
+getting ``env`` attributes and setting ``env`` attributes. Their
+descriptions follow.
 
 SQLAllocHandle(SQL_HANDLE_ENV,...)
 ==================================
@@ -100,18 +102,18 @@ Usually the first SQL-related instruction is the call to make an ``env``:
 
 The first parameter (``HandleType``) is ``SQL_HANDLE_ENV``.
 
-The second parameter (``InputHandle``) doesn't matter here. As a style 
-note: we follow a convention that "if the parameter value doesn't matter 
-then use a constant containing the word ``NULL``. This convention helps 
-make it clear that the value we're passing has no significance. 
+The second parameter (``InputHandle``) doesn't matter here. As a style
+note: we follow a convention that "if the parameter value doesn't matter
+then use a constant containing the word ``NULL``. This convention helps
+make it clear that the value we're passing has no significance.
 
-The third parameter (``*OutputHandle``) must be an address of an 
-environment handle. As explained before, we prefer to call an 
-environment handle a "``henv``". But use a descriptive name for your 
-program variable if you have one. 
+The third parameter (``*OutputHandle``) must be an address of an
+environment handle. As explained before, we prefer to call an
+environment handle a "``henv``". But use a descriptive name for your
+program variable if you have one.
 
-If the function succeeds: you have a new ``env``. Keep the ``henv``, 
-you'll need it later for input to other functions. 
+If the function succeeds: you have a new ``env``. Keep the ``henv``,
+you'll need it later for input to other functions.
 
 * Testing for error returns
 
@@ -137,11 +139,11 @@ snippet shows the scenarios:
     else {
       /* There was no error. */ }
 
-There are several other possible errors/exception conditions that the 
-``SQLAllocHandle`` function might "raise". If they occur, the function will 
-return a negative number: -2 (``SQL_INVALID_HANDLE``) or -1 (``SQL_ERROR``). 
-For more detailed information, look up the ``SQLSTATE`` codes beginning with 
-``HY``, ``HY001`` or ``HY014`` in our chapter on SQL/CLI diagnostics. 
+There are several other possible errors/exception conditions that the
+``SQLAllocHandle`` function might "raise". If they occur, the function will
+return a negative number: -2 (``SQL_INVALID_HANDLE``) or -1 (``SQL_ERROR``).
+For more detailed information, look up the ``SQLSTATE`` codes beginning with
+``HY``, ``HY001`` or ``HY014`` in our chapter on SQL/CLI diagnostics.
 
 **Algorithm:**
 
@@ -172,7 +174,7 @@ For more detailed information, look up the ``SQLSTATE`` codes beginning with
 In discussions of other CLI functions, we will usually ignore the
 "implementation-defined" possibilities.
 
-**ODBC:** The ``SQLAllocHandle`` function is new in ODBC 3.0. Error 
+**ODBC:** The ``SQLAllocHandle`` function is new in ODBC 3.0. Error
 information will not be available until you call the "connect" function.
 
 SQLAllocEnv
@@ -204,24 +206,24 @@ is the same as
 
 * Implicit Calls
 
-In the algorithm description, the words "is the same as" mean that, in effect, 
-the DBMS calls ``SQLAllocHandle`` when you call ``SQLAllocEnv``. So you have 
-called ``SQLAllocHandle`` indirectly, or -- as the Standard puts it -- 
-"implicitly". For purposes of interpreting the somewhat legalistic Standard, it 
-makes absolutely no difference whether you perform an operation explicitly or 
-implicitly. 
+In the algorithm description, the words "is the same as" mean that, in effect,
+the DBMS calls ``SQLAllocHandle`` when you call ``SQLAllocEnv``. So you have
+called ``SQLAllocHandle`` indirectly, or -- as the Standard puts it --
+"implicitly". For purposes of interpreting the somewhat legalistic Standard, it
+makes absolutely no difference whether you perform an operation explicitly or
+implicitly.
 
 * Obsolescent Handle Functions
 
-``SQLAllocEnv`` is one of six functions -- ``SQLAllocEnv``, ``SQLFreeEnv``, 
-``SQLAllocConnect``, ``SQLFreeConnect``, ``SQLAllocStmt``, ``SQLFreeStmt`` - 
-which are nowadays, mostly redundant. They are a legacy of the days when there 
-were only three kinds of resources: ``env``, ``dbc`` and ``stmt``. Mostly, you 
-will see them in programs written for early versions of ODBC. The Standard does 
-not "deprecate" these functions, so we may assume that they will continue to be 
-part of standard SQL for the indefinite future. However, their presence will 
-make a program look old-fashioned. The only exception is ``SQLFreeStmt``, which 
-has a few useful options. 
+``SQLAllocEnv`` is one of six functions -- ``SQLAllocEnv``, ``SQLFreeEnv``,
+``SQLAllocConnect``, ``SQLFreeConnect``, ``SQLAllocStmt``, ``SQLFreeStmt`` -
+which are nowadays, mostly redundant. They are a legacy of the days when there
+were only three kinds of resources: ``env``, ``dbc`` and ``stmt``. Mostly, you
+will see them in programs written for early versions of ODBC. The Standard does
+not "deprecate" these functions, so we may assume that they will continue to be
+part of standard SQL for the indefinite future. However, their presence will
+make a program look old-fashioned. The only exception is ``SQLFreeStmt``, which
+has a few useful options.
 
 **Example:**
 
@@ -236,9 +238,9 @@ has a few useful options.
         printf("Error: could not make an env.\n");
         exit(1); }
 
-**ODBC:** The ``SQLAllocEnv`` routine has been in ODBC since version 1.0. The 
-ODBC 3.0 manual deprecates it, suggesting that users should switch to using 
-``SQLAllocHandle(SQL_HANDLE_ENV,...)``. 
+**ODBC:** The ``SQLAllocEnv`` routine has been in ODBC since version 1.0. The
+ODBC 3.0 manual deprecates it, suggesting that users should switch to using
+``SQLAllocHandle(SQL_HANDLE_ENV,...)``.
 
 SQLGetEnvAttr
 =============
@@ -254,9 +256,9 @@ SQLGetEnvAttr
     SQLINTEGER BufferLength,        /* 32-bit input */
     SQLINTEGER *StringLength);      /* 32-bit pointer to output */
 
-**Job:** Get an ``env`` attribute. At the moment there is only one standard 
-``env`` attribute: a flag saying whether strings are null-terminated. The flag 
-has this ``#define`` in ``sqlcli.h``: 
+**Job:** Get an ``env`` attribute. At the moment there is only one standard
+``env`` attribute: a flag saying whether strings are null-terminated. The flag
+has this ``#define`` in ``sqlcli.h``:
 
 ::
 
@@ -276,10 +278,10 @@ has this ``#define`` in ``sqlcli.h``:
 
 **Notes:**
 
-* The ``BufferLength??`` and ``StringLength`` parameters are unused. They're 
-  there in case a future edition of the SQL Standard requires more information. 
-  Or, as with all functions, there is a chance that your particular DBMS stores 
-  attribute information that the Standard doesn't officially require. 
+* The ``BufferLength??`` and ``StringLength`` parameters are unused. They're
+  there in case a future edition of the SQL Standard requires more information.
+  Or, as with all functions, there is a chance that your particular DBMS stores
+  attribute information that the Standard doesn't officially require.
 
 **Example:**
 
@@ -291,7 +293,7 @@ has this ``#define`` in ``sqlcli.h``:
   ...
   SQLGetEnvAttr(henv,SQL_ATTR_OUTPUT_NTS,&attribute,NULL,NULL);
 
-**ODBC:** The ``SQLGetEnvAttr`` function is new in ODBC 3.0. There are also 
+**ODBC:** The ``SQLGetEnvAttr`` function is new in ODBC 3.0. There are also
 a few other ``env`` options which are specific to ODBC.
 
 SQLSetEnvAttr
@@ -308,11 +310,11 @@ SQLSetEnvAttr
     SQLINTEGER StringLength   /* 32-bit input */
     );
 
-**Job:** Set an ``env`` attribute. At the moment there is only one standard 
-``env`` attribute -- whether output strings are null-terminated -- see the 
-discussion of the ``SQLGetEnvAttr`` function for some detailed remarks on the 
-subject of Null Termination. It is probably sufficient to know that you do not 
-want to change this attribute if you program in C or Pascal. 
+**Job:** Set an ``env`` attribute. At the moment there is only one standard
+``env`` attribute -- whether output strings are null-terminated -- see the
+discussion of the ``SQLGetEnvAttr`` function for some detailed remarks on the
+subject of Null Termination. It is probably sufficient to know that you do not
+want to change this attribute if you program in C or Pascal.
 
 **Algorithm:**
 
@@ -355,9 +357,9 @@ want to change this attribute if you program in C or Pascal.
         exit(1); }
       exit(0); }
 
-**ODBC:** The ``SQLSetEnvAttr`` function is new in ODBC 3.0. It is 
-impossible to change the ``NULL TERMINATION env`` attribute. There are 
-other attributes. For example, to explicitly state that your application is 
+**ODBC:** The ``SQLSetEnvAttr`` function is new in ODBC 3.0. It is
+impossible to change the ``NULL TERMINATION env`` attribute. There are
+other attributes. For example, to explicitly state that your application is
 written for ODBC version 3.0, say:
 
 ::
@@ -377,7 +379,7 @@ SQLFreeHandle(SQL_HANDLE_ENV,...)
     SQLINTEGER Handle         /* 32-bit input (must be a henv) */
     );
 
-**Job:** Destroy an ``env``. This is the reverse of the 
+**Job:** Destroy an ``env``. This is the reverse of the
 ``SQLAllocHandle(SQL_HANDLE_ENV,...)`` function.
 
 **Algorithm:**
@@ -418,7 +420,7 @@ SQLFreeEnv
     SQLHENV henv                    /* 32-bit input */
     );
 
-**Job:** Destroy an ``env``. This is the reverse of the ``SQLAllocEnv`` 
+**Job:** Destroy an ``env``. This is the reverse of the ``SQLAllocEnv``
 function. ``SQLFreeEnv`` is redundant.
 
 **Algorithm:**
@@ -435,7 +437,7 @@ is the same thing as
 
 **Notes:**
 
-* The Standard does not say that the ``SQLFreeEnv`` function is 
+* The Standard does not say that the ``SQLFreeEnv`` function is
   deprecated. All DBMSs should support it.
 
 **Example:**
@@ -451,9 +453,9 @@ is the same thing as
       /* henv is now an invalid handle */
       ...
 
-**ODBC:** The ``SQLFreeEnv`` function has been in ODBC since version 1.0. 
-The ODBC 3 manual deprecates it, suggesting that users should switch to 
+**ODBC:** The ``SQLFreeEnv`` function has been in ODBC since version 1.0.
+The ODBC 3 manual deprecates it, suggesting that users should switch to
 using ``SQLFreeHandle(SQL_HANDLE_ENV,...)``.
 
-And that's it for the ``env`` functions. In the next chapter, we'll take a look 
+And that's it for the ``env`` functions. In the next chapter, we'll take a look
 at the ``dbc`` functions.

--- a/docs/chapters/42.rst
+++ b/docs/chapters/42.rst
@@ -4,11 +4,13 @@
 Chapter 42 -- SQL/CLI: dbc Functions
 ====================================
 
-In this chapter, we'll describe the second essential CLI resource: the ``dbc``. 
-For CLI programs, the ``dbc`` is at the level below ``env`` and above ``stmt``. 
-The ``env`` may contain multiple ``dbc``\s, and the ``dbc`` may contain multiple 
-``stmt``\s (the ``dbc`` may also contain multiple ``desc``\s, but only of the 
-"user" kind). Here's a closeup view of a ``dbc``: 
+.. include:: ../_include/note.rst
+
+In this chapter, we'll describe the second essential CLI resource: the ``dbc``.
+For CLI programs, the ``dbc`` is at the level below ``env`` and above ``stmt``.
+The ``env`` may contain multiple ``dbc``\s, and the ``dbc`` may contain multiple
+``stmt``\s (the ``dbc`` may also contain multiple ``desc``\s, but only of the
+"user" kind). Here's a closeup view of a ``dbc``:
 
 ::
 
@@ -27,8 +29,8 @@ The ``env`` may contain multiple ``dbc``\s, and the ``dbc`` may contain multiple
                          v v           v v
                          ... to stmts  ... to user descs
 
-There are eight CLI functions for creating ``dbc``\s, dropping ``dbc``\s, 
-getting ``dbc`` attributes, setting ``dbc`` attributes, connecting and 
+There are eight CLI functions for creating ``dbc``\s, dropping ``dbc``\s,
+getting ``dbc`` attributes, setting ``dbc`` attributes, connecting and
 disconnecting. Their descriptions follow.
 
 .. rubric:: Table of Contents
@@ -60,16 +62,16 @@ SQLAllocHandle(SQL_HANDLE_DBC,...)
     handle is passed in InputHandle) and returns the handle of the new dbc into
     the memory location addressed by OutputHandle. }
 
-That is, If ``(HandleType == SQL_HANDLE_DBC)``, then the job is to allocate 
+That is, If ``(HandleType == SQL_HANDLE_DBC)``, then the job is to allocate
 a new ``dbc``.
 
 **Notes:**
 
-* The second parameter, ``InputHandle``, must be a valid ``henv`` so this 
+* The second parameter, ``InputHandle``, must be a valid ``henv`` so this
   function call happens after ``SQLAllocHandle(SQL_ALLOC_ENV,...)``.
 
-* Keep the ``hdbc``, you'll need it later for 
-  ``SQLAllocHandle(SQL_HANDLE_STMT, ...)``, for ``SQLFreeHandle(SQL_HANDLE_DBC, 
+* Keep the ``hdbc``, you'll need it later for
+  ``SQLAllocHandle(SQL_HANDLE_STMT, ...)``, for ``SQLFreeHandle(SQL_HANDLE_DBC,
   ...)`` and for other functions.
 
 **Example:**
@@ -84,7 +86,7 @@ a new ``dbc``.
       sqlreturn = SQLAllocHandle(SQL_HANDLE_DBC,henv,&hdbc);
       ...
 
-**ODBC:** The ``SQLAllocHandle`` function is new in ODBC 3.0. Error 
+**ODBC:** The ``SQLAllocHandle`` function is new in ODBC 3.0. Error
 information will not be available until you call the "connect" function.
 
 SQLAllocConnect
@@ -128,11 +130,11 @@ is the same as:
 
 **Notes:**
 
-* Although ``SQLAllocConnect`` is in the "obsolescent" category, it is 
+* Although ``SQLAllocConnect`` is in the "obsolescent" category, it is
   still a standard function supported by all DBMSs.
 
-**ODBC:** The ``SQLAllocConnect`` routine has been in ODBC since version 
-1.0. The ODBC 3.0 manual deprecates it, suggesting that users should switch 
+**ODBC:** The ``SQLAllocConnect`` routine has been in ODBC since version
+1.0. The ODBC 3.0 manual deprecates it, suggesting that users should switch
 to using ``SQLAllocHandle(SQL_HANDLE_DBC, ...)``.
 
 SQLConnect
@@ -152,78 +154,78 @@ SQLConnect
     SQLSMALLINT NameLength3         /* 16-bit input (Authentication length)*/
     );
 
-**Job:** Establish an SQL-Connection for a ``dbc``. The details of "how to 
-connect" depend largely on the implementation. We describe two broad cases: a 
-Single-Tier Scenario (everything on one computer) and a Two-Tier Scenario 
-(Client on one computer, Server on another computer). One or the other will be 
-fairly close to what your specific implementation does. 
+**Job:** Establish an SQL-Connection for a ``dbc``. The details of "how to
+connect" depend largely on the implementation. We describe two broad cases: a
+Single-Tier Scenario (everything on one computer) and a Two-Tier Scenario
+(Client on one computer, Server on another computer). One or the other will be
+fairly close to what your specific implementation does.
 
 * Single-Tier scenario
 
-   * Step 1. The client (which is effectively the same thing as "the DBMS") 
-     verifies that the parameters have valid data. Specifically, it must be 
-     true that: *(a)* The ``dbc`` exists. If it doesn't, the return is 
-     CLI-specific condition: invalid handle. Read up on the ``SQLAllocHandle`` 
-     function to see how to set up the handle. *(b)* There is no SQL 
-     transaction running on this Connection. (Actually some sophisticated 
-     systems allow this, but we assume the normal case.) If there is one, the 
-     return is ``0A001`` feature not supported: multiple transactions. It's 
-     okay if you have a transaction going on a different SQL-Connection -- this 
-     just means you can't connect twice using the same ``dbc`` handle. Read up 
-     on ``SQLDisconnect`` if you're already connected. *(c)* The ``ServerName`` 
-     parameter is valid. This should be a string, with a maximum length of 128 
-     octets (as usual the length is passed along with the string, in 
-     ``NameLength1``, and may be ``SQL_NTS``). If it's not valid, the return is 
-     ``HY090`` invalid string length or buffer length. *(d)* The ``UserName`` 
-     is valid. The contents of this string will become the <AuthorizationID>, 
-     so the string should contain a valid identifier, such as: ``'USER_1'`` or 
-     ``' USER_1 '`` (lead and trail spaces don't matter). *(e)* The 
-     authentication is valid. Usually a blank is acceptable: ''. 
+   * Step 1. The client (which is effectively the same thing as "the DBMS")
+     verifies that the parameters have valid data. Specifically, it must be
+     true that: *(a)* The ``dbc`` exists. If it doesn't, the return is
+     CLI-specific condition: invalid handle. Read up on the ``SQLAllocHandle``
+     function to see how to set up the handle. *(b)* There is no SQL
+     transaction running on this Connection. (Actually some sophisticated
+     systems allow this, but we assume the normal case.) If there is one, the
+     return is ``0A001`` feature not supported: multiple transactions. It's
+     okay if you have a transaction going on a different SQL-Connection -- this
+     just means you can't connect twice using the same ``dbc`` handle. Read up
+     on ``SQLDisconnect`` if you're already connected. *(c)* The ``ServerName``
+     parameter is valid. This should be a string, with a maximum length of 128
+     octets (as usual the length is passed along with the string, in
+     ``NameLength1``, and may be ``SQL_NTS``). If it's not valid, the return is
+     ``HY090`` invalid string length or buffer length. *(d)* The ``UserName``
+     is valid. The contents of this string will become the <AuthorizationID>,
+     so the string should contain a valid identifier, such as: ``'USER_1'`` or
+     ``' USER_1 '`` (lead and trail spaces don't matter). *(e)* The
+     authentication is valid. Usually a blank is acceptable: ''.
 
-   * Step 2. The DBMS "opens" the database named ``ServerName``. This may seem 
-     like a misuse of the parameter, but the fact is, we don't need to contact 
-     a server -- but we do need to open a database. And it's fairly common that 
-     there will be more than one database on a computer, so names are 
-     necessary. 
+   * Step 2. The DBMS "opens" the database named ``ServerName``. This may seem
+     like a misuse of the parameter, but the fact is, we don't need to contact
+     a server -- but we do need to open a database. And it's fairly common that
+     there will be more than one database on a computer, so names are
+     necessary.
 
 * Two-Tier scenario
 
-   * Step 1. The client (the local task which your application is calling) 
-     verifies that the parameters have valid data. This step is local, the only 
-     likely difference is that the client will not bother to verify the 
-     "authentication" parameter, since that's usually the server's problem. 
+   * Step 1. The client (the local task which your application is calling)
+     verifies that the parameters have valid data. This step is local, the only
+     likely difference is that the client will not bother to verify the
+     "authentication" parameter, since that's usually the server's problem.
 
    * Step 2. If ``ServerName = "DEFAULT"``:
-   
+
    ::
-   
+
      If (User Name Length <> 0) invalid string or buffer length
      If (Authentication Length <> 0) invalid string or buffer length
      If (Somebody else already in as default) connection name in use
          Otherwise:
      (Compare the effect of a "CONNECT TO DEFAULT;" statement.)
 
-   * Step 3. Using RDA, the client finds the server identified by the parameter 
-     ``ServerName``, and sends a message to the server containing the parameter 
-     values (``UserName`` and ``Authentication``). If the network's down, or 
-     the server's not out there, then the return is: ``08001 connection 
-     exception-SQL-client unable to establish SQL-session.`` 
+   * Step 3. Using RDA, the client finds the server identified by the parameter
+     ``ServerName``, and sends a message to the server containing the parameter
+     values (``UserName`` and ``Authentication``). If the network's down, or
+     the server's not out there, then the return is: ``08001 connection
+     exception-SQL-client unable to establish SQL-session.``
 
-   * Step 4. The server does its own validation of ``UserName`` and 
-     ``Authentication``. One possibility is that the ``Authentication`` is 
-     designed to be a password, and it doesn't match what that ``UserName``\'s 
-     password is supposed to be. In this case, the return is: ``08004 
-     connection exception-SQL-server rejected establishment of SQL-session.`` 
-     Notice the difference between this error and the one described in Step 3 
-     -- ``SQLSTATE is '08001'`` if the client can't talk to the server; 
-     ``SQLSTATE is '08004'`` is if they can talk, but the server says no. 
+   * Step 4. The server does its own validation of ``UserName`` and
+     ``Authentication``. One possibility is that the ``Authentication`` is
+     designed to be a password, and it doesn't match what that ``UserName``\'s
+     password is supposed to be. In this case, the return is: ``08004
+     connection exception-SQL-server rejected establishment of SQL-session.``
+     Notice the difference between this error and the one described in Step 3
+     -- ``SQLSTATE is '08001'`` if the client can't talk to the server;
+     ``SQLSTATE is '08004'`` is if they can talk, but the server says no.
 
-   * Step 5. All having gone well, we now have a new SQL-session. If there was 
-     already an SQL-session in progress, it becomes dormant. The new 
-     SQL-session becomes the current SQL-session. The new SQL-session's session 
-     <AuthorizationID> becomes ``UserName`` -- that is, if the ``UserName`` 
-     parameter is ``'X'``, and you use the niladic function ``SESSION_USER`` in 
-     an SQL statement, you'll get ``'X'``. 
+   * Step 5. All having gone well, we now have a new SQL-session. If there was
+     already an SQL-session in progress, it becomes dormant. The new
+     SQL-session becomes the current SQL-session. The new SQL-session's session
+     <AuthorizationID> becomes ``UserName`` -- that is, if the ``UserName``
+     parameter is ``'X'``, and you use the niladic function ``SESSION_USER`` in
+     an SQL statement, you'll get ``'X'``.
 
 **Example:**
 
@@ -250,11 +252,11 @@ fairly close to what your specific implementation does.
             if (sqlreturn == SQL_SUCCESS || sqlreturn == SQL_SUCCESS_WITH_INFO) {
               printf("connected successfully.\n"); } } } }
 
-**ODBC:** ``SQLConnect`` has been a supported function since ODBC 1.0. But 
-there are other, non-standard, ODBC functions which can be used to connect. The 
-alternatives take advantage of the Windows environment (by putting up dialog 
-boxes etc.), and assume that Microsoft's Driver Manager software will take care 
-of some details. 
+**ODBC:** ``SQLConnect`` has been a supported function since ODBC 1.0. But
+there are other, non-standard, ODBC functions which can be used to connect. The
+alternatives take advantage of the Windows environment (by putting up dialog
+boxes etc.), and assume that Microsoft's Driver Manager software will take care
+of some details.
 
 *CONNECT versus SQLConnect:*
 ----------------------------
@@ -263,22 +265,22 @@ There is an SQL statement which we've already discussed:
 
 ::
 
-   CONNECT TO <SQL-server-name> [AS <Connection name>] 
+   CONNECT TO <SQL-server-name> [AS <Connection name>]
                USER <AuthorizationID>;
 
-You are not supposed to execute this SQL statement using the CLI! The business 
-of connecting is to be handled exclusively through the ``SQLConnect`` function. 
-So if you write a program which accepts user commands in the form of SQL 
-statements, you must intercept any that begin with ``"CONNECT ..."`` and call 
-the ``SQLAllocConnect`` and ``SQLConnect`` functions for them. Unfortunately, 
-this is difficult because there is an imperfect mapping between the arguments 
-of the ``CONNECT`` statement and the parameters of ``SQLConnect``. 
+You are not supposed to execute this SQL statement using the CLI! The business
+of connecting is to be handled exclusively through the ``SQLConnect`` function.
+So if you write a program which accepts user commands in the form of SQL
+statements, you must intercept any that begin with ``"CONNECT ..."`` and call
+the ``SQLAllocConnect`` and ``SQLConnect`` functions for them. Unfortunately,
+this is difficult because there is an imperfect mapping between the arguments
+of the ``CONNECT`` statement and the parameters of ``SQLConnect``.
 
-Similar interceptions will be necessary for the three other SQL statements 
-which must not be executed directly using the CLI: ``DISCONNECT``, ``COMMIT`` 
-and ``ROLLBACK``. For each of these statements there is an approximate 
-CLI-function analogue: ``SQLDisconnect``, ``SQLEndTran(...SQL_COMMIT)`` and 
-``SQLEndTran(...SQL_ROLLBACK)``. 
+Similar interceptions will be necessary for the three other SQL statements
+which must not be executed directly using the CLI: ``DISCONNECT``, ``COMMIT``
+and ``ROLLBACK``. For each of these statements there is an approximate
+CLI-function analogue: ``SQLDisconnect``, ``SQLEndTran(...SQL_COMMIT)`` and
+``SQLEndTran(...SQL_ROLLBACK)``.
 
 SQLDisconnect
 =============
@@ -291,7 +293,7 @@ SQLDisconnect
     SQLHDBC hdbc                    /* 32-bit input */
     );
 
-**Job:** End an SQL session which was started by calling the ``SQLConnect`` 
+**Job:** End an SQL session which was started by calling the ``SQLConnect``
 function. Analogous to the SQL ``DISCONNECT`` statement.
 
 **Algorithm:**
@@ -325,16 +327,16 @@ function. Analogous to the SQL ``DISCONNECT`` statement.
 
 **Notes:**
 
-* A connected ``dbc`` takes up space, and in a multi-user scenario there might 
-  be conflicts with other SQL-sessions using the same server. You should always 
-  call ``SQLDisconnect`` to end an SQL-session, although some single-tier DBMSs 
-  don't require it. After you call ``SQLDisconnect``, you can either re-connect 
-  (see ``SQLConnect``) or finish the tear-down process by freeing the ``dbc`` 
-  (see ``SQLFreeHandle(SQL_HANDLE_DBC...)``). 
+* A connected ``dbc`` takes up space, and in a multi-user scenario there might
+  be conflicts with other SQL-sessions using the same server. You should always
+  call ``SQLDisconnect`` to end an SQL-session, although some single-tier DBMSs
+  don't require it. After you call ``SQLDisconnect``, you can either re-connect
+  (see ``SQLConnect``) or finish the tear-down process by freeing the ``dbc``
+  (see ``SQLFreeHandle(SQL_HANDLE_DBC...)``).
 
-* There is a side effect: a previously-dormant SQL-Connection might become 
-  current. That can only happen if the DBMS allows double-connections on the 
-  same ``dbc``. 
+* There is a side effect: a previously-dormant SQL-Connection might become
+  current. That can only happen if the DBMS allows double-connections on the
+  same ``dbc``.
 
 **Example:**
 
@@ -354,8 +356,8 @@ function. Analogous to the SQL ``DISCONNECT`` statement.
       SQLFreeHandle(hdbc,...); /* SQLFreeHandle call for dbc */
       SQLFreeHandle(...); }    /* SQLFreeHandle call for env */
 
-**ODBC:** The ``SQLDisconnect`` function has been around since ODBC 1.0. 
-``SQLDisconnect`` causes automatic dropping of all statements and 
+**ODBC:** The ``SQLDisconnect`` function has been around since ODBC 1.0.
+``SQLDisconnect`` causes automatic dropping of all statements and
 descriptors open on the connection.
 
 SQLGetConnectAttr
@@ -373,31 +375,31 @@ SQLGetConnectAttr
     SQLINTEGER *StringLength        /* pointer to 32-bit output */
     );
 
-**Job:** Get the value of a ``dbc`` attribute. The standard implementation of 
-the ``SQLGetConnectAttr`` function doesn't do anything important, but there 
-might be non-standard, implementation-defined attributes that you can retrieve 
-using ``SQLGetConnectAttr``. The standard connection attribute has this 
-``#define`` in ``sqlcli.h``: 
+**Job:** Get the value of a ``dbc`` attribute. The standard implementation of
+the ``SQLGetConnectAttr`` function doesn't do anything important, but there
+might be non-standard, implementation-defined attributes that you can retrieve
+using ``SQLGetConnectAttr``. The standard connection attribute has this
+``#define`` in ``sqlcli.h``:
 
 ::
 
     #define SQL_ATTR_AUTO_IPD 10001
 
-It is, of course, an integer and may not be set by ``SQLSetConnectAttr``. 
-``SQL_ATTR_AUTO_IPD`` stands for SQL Attribute: Automatically Populate IPD. 
-This is a flag integer with a value of either ``TRUE (1)`` or ``FALSE (0)``. 
-``SQL_ATTR_AUTO_IPD`` is the only standard attribute for a connection. If 
-``SQL_ATTR_AUTO_IPD`` is ``TRUE``, the DBMS "populates" the IPD (implementation 
-parameter descriptor) whenever you prepare an SQL statement. That means that 
-there will be, automatically, one parameter descriptor for every parameter 
-marker (symbolized by "?") inside your SQL statement. For example, if you 
-execute this SQL statement: 
+It is, of course, an integer and may not be set by ``SQLSetConnectAttr``.
+``SQL_ATTR_AUTO_IPD`` stands for SQL Attribute: Automatically Populate IPD.
+This is a flag integer with a value of either ``TRUE (1)`` or ``FALSE (0)``.
+``SQL_ATTR_AUTO_IPD`` is the only standard attribute for a connection. If
+``SQL_ATTR_AUTO_IPD`` is ``TRUE``, the DBMS "populates" the IPD (implementation
+parameter descriptor) whenever you prepare an SQL statement. That means that
+there will be, automatically, one parameter descriptor for every parameter
+marker (symbolized by "?") inside your SQL statement. For example, if you
+execute this SQL statement:
 
 ::
 
    INSERT INTO Table_1 VALUES (?);
 
-there will be an automatic IPD. IPD contents are the subject of a later 
+there will be an automatic IPD. IPD contents are the subject of a later
 chapter.
 
 **Algorithm:**
@@ -416,41 +418,41 @@ chapter.
 
 **Notes:**
 
-* There might be several implementation-defined attributes for connections. The 
-  Standard allows for that. That's why ``BufferLength`` and ``*Stringlength`` 
-  -- which aren't needed for ``SQL_ATTR_AUTO_IPD`` -- are defined parameters. 
-  They're there in case someday it's necessary to return a character string 
-  value. 
+* There might be several implementation-defined attributes for connections. The
+  Standard allows for that. That's why ``BufferLength`` and ``*Stringlength``
+  -- which aren't needed for ``SQL_ATTR_AUTO_IPD`` -- are defined parameters.
+  They're there in case someday it's necessary to return a character string
+  value.
 
-* Some things which we think of as "connection attributes" are not 
+* Some things which we think of as "connection attributes" are not
   retrieved with ``SQLGetConnectAttr``. They are:
 
-   * The default time zone offset -- get it by extracting the <time zone 
-     interval> from SQL's ``CURRENT_TIME`` function. 
+   * The default time zone offset -- get it by extracting the <time zone
+     interval> from SQL's ``CURRENT_TIME`` function.
 
-   * The default Catalog -- get it by selecting from the 
-     ``INFORMATION_SCHEMA_CATALOG_NAME`` View, or by using ``SQLGetInfo`` with 
-     ``SQL_CATALOG_NAME``. 
+   * The default Catalog -- get it by selecting from the
+     ``INFORMATION_SCHEMA_CATALOG_NAME`` View, or by using ``SQLGetInfo`` with
+     ``SQL_CATALOG_NAME``.
 
-   * The default Schema -- get it by using ``SQLGetDiagField`` after any 
-     erroneous statement. 
+   * The default Schema -- get it by using ``SQLGetDiagField`` after any
+     erroneous statement.
 
-   * The default Character set -- get it by using ``SQLGetDiagField`` after any 
-     erroneous statement. 
+   * The default Character set -- get it by using ``SQLGetDiagField`` after any
+     erroneous statement.
 
-   * The default Collation -- get it by using ``SQLGetInfo`` with 
-     ``SQL_COLLATING_SEQUENCE``. 
+   * The default Collation -- get it by using ``SQLGetInfo`` with
+     ``SQL_COLLATING_SEQUENCE``.
 
-   * The <Connection name> -- get it by using ``SQLGetDiagField`` after any 
-     erroneous statement. 
+   * The <Connection name> -- get it by using ``SQLGetDiagField`` after any
+     erroneous statement.
 
-   * The <SQL-server name> -- get it by using ``SQLGetInfo`` with 
-     ``SQL_DATA_SOURCE_NAME`` or ``SQLGetInfo`` with ``SQL_SERVER_NAME``. 
+   * The <SQL-server name> -- get it by using ``SQLGetInfo`` with
+     ``SQL_DATA_SOURCE_NAME`` or ``SQLGetInfo`` with ``SQL_SERVER_NAME``.
 
-   * The SQL-session user -- get it from SQL's ``SESSION_USER`` function, or by 
-     using ``SQLGetInfo`` with ``SQL_USER_NAME``. 
+   * The SQL-session user -- get it from SQL's ``SESSION_USER`` function, or by
+     using ``SQLGetInfo`` with ``SQL_USER_NAME``.
 
-* In the final version of the SQL/CLI there will be two more attributes — 
+* In the final version of the SQL/CLI there will be two more attributes —
   ``SQL_ATTR_SAVEPOINT_NAME`` and ``SQL_ATTR_SAVEPOINT_NUMBER``.
 
 **Example:**
@@ -471,11 +473,11 @@ chapter.
   can make sure our currently-assigned parameters are okay. If pop is false: we
   can still use parameters, but we have to fill in IPD values "manually". */
 
-**ODBC:** The ``SQLGetConnectAttr`` function is new to ODBC 3.0, but a very 
-similar function (``SQLGetConnectOption``) existed in ODBC 2.0. ODBC allows for 
-16 possible Attributes. One is ``SQL_ATTR_AUTO_IPD``. Most of the others are 
-related to ODBC's optional features (timeout, trace file, network packet size, 
-etc.). 
+**ODBC:** The ``SQLGetConnectAttr`` function is new to ODBC 3.0, but a very
+similar function (``SQLGetConnectOption``) existed in ODBC 2.0. ODBC allows for
+16 possible Attributes. One is ``SQL_ATTR_AUTO_IPD``. Most of the others are
+related to ODBC's optional features (timeout, trace file, network packet size,
+etc.).
 
 SQLSetConnectAttr
 =================
@@ -508,16 +510,16 @@ SQLSetConnectAttr
 
 **Notes:**
 
-* This function is useless unless there are implementation-defined ``dbc`` 
+* This function is useless unless there are implementation-defined ``dbc``
   attributes.
 
-* In the final version of the SQL/CLI there will be two more attributes — 
-  ``SQL_ATTR_SAVEPOINT_NAME`` and ``SQL_ATTR_SAVEPOINT_NUMBER``. 
+* In the final version of the SQL/CLI there will be two more attributes —
+  ``SQL_ATTR_SAVEPOINT_NAME`` and ``SQL_ATTR_SAVEPOINT_NUMBER``.
 
-* Value might be a pointer; that's why we've used ``SQLPOINTER`` in the 
-  prototype. But it's usually an integer. C programmers, when passing an 
-  integer value here, will use casts such as ``(PTR)`` or ``(SQLPOINTER)`` or 
-  ``(void*)``. 
+* Value might be a pointer; that's why we've used ``SQLPOINTER`` in the
+  prototype. But it's usually an integer. C programmers, when passing an
+  integer value here, will use casts such as ``(PTR)`` or ``(SQLPOINTER)`` or
+  ``(void*)``.
 
 **Example:**
 
@@ -532,8 +534,8 @@ SQLSetConnectAttr
   else
     /* function call failed, as expected */
 
-**ODBC:** The ``SQLSetConnectAttr`` function is new in ODBC 3.0, but ODBC 
-2.0 had a broadly similar function (``SQLSetConnectOption``). ODBC allows 
+**ODBC:** The ``SQLSetConnectAttr`` function is new in ODBC 3.0, but ODBC
+2.0 had a broadly similar function (``SQLSetConnectOption``). ODBC allows
 for 16 ``dbc`` attributes, of various types.
 
 SQLFreeHandle(SQL_HANDLE_DBC,...)
@@ -566,16 +568,16 @@ SQLFreeHandle(SQL_HANDLE_DBC,...)
 
 **Notes:**
 
-* If ``SQLFreeHandle`` returns ``SQL_ERROR``, then the handle is still live 
+* If ``SQLFreeHandle`` returns ``SQL_ERROR``, then the handle is still live
   and you can get diagnostics.
 
 * The name ``SQLFreeHandle`` is unfortunate. We are not "freeing a handle".
   We are destroying the resource that the handle refers to. In embedded SQL
   contexts, the preferred word for this process is "deallocate".
 
-* Before you call ``SQLFreeHandle(SQL_HANDLE_DBC...)``, you must call 
-  ``SQLDisconnect``. Therefore, by this time, there are no ``stmt``\s or 
-  ``desc``\s associated with the ``dbc``. 
+* Before you call ``SQLFreeHandle(SQL_HANDLE_DBC...)``, you must call
+  ``SQLDisconnect``. Therefore, by this time, there are no ``stmt``\s or
+  ``desc``\s associated with the ``dbc``.
 
 **Example:** Typically, an SQL application ends with a flurry of freeings:
 
@@ -585,8 +587,8 @@ SQLFreeHandle(SQL_HANDLE_DBC,...)
       SQLFreeHandle(SQL_HANDLE_DBC,hdbc);
       SQLFreeHandle(SQL_HANDLE_ENV,henv);  /* ends the application */
 
-**ODBC:** The ``SQLFreeHandle`` function is new in ODBC 3.0. There will be some 
-differences in behaviour if you use ODBC-specific features, such as tracing 
+**ODBC:** The ``SQLFreeHandle`` function is new in ODBC 3.0. There will be some
+differences in behaviour if you use ODBC-specific features, such as tracing
 or environment sharing.
 
 SQLFreeConnect
@@ -600,7 +602,7 @@ SQLFreeConnect
     SQLHDBC hdbc                      /* 32-bit input */
     );
 
-**Job:** Destroy a ``dbc``. This is the reverse of the ``SQLAllocConnect`` 
+**Job:** Destroy a ``dbc``. This is the reverse of the ``SQLAllocConnect``
 function. ``SQLFreeConnect`` is redundant.
 
 **Algorithm:**
@@ -617,7 +619,7 @@ is the same thing as
 
 **Notes:**
 
-* The Standard does not say that the ``SQLFreeConnect`` function is deprecated. 
+* The Standard does not say that the ``SQLFreeConnect`` function is deprecated.
   Nevertheless, ``SQLFreeHandle(SQL_HANDLE_DBC,...)`` is more modern.
 
 **Example:**
@@ -634,9 +636,9 @@ is the same thing as
       /* hdbc is now an invalid handle */
       ...
 
-**ODBC:** The ``SQLFreeConnect`` function has been in ODBC since version 
-1.0. The ODBC 3.0 manual deprecates it, suggesting that users should switch 
+**ODBC:** The ``SQLFreeConnect`` function has been in ODBC since version
+1.0. The ODBC 3.0 manual deprecates it, suggesting that users should switch
 to using ``SQLFreeHandle(SQL_HANDLE_DBC...)``.
 
-And that's it for the ``dbc`` functions. In the next chapter, we'll take a 
+And that's it for the ``dbc`` functions. In the next chapter, we'll take a
 look at the ``stmt`` functions.

--- a/docs/chapters/43.rst
+++ b/docs/chapters/43.rst
@@ -8,10 +8,12 @@
 Chapter 43 -- SQL/CLI: stmt Functions
 =====================================
 
-In this chapter, we'll describe the third essential CLI resource: the ``stmt``. 
-For CLI programs, the ``stmt`` is at the level below ``dbc`` and (usually) 
-above ``desc``. The ``dbc`` may contain multiple ``stmt``\s, and the ``stmt`` 
-may contain four ``desc``\s. Here's a closeup view of a ``stmt``: 
+.. include:: ../_include/note.rst
+
+In this chapter, we'll describe the third essential CLI resource: the ``stmt``.
+For CLI programs, the ``stmt`` is at the level below ``dbc`` and (usually)
+above ``desc``. The ``dbc`` may contain multiple ``stmt``\s, and the ``stmt``
+may contain four ``desc``\s. Here's a closeup view of a ``stmt``:
 
 ::
 
@@ -31,8 +33,8 @@ may contain four ``desc``\s. Here's a closeup view of a ``stmt``:
       v           v           v           v
       ... to IPD  ... to IRD  ... to APD  ... to ARD
 
-There are six CLI functions for creating ``stmt``\s, dropping ``stmt``\s, 
-getting ``stmt`` attributes and setting ``stmt`` attributes. Their 
+There are six CLI functions for creating ``stmt``\s, dropping ``stmt``\s,
+getting ``stmt`` attributes and setting ``stmt`` attributes. Their
 descriptions follow.
 
 .. rubric:: Table of Contents
@@ -80,19 +82,19 @@ SQLAllocHandle(SQL_HANDLE_STMT,...)
 
 **Notes:**
 
-* You cannot allocate a ``stmt`` until you have allocated a ``dbc`` and 
+* You cannot allocate a ``stmt`` until you have allocated a ``dbc`` and
   connected (with ``SQLConnect``).
 
 * The handle of the new ``stmt`` is "unique", which means that there is no
-  other ``stmt`` in the ``env`` with the same value. This uniqueness would 
-  not be guaranteed if there were two ``env``\s, but that's usually 
+  other ``stmt`` in the ``env`` with the same value. This uniqueness would
+  not be guaranteed if there were two ``env``\s, but that's usually
   impossible anyway.
 
 * The Standard calls it the "handle of the allocated SQL-statement",
   but in all our examples we name it a ``hstmt``, which is the general fashion.
 
-* Keep the ``hstmt``. You'll need it later for 
-  ``SQLFreeHandle(SQL_HANDLE_STMT...)`` and for quite a few other things. In 
+* Keep the ``hstmt``. You'll need it later for
+  ``SQLFreeHandle(SQL_HANDLE_STMT...)`` and for quite a few other things. In
   fact, the majority of CLI functions (42 of the 62) take a ``hstmt`` as input.
 
 **Example:**
@@ -136,7 +138,7 @@ is the same as
 
 **Notes:**
 
-* The Standard does not deprecate ``SQLAllocStmt``. All DBMSs should continue 
+* The Standard does not deprecate ``SQLAllocStmt``. All DBMSs should continue
   to support it. It is, however, redundant.
 
 **Example:**
@@ -151,7 +153,7 @@ is the same as
     SQLAllocStmt(hdbc,&hstmt);
     ...
 
-**ODBC:** The ``SQLAllocStmt`` function has been in ODBC since version 1.0. 
+**ODBC:** The ``SQLAllocStmt`` function has been in ODBC since version 1.0.
 The ODBC 3.0 manual deprecates it, suggesting that users should switch to using
 ``SQLAllocHandle(SQL_HANDLE_STMT...)``.
 
@@ -235,52 +237,52 @@ SQLGetStmtAttr
 |       |                                 |           |                | | 1=true                |
 +-------+---------------------------------+-----------+----------------+-------------------------+
 
-Other ``stmt`` attributes may be defined in particular implementations. 
+Other ``stmt`` attributes may be defined in particular implementations.
 (Reminder: ``SQLHDESC`` stands for "handle of a ``desc``", a 32-bit value.)
 
-* When you allocate a ``stmt`` (with ``SQLAllocHandle`` or ``SQLAllocStmt``), 
-  the DBMS automatically sets up four ``desc``\s: the ARD, the APD, the IRD and 
-  the IPD. You can pick up the handles of these ``desc``\s by calling 
-  ``SQLGetStmtAttr`` with ``SQL_ATTR_APP_ROW_DESC``, 
-  ``SQL_ATTR_APP_PARAM_DESC``, ``SQL_ATTR_IMP_ROW_DESC`` and 
-  ``SQL_ATTR_IMP_PARAM_DESC``, respectively -- you'll need these because there 
-  are several CLI functions which use a ``desc`` handle as input. 
+* When you allocate a ``stmt`` (with ``SQLAllocHandle`` or ``SQLAllocStmt``),
+  the DBMS automatically sets up four ``desc``\s: the ARD, the APD, the IRD and
+  the IPD. You can pick up the handles of these ``desc``\s by calling
+  ``SQLGetStmtAttr`` with ``SQL_ATTR_APP_ROW_DESC``,
+  ``SQL_ATTR_APP_PARAM_DESC``, ``SQL_ATTR_IMP_ROW_DESC`` and
+  ``SQL_ATTR_IMP_PARAM_DESC``, respectively -- you'll need these because there
+  are several CLI functions which use a ``desc`` handle as input.
 
-* When you get a result set (by calling ``SQLExecDirect`` or ``SQLExecute`` for 
-  a query expression such as ``"SELECT ..."``), the DBMS implicitly declares a 
-  Cursor. What kind of Cursor? That depends on the "cursor" attributes: 
+* When you get a result set (by calling ``SQLExecDirect`` or ``SQLExecute`` for
+  a query expression such as ``"SELECT ..."``), the DBMS implicitly declares a
+  Cursor. What kind of Cursor? That depends on the "cursor" attributes:
 
     * ``SQL_ATTR_CURSOR_SCROLLABLE``
-      
+
       if ``0`` = "false" = ``SQL_NONSCROLLABLE``: you can only fetch ``NEXT``. |br|
-      if ``1`` = "true" = ``SQL_SCROLLABLE``: you can fetch ``FIRST``, 
+      if ``1`` = "true" = ``SQL_SCROLLABLE``: you can fetch ``FIRST``,
       ``NEXT``, ``PRIOR``, ``LAST``, ``ABSOLUTE`` and RELATIVE``. |br|
       The default is ``0``, but you can call ``SQLSetStmtAttr`` to change that.
 
     * ``SQL_ATTR_CURSOR_SENSITIVITY``
-      
+
       if ``0 = SQL_ASENSITIVE = SQL_UNSPECIFIED``: sensitivity isn't known. |br|
       if ``1 = SQL_INSENSITIVE``: changes made elsewhere won't be seen here. |br|
       if ``2 = SQL_SENSITIVE``: changes made elsewhere will be seen here. |br|
       The default is ``0``, but you can call ``SQLSetStmtAttr`` to change that.
 
     * ``SQL_ATTR_CURSOR_HOLDABLE``
-      
-      if ``0`` = "false" = ``SQL_NONHOLDABLE``: Cursor disappears at 
+
+      if ``0`` = "false" = ``SQL_NONHOLDABLE``: Cursor disappears at
       transaction end. |br|
       if ``1`` = "true" = ``SQL_HOLDABLE``: Cursor remains at transaction end. |br|
-      The default is probably 0 (you'd have to call ``SQLGetInfo`` to be 
+      The default is probably 0 (you'd have to call ``SQLGetInfo`` to be
       certain) but you can call ``SQLSetStmtAttr`` to change that.
 
-* When you use a Catalog function (such as ``SQLColumns`` or ``SQLTables``), 
-  the DBMS has to search the "metadata", that is, the ``INFORMATION_SCHEMA`` 
-  Views. The ``SQL_ATTR_METADATA_ID`` attribute indicates how searches are 
-  conducted with Catalog functions. We discuss this in more detail in our 
-  chapter on SQL/CLI Catalog functions. 
+* When you use a Catalog function (such as ``SQLColumns`` or ``SQLTables``),
+  the DBMS has to search the "metadata", that is, the ``INFORMATION_SCHEMA``
+  Views. The ``SQL_ATTR_METADATA_ID`` attribute indicates how searches are
+  conducted with Catalog functions. We discuss this in more detail in our
+  chapter on SQL/CLI Catalog functions.
 
-* The ``BufferLength`` and ``StringLength`` parameters aren't currently in use. 
-  They're there in case we ever have a statement attribute that contains a 
-  string value. 
+* The ``BufferLength`` and ``StringLength`` parameters aren't currently in use.
+  They're there in case we ever have a statement attribute that contains a
+  string value.
 
 **Example:**
 
@@ -297,7 +299,7 @@ Other ``stmt`` attributes may be defined in particular implementations.
             NULL,                          /* "don't care" */
             NULL);                         /* "don't care" */
 
-**ODBC**: The ``SQLGetStmtAttr`` function is new in ODBC 3.0 (in ODBC 2.0 
+**ODBC**: The ``SQLGetStmtAttr`` function is new in ODBC 3.0 (in ODBC 2.0
 there was a nearly-equivalent function, ``SQLGetStmtOption``).
 
 SQLSetStmtAttr
@@ -314,8 +316,8 @@ SQLSetStmtAttr
     SQLINTEGER StringLength      /* 32-bit input */
     );
 
-**Job:** Set an attribute of the ``stmt`` -- to change the DBMS's behaviour 
-for Cursor control, to change the handle used for an application ``desc``, 
+**Job:** Set an attribute of the ``stmt`` -- to change the DBMS's behaviour
+for Cursor control, to change the handle used for an application ``desc``,
 or to change the search method for Catalog functions.
 
 There are eight standard ``stmt`` attributes, listed in the previous section.
@@ -372,29 +374,29 @@ There are eight standard ``stmt`` attributes, listed in the previous section.
 
 **Notes:**
 
-* The specification allows for implementation-defined attributes and for the 
-  possibility of future change. That's why the ``StringLength`` parameter 
-  exists, although it's not currently used. 
+* The specification allows for implementation-defined attributes and for the
+  possibility of future change. That's why the ``StringLength`` parameter
+  exists, although it's not currently used.
 
-* ``SQL_ATTR_APP_ROW_DESC`` and ``SQL_ATTR_APP_PARAM_DESC`` are listed as 
-  settable attributes, so you can change the stmt's ARD and APD. (You can't 
-  change the ``stmt``\ 's IRD and IPD.) The ``Value`` parameter must point to 
-  the handle of a user ``desc``. This option makes it possible to save or share 
-  application ``desc``\s. 
+* ``SQL_ATTR_APP_ROW_DESC`` and ``SQL_ATTR_APP_PARAM_DESC`` are listed as
+  settable attributes, so you can change the stmt's ARD and APD. (You can't
+  change the ``stmt``\ 's IRD and IPD.) The ``Value`` parameter must point to
+  the handle of a user ``desc``. This option makes it possible to save or share
+  application ``desc``\s.
 
-* ``SQL_ATTR_CURSOR_SCROLLABLE`` and ``SQL_ATTR_CURSOR_HOLDABLE`` are used to 
-  specify whether a ``stmt``'s Cursor is "scrollable" and/or "holdable". 
+* ``SQL_ATTR_CURSOR_SCROLLABLE`` and ``SQL_ATTR_CURSOR_HOLDABLE`` are used to
+  specify whether a ``stmt``'s Cursor is "scrollable" and/or "holdable".
 
-* ``SQL_ATTR_METADATA_ID`` is an abbreviation for "the attribute for metadata 
-  identifiers", for example the names of Tables in ``INFORMATION_SCHEMA``. 
+* ``SQL_ATTR_METADATA_ID`` is an abbreviation for "the attribute for metadata
+  identifiers", for example the names of Tables in ``INFORMATION_SCHEMA``.
 
-* It's easy to forget that the Value parameter is described as ``SQLPOINTER``. 
-  Don't make the mistake of passing ``"hdesc"`` (handle of a ``desc``); pass 
-  ``"&hdesc"`` (address of a handle of a ``desc``) instead. 
+* It's easy to forget that the Value parameter is described as ``SQLPOINTER``.
+  Don't make the mistake of passing ``"hdesc"`` (handle of a ``desc``); pass
+  ``"&hdesc"`` (address of a handle of a ``desc``) instead.
 
-**Example:** Change the settings of all settable ``stmt`` attributes. This 
-example only shows what the syntax looks like for the various options. More 
-realistic examples will appear in the chapters on "Cursors", ``descs``, and 
+**Example:** Change the settings of all settable ``stmt`` attributes. This
+example only shows what the syntax looks like for the various options. More
+realistic examples will appear in the chapters on "Cursors", ``descs``, and
 "Catalog functions".
 
 ::
@@ -414,7 +416,7 @@ realistic examples will appear in the chapters on "Cursors", ``descs``, and
   SQLSetStmtAttr(hstmt,SQL_ATTR_METADATA_ID,&metadata_id,NULL);
   SQLSetStmtAttr(hstmt,SQL_ATTR_CURSOR_HOLDABLE,&holdable,NULL);
 
-**ODBC**: The ``SQLSetStmtAttr`` function is new in ODBC 3.0 but there was 
+**ODBC**: The ``SQLSetStmtAttr`` function is new in ODBC 3.0 but there was
 a similar function in ODBC 2.0 (``SQLSetStmtOption``).
 
 SQLFreeHandle(SQL_HANDLE_STMT,...)
@@ -450,24 +452,24 @@ SQLFreeHandle(SQL_HANDLE_STMT,...)
 
 **Notes:**
 
-* Correctly speaking, this functions "frees the ``stmt``"; it doesn't merely 
+* Correctly speaking, this functions "frees the ``stmt``"; it doesn't merely
   free the ``stmt``'s handle.
 
-* The DBMS calls ``SQLFreeHandle(SQL_HANDLE_STMT...)`` implicitly, for all 
+* The DBMS calls ``SQLFreeHandle(SQL_HANDLE_STMT...)`` implicitly, for all
   ``stmt``\s in a ``dbc``, as part of an ``SQLDisconnect`` operation.
 
-* There is a mention here of a "current" ``dbc``. If there are multiple 
-  ``dbc``\s, the DBMS will implicitly switch, when necessary, to the ``dbc`` 
-  whose handle is passed in the function call (or, as in this case, to the 
-  ``dbc`` associated with the ``stmt`` whose handle is passed in the function 
-  call). This switching is transparent. There is no need, when using the CLI, 
-  for any analogue of the basic SQL ``"SET CONNECTION ..."`` statement. 
+* There is a mention here of a "current" ``dbc``. If there are multiple
+  ``dbc``\s, the DBMS will implicitly switch, when necessary, to the ``dbc``
+  whose handle is passed in the function call (or, as in this case, to the
+  ``dbc`` associated with the ``stmt`` whose handle is passed in the function
+  call). This switching is transparent. There is no need, when using the CLI,
+  for any analogue of the basic SQL ``"SET CONNECTION ..."`` statement.
 
-* Freeing a statement causes an implicit "close Cursor" operation, but not 
+* Freeing a statement causes an implicit "close Cursor" operation, but not
   an implicit "end transaction" operation.
 
-* Quite often, programmers allocate a ``stmt`` only once, and re-use the 
-  same ``stmt`` throughout the SQL-session. So 
+* Quite often, programmers allocate a ``stmt`` only once, and re-use the
+  same ``stmt`` throughout the SQL-session. So
   ``SQLFreeHandle(SQL_HANDLE_STMT...)`` may be seen only infrequently.
 
 **Example:**
@@ -496,7 +498,7 @@ SQLFreeStmt
     SQLSMALLINT Option;        /* 16-bit input */
     );
 
-``Job:`` ``SQLFreeStmt`` has five different jobs, depending on the value of 
+``Job:`` ``SQLFreeStmt`` has five different jobs, depending on the value of
 ``Option``:
 
 * If ``Option`` is 0, ``SQLFreeStmt``'s job is to close a Cursor.
@@ -543,37 +545,37 @@ SQLFreeStmt
   for full discussion is come. For the immediate purpose, we hope it is enough
   to say that:
 
-   * ``RESULT SETS`` are temporary Tables which result from the execution 
+   * ``RESULT SETS`` are temporary Tables which result from the execution
      of an SQL query.
 
    * ``Cursors`` are named interface objects through which result sets
      can be retrieved one row at a time.
 
-   * ``BINDINGS`` are associations between a host program's host variables 
+   * ``BINDINGS`` are associations between a host program's host variables
      (i.e.: pointers to data buffers and indicator variables) and their
-     corresponding SQL Objects (Columns and/or parameter markers). Often 
-     Columns are bound with the ``SQLBindCol`` function, while parameters 
+     corresponding SQL Objects (Columns and/or parameter markers). Often
+     Columns are bound with the ``SQLBindCol`` function, while parameters
      are bound with the ``SQLBindParameter`` function.
 
-* Because ``SQLFreeHandle`` is now the main function for freeing resources, the 
-  name ``SQLFreeStmt`` is now a misnomer -- we don't use ``SqlFreeStmt`` for 
-  freeing ``stmt``\s nowadays. However, it maintains a residue of usefulness. 
-  It's good for "partial ``stmt`` freeing", freeing things associated with 
-  ``stmt``\s that might be taking up space, or whose continued existence might 
-  cause conflict with other operations. 
+* Because ``SQLFreeHandle`` is now the main function for freeing resources, the
+  name ``SQLFreeStmt`` is now a misnomer -- we don't use ``SqlFreeStmt`` for
+  freeing ``stmt``\s nowadays. However, it maintains a residue of usefulness.
+  It's good for "partial ``stmt`` freeing", freeing things associated with
+  ``stmt``\s that might be taking up space, or whose continued existence might
+  cause conflict with other operations.
 
-* ``SQLFreeStmt(...,SQL_CLOSE)`` does exactly the same thing as the 
-  ``SQLCloseCursor`` function, except for one detail: if there is no Cursor 
-  currently open, then ``SQLCloseCursor`` returns an error, while 
-  ``SQLFreeStmt(...,SQL_CLOSE)`` does not return an error. 
+* ``SQLFreeStmt(...,SQL_CLOSE)`` does exactly the same thing as the
+  ``SQLCloseCursor`` function, except for one detail: if there is no Cursor
+  currently open, then ``SQLCloseCursor`` returns an error, while
+  ``SQLFreeStmt(...,SQL_CLOSE)`` does not return an error.
 
-* ``SQLFreeStmt(hstmt,SQL_DROP)`` is now just another way of saying: 
-  ``SQLFreeHandle(SQL_HANDLE_STMT,hstmt)``. 
+* ``SQLFreeStmt(hstmt,SQL_DROP)`` is now just another way of saying:
+  ``SQLFreeHandle(SQL_HANDLE_STMT,hstmt)``.
 
-* ``SQLFreeStmt(...,SQL_UNBIND)`` and ``SQLFreeStmt(...,SQL_RESET_PARAMS)`` are 
-  handy ways of "disassociating" the application's RAM from the DBMS, so that 
-  there won't be inadvertent access to memory that's no longer valid. Here's an 
-  example: 
+* ``SQLFreeStmt(...,SQL_UNBIND)`` and ``SQLFreeStmt(...,SQL_RESET_PARAMS)`` are
+  handy ways of "disassociating" the application's RAM from the DBMS, so that
+  there won't be inadvertent access to memory that's no longer valid. Here's an
+  example:
 
   ::
 
@@ -587,17 +589,17 @@ SQLFreeStmt
 
 * ``SQLFreeStmt(...,SQL_REALLOCATE)`` can be used to clear parts of ``stmt``\s:
 
-   * The "statement" (a copy of the SQL statement string which was last 
-     prepared or executed for this ``stmt``, including "select" source 
+   * The "statement" (a copy of the SQL statement string which was last
+     prepared or executed for this ``stmt``, including "select" source
      statements).
 
-   * The "Cursor", including the Cursor's result set. These things take up 
+   * The "Cursor", including the Cursor's result set. These things take up
      space, so presumably ``SQLFreeStmt(...,SQL_REALLOCATE)`` is useful under
-     low-memory conditions. But normally it's unnecessary: "statement" and 
-     "Cursor" are superseded in any case when an SQL statement is 
+     low-memory conditions. But normally it's unnecessary: "statement" and
+     "Cursor" are superseded in any case when an SQL statement is
      re-prepared/re-executed.
 
-**Example:** Since ``SQLFreeStmt(...,SQL_DROP)`` is the reverse of 
+**Example:** Since ``SQLFreeStmt(...,SQL_DROP)`` is the reverse of
 ``SQLAllocStmt(...)``, we show both these obsolescent calls together.
 
 ::
@@ -611,13 +613,13 @@ SQLFreeStmt
   SQLFreeStmt(hstmt,SQL_UNBIND);    /* unbind all stmt Columns */    ...
   SQLFreeStmt(hstmt,SQL_DROP);      /* free a stmt */
 
-**ODBC:** The ``SQLFreeStmt`` function has been in ODBC since version 1.0. The 
-ODBC 3.0 manual deprecates the use of ``SQLFreeStmt(...,SQL_DROP)``, suggesting 
-that the user should switch to using ``SQLFreeHandle(SQL_HANDLE_STMT,...)``. 
-The ODBC action for ``SQL_UNBIND`` is different: ``ARD.SQL_DESC_COUNT`` is set 
-to 0. The ODBC action for ``SQL_RESET_PARAMS`` is different: 
-``APD.SQL_DESC_COUNT`` is set to 0. The ``SQL_REALLOCATE`` option is not 
-supported. 
+**ODBC:** The ``SQLFreeStmt`` function has been in ODBC since version 1.0. The
+ODBC 3.0 manual deprecates the use of ``SQLFreeStmt(...,SQL_DROP)``, suggesting
+that the user should switch to using ``SQLFreeHandle(SQL_HANDLE_STMT,...)``.
+The ODBC action for ``SQL_UNBIND`` is different: ``ARD.SQL_DESC_COUNT`` is set
+to 0. The ODBC action for ``SQL_RESET_PARAMS`` is different:
+``APD.SQL_DESC_COUNT`` is set to 0. The ``SQL_REALLOCATE`` option is not
+supported.
 
-And that's it for the ``stmt`` functions. In the next chapter, we'll take a 
-look at the statement functions. 
+And that's it for the ``stmt`` functions. In the next chapter, we'll take a
+look at the statement functions.

--- a/docs/chapters/44.rst
+++ b/docs/chapters/44.rst
@@ -4,12 +4,14 @@
 Chapter 44 -- SQL/CLI Statement Functions
 =========================================
 
-Of the 62 CLI functions, only three actually handle what we know as "SQL 
-statements". There are two steps in SQL statement handling: the "prepare" step 
-and the "execute" step. You can do these steps separately, using the 
-``SQLPrepare`` and ``SQLExecute`` functions or you can roll them together and 
-just use the ``SQLExecDirect`` function. The following flowchart shows the 
-steps involved: 
+.. include:: ../_include/note.rst
+
+Of the 62 CLI functions, only three actually handle what we know as "SQL
+statements". There are two steps in SQL statement handling: the "prepare" step
+and the "execute" step. You can do these steps separately, using the
+``SQLPrepare`` and ``SQLExecute`` functions or you can roll them together and
+just use the ``SQLExecDirect`` function. The following flowchart shows the
+steps involved:
 
 ::
 
@@ -78,7 +80,7 @@ steps involved:
 Preparable SQL Statements
 =========================
 
-Some SQL statements are not preparable. Here's the list of all 
+Some SQL statements are not preparable. Here's the list of all
 possibilities, showing whether the SQL statement can be prepared.
 
 +--------------------------+---------------------+-----------------+
@@ -145,21 +147,21 @@ possibilities, showing whether the SQL statement can be prepared.
 
 **Notes:** The "preparable statements" for embedded SQL are as above, except:
 
-* [1] Connection statements are "directly executable" with embedded SQL, 
+* [1] Connection statements are "directly executable" with embedded SQL,
   but not preparable.
 
 * [2] ``COMMIT`` and ``ROLLBACK`` are "preparable" with embedded SQL.
 
-There are some SQL statements which you may use in other contexts (such as 
-embedded SQL or SQL/PSM), but their use is inappropriate with the CLI because 
-their functionality is included in special function calls which require a 
-``henv`` or ``hdbc`` as the input handle -- and the ``SQLPrepare`` function 
-requires a ``hstmt``. For such SQL statements there will usually be an 
-analogous CLI function. For example: ``CONNECT`` and ``DISCONNECT`` statements 
-are not preparable, but there are ``SQLConnect`` and ``SQLDisconnect`` 
-functions; ``GET DIAGNOSTICS`` is not preparable but there are 
-``SQLGetDiag...`` functions; ``COMMIT`` and ``ROLLBACK`` are not preparable but 
-there is an ``SQLEndTran`` ("end transaction") function. 
+There are some SQL statements which you may use in other contexts (such as
+embedded SQL or SQL/PSM), but their use is inappropriate with the CLI because
+their functionality is included in special function calls which require a
+``henv`` or ``hdbc`` as the input handle -- and the ``SQLPrepare`` function
+requires a ``hstmt``. For such SQL statements there will usually be an
+analogous CLI function. For example: ``CONNECT`` and ``DISCONNECT`` statements
+are not preparable, but there are ``SQLConnect`` and ``SQLDisconnect``
+functions; ``GET DIAGNOSTICS`` is not preparable but there are
+``SQLGetDiag...`` functions; ``COMMIT`` and ``ROLLBACK`` are not preparable but
+there is an ``SQLEndTran`` ("end transaction") function.
 
 SQLPrepare
 ==========
@@ -174,8 +176,8 @@ SQLPrepare
     SQLINTEGER TextLength     /* 32-bit input */
     );
 
-**Job:** Check a SQL statement for syntax or access errors. If all is well, 
-make this string the "prepared SQL statement" associated with ``stmt``. It 
+**Job:** Check a SQL statement for syntax or access errors. If all is well,
+make this string the "prepared SQL statement" associated with ``stmt``. It
 is then ready to execute.
 
 **Algorithm:**
@@ -223,59 +225,59 @@ is then ready to execute.
 
 **Notes:**
 
-* You can process SQL statements in two separate phases using the 
-  ``SQLPrepare`` and ``SQLExecute`` functions. Usually, you would want to do 
-  the two phases separately if the SQL statement appeared in a loop -- you'd 
-  call ``SQLPrepare`` before entering the loop, and you'd call ``SQLExecute`` 
-  within the loop. That way, you'd only be preparing once, but executing many 
-  times. If you used the alternative -- ``SQLExecDirect`` -- you'd be preparing 
-  and executing with every iteration of the loop. 
+* You can process SQL statements in two separate phases using the
+  ``SQLPrepare`` and ``SQLExecute`` functions. Usually, you would want to do
+  the two phases separately if the SQL statement appeared in a loop -- you'd
+  call ``SQLPrepare`` before entering the loop, and you'd call ``SQLExecute``
+  within the loop. That way, you'd only be preparing once, but executing many
+  times. If you used the alternative -- ``SQLExecDirect`` -- you'd be preparing
+  and executing with every iteration of the loop.
 
-* The prepare and execute phases of SQL resemble the compile and execute phases 
-  of most computer languages. If we were going to make a distinction between 
-  preparing and compiling, we would point out that: *(a)* preparing fails if an 
-  SQL statement refers to an inaccessible Table, but compiling does not fail if 
-  a file is unavailable at compile time; and *(b)* compiling results in 
-  executable code, but preparing results only in a descriptive "plan" which 
-  needs some interpretation at run time. Such, at least, is the state of SQL 
-  today. There are no true SQL compilers. 
+* The prepare and execute phases of SQL resemble the compile and execute phases
+  of most computer languages. If we were going to make a distinction between
+  preparing and compiling, we would point out that: *(a)* preparing fails if an
+  SQL statement refers to an inaccessible Table, but compiling does not fail if
+  a file is unavailable at compile time; and *(b)* compiling results in
+  executable code, but preparing results only in a descriptive "plan" which
+  needs some interpretation at run time. Such, at least, is the state of SQL
+  today. There are no true SQL compilers.
 
-* If ``SQLPrepare`` finds an error, the ``stmt``\'s state is unchanged. A SQL 
-  statement that was previously prepared continues to be "live". For example: 
-  
+* If ``SQLPrepare`` finds an error, the ``stmt``\'s state is unchanged. A SQL
+  statement that was previously prepared continues to be "live". For example:
+
   ::
-  
+
      SQLPrepare(hstmt,"UPDATE t SET t_column = t_column + 1;",SQL_NTS);
      SQLExecute(hstmt);
      SQLPrepare(hstmt,"SELCT * FROM t;",SQL_NTS); /* sic-"SELCT" */
      SQLExecute(hstmt);
-  
-  The second ``SQLPrepare`` won't work because ``"SELCT"`` is bad SQL syntax -- 
-  but what happens to the ``SQLExecute`` that follows it? Answer: it executes 
-  the ``"UPDATE t ..."`` statement a second time. Silly, eh? Well it wouldn't 
-  happen if we had made sure to check what the ``SQLPrepare`` call returned. 
 
-* Some DBMSs do nothing during ``SQLPrepare``. They defer even syntax 
-  checking until ``SQLExecute`` time. You have to be ready for such 
-  non-standard behaviour: do not assume that an SQL statement is 
+  The second ``SQLPrepare`` won't work because ``"SELCT"`` is bad SQL syntax --
+  but what happens to the ``SQLExecute`` that follows it? Answer: it executes
+  the ``"UPDATE t ..."`` statement a second time. Silly, eh? Well it wouldn't
+  happen if we had made sure to check what the ``SQLPrepare`` call returned.
+
+* Some DBMSs do nothing during ``SQLPrepare``. They defer even syntax
+  checking until ``SQLExecute`` time. You have to be ready for such
+  non-standard behaviour: do not assume that an SQL statement is
   grammatical until it's been executed.
 
-* There is no "UnPrepare" function. Instead, prepared statements are 
+* There is no "UnPrepare" function. Instead, prepared statements are
   removed by:
 
    * Calling ``SQLPrepare`` again for the same ``stmt``.
 
    * Calling ``SQLFreeStmt(...,SQL_REALLOCATE)``.
 
-   * Cascade effects -- for example, if the prepared statement depends on a 
+   * Cascade effects -- for example, if the prepared statement depends on a
      Cursor which is destroyed.
 
-   * (Usually) calling ``SQLEndTran`` (the "transaction-end" function which is 
-     used instead of ``COMMIT`` or ``ROLLBACK``). It is best to assume that SQL 
-     statements need re-preparing after transaction end, though some DBMSs 
-     preserve prepared statements. You can find out what your DBMS does by 
-     calling the ``SQLGetInfo`` function. (In any case, if a Cursor is 
-     holdable, its result set survives if the termination is with ``COMMIT``.) 
+   * (Usually) calling ``SQLEndTran`` (the "transaction-end" function which is
+     used instead of ``COMMIT`` or ``ROLLBACK``). It is best to assume that SQL
+     statements need re-preparing after transaction end, though some DBMSs
+     preserve prepared statements. You can find out what your DBMS does by
+     calling the ``SQLGetInfo`` function. (In any case, if a Cursor is
+     holdable, its result set survives if the termination is with ``COMMIT``.)
 
 * In standard SQL, the SQL statement does not have to end with a semicolon.
 
@@ -289,7 +291,7 @@ is then ready to execute.
   SQLPrepare(hstmt,"DELETE FROM t",SQL_NTS);
   /* Now we need to call SQLExecute. */
 
-**ODBC:** The ``SQLPrepare`` function has been part of ODBC since ODBC 
+**ODBC:** The ``SQLPrepare`` function has been part of ODBC since ODBC
 version 1.0.
 
 SQLExecute
@@ -325,21 +327,21 @@ SQLExecute
         Get parameter addresses and do appropriate "casting"
       Change the Diagnostics Area
 
-Since there are many possible SQL statements, the range of possible problem 
-conditions is wide -- see especially the ``SQLSTATE`` errors in class ``22000`` 
-(data exception) and class ``23000`` (integrity constraint violation) in our 
-chapter on SQL/CLI diagnostics. Watch also for warnings and even "No data" 
-conditions (for example, execution of ``UPDATE Table_1 SET column_1 = 0;`` will 
-result in ``SQLSTATE 02000 "Data not found"`` if there are no rows in 
-``TABLE_1``). 
+Since there are many possible SQL statements, the range of possible problem
+conditions is wide -- see especially the ``SQLSTATE`` errors in class ``22000``
+(data exception) and class ``23000`` (integrity constraint violation) in our
+chapter on SQL/CLI diagnostics. Watch also for warnings and even "No data"
+conditions (for example, execution of ``UPDATE Table_1 SET column_1 = 0;`` will
+result in ``SQLSTATE 02000 "Data not found"`` if there are no rows in
+``TABLE_1``).
 
 **Notes:**
 
-* Calls to ``SQLExecute`` always follow calls to ``SQLPrepare`` (for the 
+* Calls to ``SQLExecute`` always follow calls to ``SQLPrepare`` (for the
   same ``stmt``), but other function calls may intervene.
 
-**Example:** In this example we prepare and execute two SQL statements. We 
-use two different ``stmt``\s, so that we can get all the preparing done 
+**Example:** In this example we prepare and execute two SQL statements. We
+use two different ``stmt``\s, so that we can get all the preparing done
 before we start executing.
 
 ::
@@ -387,40 +389,40 @@ is the same as
 
 **Notes:**
 
-* Technically, ``SQLExecDirect`` is redundant: you can do the same thing by 
-  calling ``SQLPrepare`` and ``SQLExecute``. But programmers prefer to use 
-  ``SQLExecDirect`` for SQL statements that will only be prepared and executed 
-  once. 
+* Technically, ``SQLExecDirect`` is redundant: you can do the same thing by
+  calling ``SQLPrepare`` and ``SQLExecute``. But programmers prefer to use
+  ``SQLExecDirect`` for SQL statements that will only be prepared and executed
+  once.
 
-* Since ``SQLExecDirect`` includes a "prepare" step, it follows that 
-  non-preparable SQL statements cannot be arguments of ``SQLExecDirect``. Such 
-  statements include ``CONNECT``, ``DISCONNECT``, ``COMMIT``, ``ROLLBACK`` -- 
-  refer to the list of "Preparable and Non-Preparable SQL Statements", shown 
-  earlier. 
+* Since ``SQLExecDirect`` includes a "prepare" step, it follows that
+  non-preparable SQL statements cannot be arguments of ``SQLExecDirect``. Such
+  statements include ``CONNECT``, ``DISCONNECT``, ``COMMIT``, ``ROLLBACK`` --
+  refer to the list of "Preparable and Non-Preparable SQL Statements", shown
+  earlier.
 
 * Does the size of a string include the null terminator?
 
    * If you are passing a string's octet length: NO. For example:
-     
+
      ::
-     
+
         SQLExecDirect(hstmt,"abcd",4);
-   
+
    * If you are passing (maximum) target octet length: YES. For example:
-     
+
      ::
-     
+
         char x[8];
         ...
         SQLGetCursorName(hstmt,x,8,&strlen_or_ind);
-     
-   * If the DBMS is returning the (actual) target octet length: NO. Using 
-     the previous example: if a null-terminated string "``abcd\0``" is 
+
+   * If the DBMS is returning the (actual) target octet length: NO. Using
+     the previous example: if a null-terminated string "``abcd\0``" is
      returned, then ``strlen_or_ind`` will equal 4.
-   
+
    * If the string is a ``BIT`` or ``BINARY`` string: NO.
 
-**Example:** Take a value at run time, incorporate it in an SQL statement. 
+**Example:** Take a value at run time, incorporate it in an SQL statement.
 This is how you can pass a parameter value without using a ``desc`` function.
 
 ::
@@ -434,8 +436,8 @@ This is how you can pass a parameter value without using a ``desc`` function.
     len = sprintf(statement, "UPDATE t SET measurement = %f", measurement);
     SQLExecDirect(hstmt, update_statement, len); }
 
-**EXAMPLE3.C; Basic "Interactive SQL" Program:** If you want to put together 
-a program that accepts SQL statements from the keyboard and displays 
+**EXAMPLE3.C; Basic "Interactive SQL" Program:** If you want to put together
+a program that accepts SQL statements from the keyboard and displays
 results on the screen, this is the skeletal arrangement:
 
 ::
@@ -454,13 +456,13 @@ results on the screen, this is the skeletal arrangement:
   ...
   SQLFreeHandle(); SQLDisconnect(); SQLFreeHandle(); SQLFreeHandle();
 
-In this code, notice how ``SQLExecDirect`` is fundamental -- it's the only CLI 
-function that must be called for every iteration of the loop. In later 
-examples, we'll show you other things that are necessary here (e.g.: how to 
-exit from the loop, what to do with errors and how queries need special 
-handling). 
+In this code, notice how ``SQLExecDirect`` is fundamental -- it's the only CLI
+function that must be called for every iteration of the loop. In later
+examples, we'll show you other things that are necessary here (e.g.: how to
+exit from the loop, what to do with errors and how queries need special
+handling).
 
-**ODBC:** The SQLExecDirect function has been around since ODBC 1.0. 
+**ODBC:** The SQLExecDirect function has been around since ODBC 1.0.
 
 SQLEndTran
 ==========
@@ -475,10 +477,10 @@ SQLEndTran
     SQLSMALLINT CompletionType      /* 16-bit input */
     );
 
-**Job:** End a transaction, either with ``COMMIT`` or with ``ROLLBACK``. 
-``SQLEndTran`` is not a "statement" function, but we believe that it fits in 
-this chapter because it's used to ``COMMIT`` or ``ROLLBACK`` the results of SQL 
-statements that have been processed with ``SQLExecute`` or ``SQLExecDirect``. 
+**Job:** End a transaction, either with ``COMMIT`` or with ``ROLLBACK``.
+``SQLEndTran`` is not a "statement" function, but we believe that it fits in
+this chapter because it's used to ``COMMIT`` or ``ROLLBACK`` the results of SQL
+statements that have been processed with ``SQLExecute`` or ``SQLExecDirect``.
 
 **Algorithm:**
 
@@ -534,24 +536,24 @@ statements that have been processed with ``SQLExecute`` or ``SQLExecDirect``.
 
 **Notes about the algorithm:**
 
-* See the ``SQLSTATE`` error codes ``HY010``, ``HY092`` and ``40002`` in our 
-  chapter on SQL/CLI diagnostics. Pay particular attention to ``40002``, which 
-  implies that ``ROLLBACK`` occurred when you asked for ``COMMIT``. 
+* See the ``SQLSTATE`` error codes ``HY010``, ``HY092`` and ``40002`` in our
+  chapter on SQL/CLI diagnostics. Pay particular attention to ``40002``, which
+  implies that ``ROLLBACK`` occurred when you asked for ``COMMIT``.
 
-* Since ``COMMIT`` and ``ROLLBACK`` are non-preparable SQL statements, the 
-  correct way to end a transaction is to call ``SQLEndTran``. Some DBMSs accept 
-  ``SQLExecDirect(hstmt,"COMMIT;",SQL_NTS);`` anyway, but it's not legal 
-  according to the SQL Standard and you can't be sure exactly what will happen. 
+* Since ``COMMIT`` and ``ROLLBACK`` are non-preparable SQL statements, the
+  correct way to end a transaction is to call ``SQLEndTran``. Some DBMSs accept
+  ``SQLExecDirect(hstmt,"COMMIT;",SQL_NTS);`` anyway, but it's not legal
+  according to the SQL Standard and you can't be sure exactly what will happen.
 
-* It is not clear why one would pass a ``hstmt`` or ``hdesc`` to 
-  ``SQLEndTran``. These are new (SQL3) options. The safe thing is to use only 
-  ``hdbc`` or ``henv`` for the handle. 
+* It is not clear why one would pass a ``hstmt`` or ``hdesc`` to
+  ``SQLEndTran``. These are new (SQL3) options. The safe thing is to use only
+  ``hdbc`` or ``henv`` for the handle.
 
-* When there is only one ``env`` and one ``dbc``, the convention is to use the 
-  ``henv`` for this function: 
-  
+* When there is only one ``env`` and one ``dbc``, the convention is to use the
+  ``henv`` for this function:
+
   ::
-  
+
      SQLEndTran(SQL_HANDLE_ENV,henv,SQL_COMMIT)
 
 * Have a look at our chapter on transactions before you try to use
@@ -571,20 +573,20 @@ statements that have been processed with ``SQLExecute`` or ``SQLExecDirect``.
   /* Commit the statement results using the dbc */
   SQLEndTran(SQL_HANDLE_DBC,hdbc,SQL_COMMIT);
 
-**ODBC:** The ``SQLEndTran`` function was added in ODBC 3.0, but there was a 
-nearly-equivalent function in ODBC 2.0 (``SQLTransact``). With ODBC, if the 
-``HandleType`` value is not ``SQL_HANDLE_ENV`` or ``SQL_HANDLE_DBC``, the 
-return is ``HY092`` (invalid attribute/option identifier), rather than 
-"``invalid handle``". 
+**ODBC:** The ``SQLEndTran`` function was added in ODBC 3.0, but there was a
+nearly-equivalent function in ODBC 2.0 (``SQLTransact``). With ODBC, if the
+``HandleType`` value is not ``SQL_HANDLE_ENV`` or ``SQL_HANDLE_DBC``, the
+return is ``HY092`` (invalid attribute/option identifier), rather than
+"``invalid handle``".
 
-With ODBC, the default behaviour is "autocommit" (i.e.: perform an automatic 
-"commit" after every SQL statement), so ``SQLEndTran`` has nothing to do. *This 
-is a major difference between ODBC and Standard SQL.* The suggested way to 
-resolve it is to call an ODBC function which turns the "autocommit" flag off: 
+With ODBC, the default behaviour is "autocommit" (i.e.: perform an automatic
+"commit" after every SQL statement), so ``SQLEndTran`` has nothing to do. *This
+is a major difference between ODBC and Standard SQL.* The suggested way to
+resolve it is to call an ODBC function which turns the "autocommit" flag off:
 
 ::
 
     SQLSetConnectAttr(hdbc,SQL_ATTR_AUTOCOMMIT,SQL_AUTOCOMMIT_OFF);
 
-And that's it for the statement functions. In the next chapter, we'll take 
+And that's it for the statement functions. In the next chapter, we'll take
 a look at the Cursor functions.

--- a/docs/chapters/45.rst
+++ b/docs/chapters/45.rst
@@ -4,8 +4,10 @@
 Chapter 45 -- SQL/CLI: Cursor Functions
 =======================================
 
-When you execute a query, you are implicitly opening a Cursor. For example, the 
-function call: 
+.. include:: ../_include/note.rst
+
+When you execute a query, you are implicitly opening a Cursor. For example, the
+function call:
 
 ::
 
@@ -13,34 +15,34 @@ function call:
 
 will open a Cursor.
 
-The reason for Cursors is that a query returns a set of rows -- a "result set", 
-as it's usually referred to in CLI contexts. But it is not possible for the 
-host language to deal with the whole result set at once -- it must deal with 
-one row at a time. The Cursor is the Object that indicates which row of the 
-result set you're currently dealing with. 
+The reason for Cursors is that a query returns a set of rows -- a "result set",
+as it's usually referred to in CLI contexts. But it is not possible for the
+host language to deal with the whole result set at once -- it must deal with
+one row at a time. The Cursor is the Object that indicates which row of the
+result set you're currently dealing with.
 
-Cursor movement is just part of the story: "Get the stick, Rover!", coos the 
-hopeful master. Rover charges off, picks up the stick, and sits down. "No, I 
-mean get the stick and *fetch it to me*!" addends the master. So Rover trots 
-dutifully back to his caller, and sits down again -- still holding the stick in 
-his teeth. "!@###~$!!", yells the master (we've amended the wording slightly as 
-this is a family computer book). "I wanted you to get the stick, then fetch it, 
-then *put it in my hands*!" 
+Cursor movement is just part of the story: "Get the stick, Rover!", coos the
+hopeful master. Rover charges off, picks up the stick, and sits down. "No, I
+mean get the stick and *fetch it to me*!" addends the master. So Rover trots
+dutifully back to his caller, and sits down again -- still holding the stick in
+his teeth. "!@###~$!!", yells the master (we've amended the wording slightly as
+this is a family computer book). "I wanted you to get the stick, then fetch it,
+then *put it in my hands*!"
 
-Well, you know, Rover is a lot like our faithful pal SQL. The execution of an 
-SQL query (the subject of the last chapter) is analogous to a dog picking up a 
-stick. Now, in this chapter, we've reached step 2: fetch the stick. And -- like 
-Rover -- that's as far as we go. Step 3, delivering the fetched stuff into your 
-hands, must wait until you have a thorough grounding in the desc functions. So 
-this chapter on "Cursors" is short. The only thing we'll worry about now is the 
-mechanics of opening, closing, fetching and naming Cursors. The fun part -- 
-doing something with the contents -- will come later. 
+Well, you know, Rover is a lot like our faithful pal SQL. The execution of an
+SQL query (the subject of the last chapter) is analogous to a dog picking up a
+stick. Now, in this chapter, we've reached step 2: fetch the stick. And -- like
+Rover -- that's as far as we go. Step 3, delivering the fetched stuff into your
+hands, must wait until you have a thorough grounding in the desc functions. So
+this chapter on "Cursors" is short. The only thing we'll worry about now is the
+mechanics of opening, closing, fetching and naming Cursors. The fun part --
+doing something with the contents -- will come later.
 
-The following diagram shows a result set: the result of an execution of a query 
-statement, which has returned three rows. The Cursor is represented by the 
-symbol <<<. The diagram shows where the Cursor is *(a)* after the execution, 
-*(b)* after one fetch, *(c)* after another fetch, *(d)* after another fetch and 
-*(e)* after another fetch. 
+The following diagram shows a result set: the result of an execution of a query
+statement, which has returned three rows. The Cursor is represented by the
+symbol <<<. The diagram shows where the Cursor is *(a)* after the execution,
+*(b)* after one fetch, *(c)* after another fetch, *(d)* after another fetch and
+*(e)* after another fetch.
 
 ::
 
@@ -55,12 +57,12 @@ symbol <<<. The diagram shows where the Cursor is *(a)* after the execution,
     ----------      ----------     ----------     ----------     ----------
                                                                             <<<
 
-Notice that there are five possible positions of the Cursor, since it is 
-possible to be "before the first row" or "after the last row", as well as "on 
-each row". 
+Notice that there are five possible positions of the Cursor, since it is
+possible to be "before the first row" or "after the last row", as well as "on
+each row".
 
-There are six CLI functions for creating Cursors, dropping Cursors, getting 
-Cursor attributes and fetching from Cursors. Their descriptions follow. 
+There are six CLI functions for creating Cursors, dropping Cursors, getting
+Cursor attributes and fetching from Cursors. Their descriptions follow.
 
 .. rubric:: Table of Contents
 
@@ -77,13 +79,13 @@ SQLFetch
       SQLHSTMT hstmt                    /* input: 32-bit handle */
       );
 
-**Job:** Get the next row of a Cursor's result set. (Assumption: using 
-``hstmt``, you've already run a query which returned a result set.) 
+**Job:** Get the next row of a Cursor's result set. (Assumption: using
+``hstmt``, you've already run a query which returned a result set.)
 
-You can use ``SQLFetch`` for one-row-at-a-time processing of a result set. 
-``SQLFetch`` is appropriate for sequential processing, since it always gets the 
-"next" row. For random-access processing, use a different function: 
-``SQLFetchScroll``. 
+You can use ``SQLFetch`` for one-row-at-a-time processing of a result set.
+``SQLFetch`` is appropriate for sequential processing, since it always gets the
+"next" row. For random-access processing, use a different function:
+``SQLFetchScroll``.
 
 **Algorithm:**
 
@@ -100,22 +102,22 @@ You can use ``SQLFetch`` for one-row-at-a-time processing of a result set.
       Transfer the values in the select list to bound Columns, if any.
       (Column-binding and transfer is the subject of the CLI desc chapter.)
 
-For common errors, see our descriptions of SQLSTATE`` codes ``HY010``, 
-``24000`` and ``02000`` in our chapter on CLI diagnostics. Note that ``SQLSTATE 
-02000`` is not an exception condition -- it is a completion condition. There 
-are also possible errors -- data exceptions -- which can take place during 
-transfers. There are also possible warnings, such as ``01004 "string data right 
-truncation"``. 
+For common errors, see our descriptions of SQLSTATE`` codes ``HY010``,
+``24000`` and ``02000`` in our chapter on CLI diagnostics. Note that ``SQLSTATE
+02000`` is not an exception condition -- it is a completion condition. There
+are also possible errors -- data exceptions -- which can take place during
+transfers. There are also possible warnings, such as ``01004 "string data right
+truncation"``.
 
 **Notes:**
 
-* ``SQLFetch`` only works if there is an open Cursor. A Cursor is automatically 
-  opened as a result of executing an SQL query statement. A Cursor can be 
-  explicitly closed using the CLI function ``SQLCloseCursor``. Usually, though, 
-  a Cursor is closed as a result of calling the CLI function ``SQLEndTran``. 
+* ``SQLFetch`` only works if there is an open Cursor. A Cursor is automatically
+  opened as a result of executing an SQL query statement. A Cursor can be
+  explicitly closed using the CLI function ``SQLCloseCursor``. Usually, though,
+  a Cursor is closed as a result of calling the CLI function ``SQLEndTran``.
 
-* There is no such Cursor position as "two places after the last row". A Cursor 
-  which is "after the last row" does not move. 
+* There is no such Cursor position as "two places after the last row". A Cursor
+  which is "after the last row" does not move.
 
 **Example:** Here's a fetch loop example:
 
@@ -151,11 +153,11 @@ style is different -- using names, macros and indentation a la Microsoft:
       ...  rc = SQLFetch(hstmt0);
     } // while
 
-**ODBC:** All versions of ODBC support the ``SQLFetch`` function as described 
-here, but ODBC version 3.0 has an optional feature: you can fetch multiple rows 
-with one call. Logically, such a feature is unnecessary, and it makes 
-applications more complex. We assume Microsoft added the feature for 
-performance reasons. 
+**ODBC:** All versions of ODBC support the ``SQLFetch`` function as described
+here, but ODBC version 3.0 has an optional feature: you can fetch multiple rows
+with one call. Logically, such a feature is unnecessary, and it makes
+applications more complex. We assume Microsoft added the feature for
+performance reasons.
 
 *Fetch Loops*
 --------------
@@ -164,13 +166,13 @@ When dealing with a result set, the procedure is almost always to:
 
 1. Make a result set.
 
-2. Begin a loop which calls ``SQLFetch`` for each row; stopping when there 
+2. Begin a loop which calls ``SQLFetch`` for each row; stopping when there
    are no more rows.
-   
+
    Here's what it looks like in pseudocode:
-   
+
    ::
-   
+
      Make a result set.
      LOOP:
        Call SQLFetch to get the next row.
@@ -182,9 +184,9 @@ Let's explore these pseudocode statements in a little more detail.
 
 * Make a result set:
 
-You create a result set when you execute an SQL "query". The "query" statements 
-are the ones that begin with ``SELECT`` or ``VALUES`` or ``TABLE``. For 
-example, this CLI function call makes a result set associated with ``stmt``: 
+You create a result set when you execute an SQL "query". The "query" statements
+are the ones that begin with ``SELECT`` or ``VALUES`` or ``TABLE``. For
+example, this CLI function call makes a result set associated with ``stmt``:
 
 ::
 
@@ -201,12 +203,12 @@ execute SQL queries implicitly. See our chapter on that subject.)
 
 * Check for end of result set.
 
-Eventually, the ``SQLFetch`` function will return ``SQL_NO_DATA``. At that 
-point, it is certain that the ``SQLSTATE`` class is '``02``'. ``SQL_NO_DATA`` 
-is a completion condition -- the function is completed. But there wasn't any 
-row to fetch, so no data actually moved from bound Columns into host variables. 
-The Cursor is now positioned "after the last row" and if you call ``SQLFetch`` 
-again, it will remain there. This is a cue to break out of the fetch loop: 
+Eventually, the ``SQLFetch`` function will return ``SQL_NO_DATA``. At that
+point, it is certain that the ``SQLSTATE`` class is '``02``'. ``SQL_NO_DATA``
+is a completion condition -- the function is completed. But there wasn't any
+row to fetch, so no data actually moved from bound Columns into host variables.
+The Cursor is now positioned "after the last row" and if you call ``SQLFetch``
+again, it will remain there. This is a cue to break out of the fetch loop:
 
 ::
 
@@ -214,7 +216,7 @@ again, it will remain there. This is a cue to break out of the fetch loop:
 
 * Check for errors.
 
-``SQLFetch`` functions rarely return ``SQL_ERROR``, but we'll do some 
+``SQLFetch`` functions rarely return ``SQL_ERROR``, but we'll do some
 checking to be on the safe side:
 
 ::
@@ -229,8 +231,8 @@ has moved forward despite the error, and the next row is okay.
 
 * Do something with the result row.
 
-The data in the fetched row will go to host variables in the program. We do 
-not show that here. We will revisit fetch loops later, after looking at 
+The data in the fetched row will go to host variables in the program. We do
+not show that here. We will revisit fetch loops later, after looking at
 ``desc`` functions. Until then, remember: Rover is still holding the stick.
 
 SQLFetchScroll
@@ -246,13 +248,13 @@ SQLFetchScroll
     SQLINTEGER FetchOffset               /* 32-bit input. offset. */
     );
 
-**Job:** Get a specified row of a Cursor's result set. (Assumption: using 
+**Job:** Get a specified row of a Cursor's result set. (Assumption: using
 ``hstmt``, you've already run a query which returned a result set.)
 
-You can use ``SQLFetchScroll`` for one-row-at-a-time processing of a result 
-set. ``SQLFetchScroll`` is appropriate for random-order processing, since it 
-always gets the "specified" row. For sequential processing, use a different 
-function: ``SQLFetch``. 
+You can use ``SQLFetchScroll`` for one-row-at-a-time processing of a result
+set. ``SQLFetchScroll`` is appropriate for random-order processing, since it
+always gets the "specified" row. For sequential processing, use a different
+function: ``SQLFetch``.
 
 **Algorithm:**
 
@@ -278,34 +280,34 @@ function: ``SQLFetch``.
   the way it positions the Cursor. There are six possible values of the
   ``FetchOrientation`` parameter:
 
-   * If the value is 1, the ``#define`` in ``sqlcli.h`` is ``SQL_FETCH_NEXT`` 
-     and the requested action is "Fetch the next row of the result set", just 
-     as for ``SQLFetch``. ``SQL_FETCH_NEXT`` is the only legal orientation if 
-     the Cursor is non-scrollable. 
+   * If the value is 1, the ``#define`` in ``sqlcli.h`` is ``SQL_FETCH_NEXT``
+     and the requested action is "Fetch the next row of the result set", just
+     as for ``SQLFetch``. ``SQL_FETCH_NEXT`` is the only legal orientation if
+     the Cursor is non-scrollable.
 
-   * If the value is 2, the ``#define`` in ``sqlcli.h`` is ``SQL_FETCH_FIRST`` 
-     and the requested action is "Fetch the first row of the result set". 
+   * If the value is 2, the ``#define`` in ``sqlcli.h`` is ``SQL_FETCH_FIRST``
+     and the requested action is "Fetch the first row of the result set".
 
-   * If the value is 3, the ``#define`` in ``sqlcli.h`` is ``SQL_FETCH_LAST`` 
-     and the requested action is "Fetch the last row of the result set". 
+   * If the value is 3, the ``#define`` in ``sqlcli.h`` is ``SQL_FETCH_LAST``
+     and the requested action is "Fetch the last row of the result set".
 
-   * If the value is 4, the ``#define`` in ``sqlcli.h`` is ``SQL_FETCH_PRIOR`` 
-     and the requested action is "Fetch the previous row of the result set". 
+   * If the value is 4, the ``#define`` in ``sqlcli.h`` is ``SQL_FETCH_PRIOR``
+     and the requested action is "Fetch the previous row of the result set".
 
-   * If the value is 5, the ``#define`` in ``sqlcli.h`` is 
-     ``SQL_FETCH_ABSOLUTE`` and the requested action is "Fetch row#n of the 
-     result set" (where ``n = FetchOffset`` -- see parameter list). The 
-     ``FetchOffset`` parameter can be negative, in which case the DBMS seeks 
-     relative to the end of the result set rather than relative to the 
-     beginning of the result set. If you pass ``FetchOrientation=SQL_ABSOLUTE`` 
-     and ``FetchOffset=0``, you fetch the first row in the result set. 
+   * If the value is 5, the ``#define`` in ``sqlcli.h`` is
+     ``SQL_FETCH_ABSOLUTE`` and the requested action is "Fetch row#n of the
+     result set" (where ``n = FetchOffset`` -- see parameter list). The
+     ``FetchOffset`` parameter can be negative, in which case the DBMS seeks
+     relative to the end of the result set rather than relative to the
+     beginning of the result set. If you pass ``FetchOrientation=SQL_ABSOLUTE``
+     and ``FetchOffset=0``, you fetch the first row in the result set.
 
-   * If the value is 6, the ``#define`` in ``sqlcli.h is`` 
-     ``SQL_FETCH_RELATIVE`` and the requested action is "Fetch row#n of the 
-     result set" (where ``n`` = current row#``+FetchOffset``). Once again, the 
-     ``FetchOffset`` parameter can be negative. If you pass 
-     ``FetchOrientation=SQL_RELATIVE`` and ``FetchOffset=0``, you re-fetch the 
-     same row as last time. 
+   * If the value is 6, the ``#define`` in ``sqlcli.h is``
+     ``SQL_FETCH_RELATIVE`` and the requested action is "Fetch row#n of the
+     result set" (where ``n`` = current row#``+FetchOffset``). Once again, the
+     ``FetchOffset`` parameter can be negative. If you pass
+     ``FetchOrientation=SQL_RELATIVE`` and ``FetchOffset=0``, you re-fetch the
+     same row as last time.
 
 * The ``ABSOLUTE`` and ``RELATIVE`` fetch orientations may be thought of as
   similar to the arguments for the C function ``l seek``.
@@ -332,24 +334,24 @@ non-scrollable. A non-scrollable Cursor is useful only for ``SQLFetch`` and
 ``SQLFetchScroll(...SQL_FETCH_NEXT...)``. A non-scrollable Cursor is generally
 slightly more efficient than a scrollable Cursor.
 
-* It might be convenient to use ``SQLFetchScroll`` for paged-display purposes. 
-  For example, start by displaying the first 20 rows on the screen. If the user 
-  presses a "next page" button, fetch the next 20 rows. If the user presses a 
-  "previous page" button, fetch the previous 20 rows. This process is easy to 
-  keep track of with ``SQLFetchScroll(...,ABSOLUTE,...)`` using a 
-  ``FetchOffset`` value to which you add or subtract 20, depending on the 
-  button pushing. (In multi-user environments, paged displays might require a 
-  different mechanism.) 
+* It might be convenient to use ``SQLFetchScroll`` for paged-display purposes.
+  For example, start by displaying the first 20 rows on the screen. If the user
+  presses a "next page" button, fetch the next 20 rows. If the user presses a
+  "previous page" button, fetch the previous 20 rows. This process is easy to
+  keep track of with ``SQLFetchScroll(...,ABSOLUTE,...)`` using a
+  ``FetchOffset`` value to which you add or subtract 20, depending on the
+  button pushing. (In multi-user environments, paged displays might require a
+  different mechanism.)
 
-* ``Fetch orientation`` only works within the bounds of the result set. For 
-  example, suppose that there are 3 rows in a result set. If you try to fetch 
-  row number 20 -- using ``SQLFetchScroll(...,ABSOLUTE,20)`` -- the function 
-  will fail with ``SQLSTATE 02000 "no data"``. The possible surprise lies in 
-  the fact that the Cursor is now positioned, not at some nonexistent "row 
-  #20", but just after the last row of the result set -- so if you then call 
-  ``SQLFetchScroll(...,PRIOR,...)``, the DBMS will fetch row#3. 
+* ``Fetch orientation`` only works within the bounds of the result set. For
+  example, suppose that there are 3 rows in a result set. If you try to fetch
+  row number 20 -- using ``SQLFetchScroll(...,ABSOLUTE,20)`` -- the function
+  will fail with ``SQLSTATE 02000 "no data"``. The possible surprise lies in
+  the fact that the Cursor is now positioned, not at some nonexistent "row
+  #20", but just after the last row of the result set -- so if you then call
+  ``SQLFetchScroll(...,PRIOR,...)``, the DBMS will fetch row#3.
 
-* ``SQLFetch`` and ``SQLFetchScroll`` calls can be interlaced. 
+* ``SQLFetch`` and ``SQLFetchScroll`` calls can be interlaced.
 
 **Example:**
 
@@ -365,12 +367,12 @@ slightly more efficient than a scrollable Cursor.
       SQLFetchScroll(hstmt,SQL_FETCH_LAST,NULL);      /* get last row */
       SQLFetchScroll(hstmt,SQL_FETCH_RELATIVE,-1);    /* now 2nd-last row */
 
-**ODBC:** The ODBC function is pretty much as described above, except for 
-details -- for example, ``SQLFetchScroll(hstmt,SQL_ABSOLUTE,0)`` will cause the 
-Cursor to be positioned before the first row (in standard SQL it would cause 
-the Cursor to be positioned at the first row). The more important difference is 
-that ODBC allows many extensions, such as multi-row retrieval and retrieval 
-using "bookmarks" (which are a special sort row address). 
+**ODBC:** The ODBC function is pretty much as described above, except for
+details -- for example, ``SQLFetchScroll(hstmt,SQL_ABSOLUTE,0)`` will cause the
+Cursor to be positioned before the first row (in standard SQL it would cause
+the Cursor to be positioned at the first row). The more important difference is
+that ODBC allows many extensions, such as multi-row retrieval and retrieval
+using "bookmarks" (which are a special sort row address).
 
 SQLCloseCursor
 ==============
@@ -400,21 +402,21 @@ SQLCloseCursor
 
 **Notes:**
 
-* You MUST close the Cursor when you are done processing a result set. 
-  Otherwise, you won't be able to re-use the ``stmt``. ``SQLPrepare`` and 
+* You MUST close the Cursor when you are done processing a result set.
+  Otherwise, you won't be able to re-use the ``stmt``. ``SQLPrepare`` and
   ``SQLExecute`` will return with an error if there is an open Cursor.
 
-* The DBMS automatically closes the Cursor when executing any of these CLI 
+* The DBMS automatically closes the Cursor when executing any of these CLI
   functions:
-   
+
    * ``SQLFreeStmt(...,SQL_CLOSE)``
-   
+
    * ``SQLEndTran`` (but see later description of "held Cursors")
-   
+
    * ``SQLCancel``
-   
+
    * ``SQLFreeHandle(SQL_HANDLE_STMT,...)``
-   
+
    * ``SQLMoreResults``
 
 However, it is good style to call ``SQLCloseCursor`` explicitly, rather than
@@ -425,7 +427,7 @@ depending on automatic behaviour.
   currently open, then ``SQLCloseCursor`` returns an error, while
   ``SQLFreeStmt(...,SQL_CLOSE)`` does not return an error.
 
-**Example:** This is a repetition of the earlier "fetch loop" example. 
+**Example:** This is a repetition of the earlier "fetch loop" example.
 Notice that ``SQLCloseCursor`` is called at the end of the loop.
 
 ::
@@ -444,12 +446,12 @@ Notice that ``SQLCloseCursor`` is called at the end of the loop.
     printf("*"); }
   SQLCloseCursor(hstmt);      /* "Close Cursor" */
 
-**ODBC:** The ``SQLCloseCursor`` function is new in ODBC 3.0; with earlier ODBC 
-versions, the way to close Cursors was ``SQLFreeStmt(hstmt,SQL_CLOSE);``. If 
-ODBC's "autocommit" mode is in effect, then ``SQLCloseCursor`` causes a 
-``COMMIT``. (In order for this to work, the DBMS must avoid performing an 
-automatic commit immediately after execution of the ``SELECT`` statement which 
-causes the Cursor to be opened.) 
+**ODBC:** The ``SQLCloseCursor`` function is new in ODBC 3.0; with earlier ODBC
+versions, the way to close Cursors was ``SQLFreeStmt(hstmt,SQL_CLOSE);``. If
+ODBC's "autocommit" mode is in effect, then ``SQLCloseCursor`` causes a
+``COMMIT``. (In order for this to work, the DBMS must avoid performing an
+automatic commit immediately after execution of the ``SELECT`` statement which
+causes the Cursor to be opened.)
 
 SQLGetCursorName
 ================
@@ -483,23 +485,23 @@ SQLGetCursorName
 
 **Notes:**
 
-* With embedded SQL, the <Cursor name> is important. With the CLI, the <Cursor 
-  name> is not important -- we distinguish between statements using the 
-  ``hstmt`` value. The only time you actually need a <Cursor name> is when you 
-  have to use positioned ``UPDATE|DELETE`` statements (we'll discuss positioned 
-  ``UPDATE|DELETE`` statements later in this chapter). 
+* With embedded SQL, the <Cursor name> is important. With the CLI, the <Cursor
+  name> is not important -- we distinguish between statements using the
+  ``hstmt`` value. The only time you actually need a <Cursor name> is when you
+  have to use positioned ``UPDATE|DELETE`` statements (we'll discuss positioned
+  ``UPDATE|DELETE`` statements later in this chapter).
 
-* The <Cursor name> exists independently of the Cursor itself. You can retrieve 
-  a <Cursor name> even if the Cursor is not open. 
+* The <Cursor name> exists independently of the Cursor itself. You can retrieve
+  a <Cursor name> even if the Cursor is not open.
 
-* An implicit <Cursor name> begins with the letters ``SQL_CUR`` or ``SQLCUR`` 
-  (e.g.: ``SQL_CUR0001``). In practice, implicit <Cursor name>s are not more 
-  than 18 characters long. A <Cursor name> is created implicitly (if it doesn't 
-  already exist) when either of these things happens: *(a)* ``SQLPrepare`` is 
-  called and the prepared statement is a query or *(b)* ``SQLGetCursorName`` is 
-  called. Once an implicit <Cursor name> is established, it remains until the 
-  statement is freed, or until a call to ``SQLSetCursorName`` changes it 
-  explicitly. 
+* An implicit <Cursor name> begins with the letters ``SQL_CUR`` or ``SQLCUR``
+  (e.g.: ``SQL_CUR0001``). In practice, implicit <Cursor name>s are not more
+  than 18 characters long. A <Cursor name> is created implicitly (if it doesn't
+  already exist) when either of these things happens: *(a)* ``SQLPrepare`` is
+  called and the prepared statement is a query or *(b)* ``SQLGetCursorName`` is
+  called. Once an implicit <Cursor name> is established, it remains until the
+  statement is freed, or until a call to ``SQLSetCursorName`` changes it
+  explicitly.
 
 **Example:**
 
@@ -513,8 +515,8 @@ SQLGetCursorName
   ...
   SQLGetCursorName(hstmt,Cursor_name,sizeof(Cursor_name),&Cursor_name_length);
 
-**ODBC:** The ``SQLGetCursorName`` function has been around since ODBC 1.0. 
-In ODBC, implicit <Cursor name>s always begin with ``SQL_CUR`` (not 
+**ODBC:** The ``SQLGetCursorName`` function has been around since ODBC 1.0.
+In ODBC, implicit <Cursor name>s always begin with ``SQL_CUR`` (not
 ``SQLCUR``).
 
 SQLSetCursorName
@@ -550,18 +552,18 @@ SQLSetCursorName
 
 **Notes:**
 
-* You only need to call ``SQLSetCursorName`` if you intend to execute 
-  "positioned ``UPDATE|DELETE``" statements. 
+* You only need to call ``SQLSetCursorName`` if you intend to execute
+  "positioned ``UPDATE|DELETE``" statements.
 
-* It is a good idea to assign your own <Cursor name>, rather than depending on 
-  an implicit <Cursor name>. 
+* It is a good idea to assign your own <Cursor name>, rather than depending on
+  an implicit <Cursor name>.
 
-* The best time to call ``SQLSetCursorName`` is immediately after calling 
-  ``SQLAllocHandle(SQL_HANDLE_STMT,...)``. 
+* The best time to call ``SQLSetCursorName`` is immediately after calling
+  ``SQLAllocHandle(SQL_HANDLE_STMT,...)``.
 
-* The <Cursor name> is permanent. It exists until the ``stmt`` is freed, or 
-  until superseded by another call to ``SQLSetCursorName``. Opening and closing 
-  the Cursor has no effect on the name. 
+* The <Cursor name> is permanent. It exists until the ``stmt`` is freed, or
+  until superseded by another call to ``SQLSetCursorName``. Opening and closing
+  the Cursor has no effect on the name.
 
 **Example:**
 
@@ -574,9 +576,9 @@ SQLSetCursorName
   SQLAllocHandle(SQLHANDLE_STMT,hdbc,&hstmt);
   SQLSetCursorName(hstmt,"Cursor_1",sizeof("Cursor_1"));
 
-**ODBC:** The ``SQLSetCursorName`` function has been around since ODBC version 
-1.0. If the <Cursor name> already exists, ODBC requires that the ``SQLSTATE`` 
-should be ``3C000 "Duplicate <Cursor name>"``, instead of ``34000``. 
+**ODBC:** The ``SQLSetCursorName`` function has been around since ODBC version
+1.0. If the <Cursor name> already exists, ODBC requires that the ``SQLSTATE``
+should be ``3C000 "Duplicate <Cursor name>"``, instead of ``34000``.
 
 Embedded SQL versus CLI
 =======================
@@ -607,24 +609,24 @@ Comparing these two examples, you will notice two major differences:
    opened by execution of a ``SELECT`` statement.
 
 2. In the CLI, there is no use of <Cursor name>s -- different Cursors
-   are associated with different ``stmt``\s, so ``hstmt`` alone is sufficient 
+   are associated with different ``stmt``\s, so ``hstmt`` alone is sufficient
    for unique identification.
 
-The CLI functions ``SQLGetCursorName`` and ``SQLSetCursorName`` are 
-unimportant. CLI programmers only worry about <Cursor name>s if they have 
+The CLI functions ``SQLGetCursorName`` and ``SQLSetCursorName`` are
+unimportant. CLI programmers only worry about <Cursor name>s if they have
 to use positioned ``UPDATE|DELETE`` statements.
 
 *Positioned UPDATE|DELETE Statements*
 -------------------------------------
 
-In our chapter on embedded SQL, we mentioned that there are two kinds of 
-``UPDATE`` and ``DELETE`` statements. The normal kind (called "searched 
-``UPDATE``" and "searched ``DELETE``"), provide conditions for changing or 
-removing rows in a ``WHERE`` clause -- these statements are not our concern 
-here. The Cursor-related kind (called "positioned ``UPDATE``" and "positioned 
-``DELETE``") are distinguished by the presence of a ``WHERE CURRENT OF`` 
-<Cursor name> clause, rather than a conditional ``WHERE`` clause. Here's an 
-example of each: 
+In our chapter on embedded SQL, we mentioned that there are two kinds of
+``UPDATE`` and ``DELETE`` statements. The normal kind (called "searched
+``UPDATE``" and "searched ``DELETE``"), provide conditions for changing or
+removing rows in a ``WHERE`` clause -- these statements are not our concern
+here. The Cursor-related kind (called "positioned ``UPDATE``" and "positioned
+``DELETE``") are distinguished by the presence of a ``WHERE CURRENT OF``
+<Cursor name> clause, rather than a conditional ``WHERE`` clause. Here's an
+example of each:
 
 ::
 
@@ -632,19 +634,19 @@ example of each:
 
    DELETE FROM Table_1 WHERE CURRENT OF Cursor_1;
 
-The first example will update only one row in ``TABLE_1``: the row that 
-underlies the result-set row which is indicated by the current position of 
-``CURSOR_1``. The second example will delete only that single row of 
-``TABLE_1``. 
+The first example will update only one row in ``TABLE_1``: the row that
+underlies the result-set row which is indicated by the current position of
+``CURSOR_1``. The second example will delete only that single row of
+``TABLE_1``.
 
-With the CLI, there is one complicating factor: the positioned 
-``UPDATE|DELETE`` statement must be executed using a different ``stmt`` than 
-the ``stmt`` which is associated with ``CURSOR_1``. This is just a corollary of 
-the reasonable rule that "at any given time there may be only one statement 
-associated with a ``stmt``". Since there is already an active statement -- the 
-``SELECT`` which caused the Cursor to be opened -- the positioned ``UPDATE`` 
-must go elsewhere. A general skeleton of a positioned ``UPDATE|DELETE`` 
-operation, then, could be: 
+With the CLI, there is one complicating factor: the positioned
+``UPDATE|DELETE`` statement must be executed using a different ``stmt`` than
+the ``stmt`` which is associated with ``CURSOR_1``. This is just a corollary of
+the reasonable rule that "at any given time there may be only one statement
+associated with a ``stmt``". Since there is already an active statement -- the
+``SELECT`` which caused the Cursor to be opened -- the positioned ``UPDATE``
+must go elsewhere. A general skeleton of a positioned ``UPDATE|DELETE``
+operation, then, could be:
 
 ::
 
@@ -655,13 +657,13 @@ operation, then, could be:
     Fetch on stmt_1 (thus positioning the Cursor)
     Execute positioned UPDATE|DELETE on stmt_2, using the <Cursor name>
 
-(If, later, the same row is re-fetched using ``SQLFetchScroll``, then results 
-are implementation-defined.) 
+(If, later, the same row is re-fetched using ``SQLFetchScroll``, then results
+are implementation-defined.)
 
-**Example:** This program uses a positioned ``DELETE`` statement. Just by the 
-way, we'll use "A delimited identifier" for our <Cursor name>. In real life the 
-<Cursor name> would be a short <regular identifier> like ``X`` or ``Cursor_1`` 
-or ``SELECTION_WHERE_X_GT_0``. 
+**Example:** This program uses a positioned ``DELETE`` statement. Just by the
+way, we'll use "A delimited identifier" for our <Cursor name>. In real life the
+<Cursor name> would be a short <regular identifier> like ``X`` or ``Cursor_1``
+or ``SELECTION_WHERE_X_GT_0``.
 
 ::
 
@@ -698,83 +700,83 @@ or ``SELECTION_WHERE_X_GT_0``.
 *Singleton SELECTs*
 -------------------
 
-In embedded SQL, there is a construct called the singleton ``SELECT``. 
+In embedded SQL, there is a construct called the singleton ``SELECT``.
 Here's an example:
 
 ::
 
    EXEC SQL SELECT Column_1 INTO :host_variable FROM Table_1;
 
-In the CLI, there is no equivalent of a singleton ``SELECT``. All query 
-results, even ones that consist of zero rows or one row, must be processed 
+In the CLI, there is no equivalent of a singleton ``SELECT``. All query
+results, even ones that consist of zero rows or one row, must be processed
 via the Cursor functions.
 
 *Sensitive Cursors*
 -------------------
 
-What happens if a Cursor is open on ``stmt_1``, and a data change operation 
-happens on ``stmt_2``? We've already noted that "positioned ``UPDATE|DELETE`` 
-statements" are possible, but here we're asking about effects in a more general 
-way -- that is, we're assuming that the SQL-data change statement is 
-``INSERT``, ``UPDATE`` or ``DELETE`` and that ``stmt_2`` is associated either 
-with the same ``dbc``, or with another ``dbc``. For example, suppose you've 
-executed this SQL statement: 
+What happens if a Cursor is open on ``stmt_1``, and a data change operation
+happens on ``stmt_2``? We've already noted that "positioned ``UPDATE|DELETE``
+statements" are possible, but here we're asking about effects in a more general
+way -- that is, we're assuming that the SQL-data change statement is
+``INSERT``, ``UPDATE`` or ``DELETE`` and that ``stmt_2`` is associated either
+with the same ``dbc``, or with another ``dbc``. For example, suppose you've
+executed this SQL statement:
 
 ::
 
    SELECT * FROM Table_1;
 
-and you are now fetching from the result. But -- after the ``SELECT`` was 
-processed and before your first ``FETCH``, some ``UPDATE`` took place on one 
-row of ``TABLE_1``. When you ``FETCH`` that row, will you see the new values, 
-or the original values? There are three possible answers, which depend on an 
-attribute of the ``stmt`` called the *Cursor sensitivity*. Here are the 
-options: 
+and you are now fetching from the result. But -- after the ``SELECT`` was
+processed and before your first ``FETCH``, some ``UPDATE`` took place on one
+row of ``TABLE_1``. When you ``FETCH`` that row, will you see the new values,
+or the original values? There are three possible answers, which depend on an
+attribute of the ``stmt`` called the *Cursor sensitivity*. Here are the
+options:
 
-1. If the attribute value is 0, the ``#define`` in ``sqlcli.h`` is 
-   ``SQL_UNDEFINED`` and the requested action is "I don't care whether I see 
-   new or old values; leave it up to the implementation". 
+1. If the attribute value is 0, the ``#define`` in ``sqlcli.h`` is
+   ``SQL_UNDEFINED`` and the requested action is "I don't care whether I see
+   new or old values; leave it up to the implementation".
 
-2. If the attribute value is 1, the ``#define`` in ``sqlcli.h`` is 
-   ``SQL_INSENSITIVE`` and the requested action is "show me the original 
-   values". 
+2. If the attribute value is 1, the ``#define`` in ``sqlcli.h`` is
+   ``SQL_INSENSITIVE`` and the requested action is "show me the original
+   values".
 
-3. If the attribute value is 2, the ``#define`` in ``sqlcli.h`` is 
-   ``SQL_SENSITIVE`` and the requested action is "show me the changed values". 
+3. If the attribute value is 2, the ``#define`` in ``sqlcli.h`` is
+   ``SQL_SENSITIVE`` and the requested action is "show me the changed values".
 
-The default is ``SQL_UNDEFINED`` (which may be known as ``SQL_ASENSITIVE`` in 
-ANSI SQL3). Your best option is to just leave this attribute setting alone, and 
-do what you can to avoid the situation. If you must specify one of the other 
-settings, you can do so with a call to the ``SQLSetStmtAttr`` function, for 
-example: 
+The default is ``SQL_UNDEFINED`` (which may be known as ``SQL_ASENSITIVE`` in
+ANSI SQL3). Your best option is to just leave this attribute setting alone, and
+do what you can to avoid the situation. If you must specify one of the other
+settings, you can do so with a call to the ``SQLSetStmtAttr`` function, for
+example:
 
 ::
 
    SQLSetStmtAttr(hstmt,SQL_ATTR_CURSOR_SENSITIVITY,&SQL_INSENSITIVE,NULL);
 
-You would probably want an insensitive Cursor if the fetched rows have to be 
-consistent with each other. However, most DBMSs maintain insensitive Cursors by 
-making a copy of the Table (that is: the rows in the result set are not 
-necessarily identical to the rows of the Table you selected from). Therefore, 
-an insensitive Cursor is always a *READ-ONLY Cursor*. The ``SQLGetStmtAttr`` 
-function can be used to check which Cursor sensitivity option is currently in 
-effect. The ``SQLGetInfo`` function can be used to check whether a DBMS 
-supports the Cursor sensitivity options. Many DBMSs support ``SQL_UNSPECIFIED`` 
-only. 
+You would probably want an insensitive Cursor if the fetched rows have to be
+consistent with each other. However, most DBMSs maintain insensitive Cursors by
+making a copy of the Table (that is: the rows in the result set are not
+necessarily identical to the rows of the Table you selected from). Therefore,
+an insensitive Cursor is always a *READ-ONLY Cursor*. The ``SQLGetStmtAttr``
+function can be used to check which Cursor sensitivity option is currently in
+effect. The ``SQLGetInfo`` function can be used to check whether a DBMS
+supports the Cursor sensitivity options. Many DBMSs support ``SQL_UNSPECIFIED``
+only.
 
 *Holdable Cursors*
 ------------------
 
-Another ``stmt`` attribute that affects Cursor management is "holdability". 
-This attribute, which can also be set with the ``SQLSetStmtAttr`` function, 
-affects the question: What happens to an open Cursor when we end a transaction 
-with ``SQLEndTran(...SQL_COMMIT)``? Here are the two possible options: 
+Another ``stmt`` attribute that affects Cursor management is "holdability".
+This attribute, which can also be set with the ``SQLSetStmtAttr`` function,
+affects the question: What happens to an open Cursor when we end a transaction
+with ``SQLEndTran(...SQL_COMMIT)``? Here are the two possible options:
 
-1. If the attribute value is 0, the ``#define`` in ``sqlcli.h`` is 
+1. If the attribute value is 0, the ``#define`` in ``sqlcli.h`` is
    ``SQL_NONHOLDABLE`` and the requested action is "close the Cursor".
 
-2. If the attribute value is 1, the ``#define`` in ``sqlcli.h`` is 
-   ``SQL_HOLDABLE`` and the requested action is "leave the Cursor open into 
+2. If the attribute value is 1, the ``#define`` in ``sqlcli.h`` is
+   ``SQL_HOLDABLE`` and the requested action is "leave the Cursor open into
    the next transaction".
 
 The default is ``SQL_NONHOLDABLE``. In fact, for most DBMSs, holdability is not
@@ -793,9 +795,9 @@ SQLMoreResults
     SQLHSTMT hstmt       /* 32-bit input */
     );
 
-**Job:** Find out if there is another result set associated with the 
-``stmt``. If so, position the Cursor at the start of the next result set 
-(that is, before the first row of the next result set). This is an SQL3 
+**Job:** Find out if there is another result set associated with the
+``stmt``. If so, position the Cursor at the start of the next result set
+(that is, before the first row of the next result set). This is an SQL3
 function.
 
 Only one SQL statement can produce multiple result sets:
@@ -804,7 +806,7 @@ Only one SQL statement can produce multiple result sets:
 
    CALL <procedure-name>
 
-That's because a "procedure" might contain multiple ``SELECT`` statements. 
+That's because a "procedure" might contain multiple ``SELECT`` statements.
 In such a case, result sets are returned in the order they were produced.
 
 **Algorithm:**
@@ -829,7 +831,7 @@ In such a case, result sets are returned in the order they were produced.
 * Result sets must be processed one at a time. You cannot process them
   in parallel (though that's a feature that's being considered for SQL4).
 
-* Since earlier versions of the SQL Standard didn't support SQL procedures, 
+* Since earlier versions of the SQL Standard didn't support SQL procedures,
   there was no need for an ``SQLMoreResults`` function until SQL3.
 
 **Example:**
@@ -845,10 +847,10 @@ In such a case, result sets are returned in the order they were produced.
       SQLMoreResults(hstmt);
       SQLFetch(hstmt);
 
-**ODBC:** ``SQLMoreResults`` has been around since ODBC version 1.0. That has 
-more to do with ODBC's non-standard "batching" feature than with support for 
-procedures. However, Microsoft has always assumed that DBMSs support 
-procedures. 
+**ODBC:** ``SQLMoreResults`` has been around since ODBC version 1.0. That has
+more to do with ODBC's non-standard "batching" feature than with support for
+procedures. However, Microsoft has always assumed that DBMSs support
+procedures.
 
-And that's it for the Cursor functions. In the next chapter, we'll take a look 
-at the meat of CLI -- the ``desc`` functions. 
+And that's it for the Cursor functions. In the next chapter, we'll take a look
+at the meat of CLI -- the ``desc`` functions.

--- a/docs/chapters/46.rst
+++ b/docs/chapters/46.rst
@@ -4,21 +4,23 @@
 Chapter 46 -- SQL/CLI: desc Functions
 =====================================
 
-In this chapter, we'll describe the fourth essential CLI resource: the 
-``desc``. We have much to say about: 
+.. include:: ../_include/note.rst
 
-* What is in a ``desc`` -- fields of the header and the "item descriptor 
+In this chapter, we'll describe the fourth essential CLI resource: the
+``desc``. We have much to say about:
+
+* What is in a ``desc`` -- fields of the header and the "item descriptor
   areas".
 
 * How to make a ``desc``, or how to use an automatically-made ``desc``.
 
 * Similarities and differences of ARDs, APDs, IRDs and IPDs.
 
-* Functions which attack ``desc``\s directly: ``SQLAllocHandle``, 
-  ``SQLGetDescField``, ``SQLSetDescField``, ``SQLGetDescRec``, 
+* Functions which attack ``desc``\s directly: ``SQLAllocHandle``,
+  ``SQLGetDescField``, ``SQLSetDescField``, ``SQLGetDescRec``,
   ``SQLSetDescRec``, ``SQLCopyDesc`` and others.
 
-* Functions which attack descs indirectly: ``SQLBindParameter``, 
+* Functions which attack descs indirectly: ``SQLBindParameter``,
   ``SQLBindCol``, ``SQLColAttribute``, ``SQLDescribeCol`` and others.
 
 .. rubric:: Table of Contents
@@ -36,48 +38,48 @@ Here is a piece of CLI code:
    SQLExecDirect(hstmt,"SELECT col_1,col_2 FROM T WHERE col_1=?",SQL_NTS);
    SQLFetch(hstmt);
 
-The ``SELECT`` statement in this example contains a question mark: it 
-represents a parameter marker -- that is, it means "there is an input parameter 
-here". (An *input parameter* is a host variable value which travels from the 
-application to the DBMS. For some ``CALL`` statements a parameter may be an 
-output parameter, but the normal case is that parameters are input parameters.) 
-The input will happen during ``SQLExecDirect``. 
+The ``SELECT`` statement in this example contains a question mark: it
+represents a parameter marker -- that is, it means "there is an input parameter
+here". (An *input parameter* is a host variable value which travels from the
+application to the DBMS. For some ``CALL`` statements a parameter may be an
+output parameter, but the normal case is that parameters are input parameters.)
+The input will happen during ``SQLExecDirect``.
 
-The ``SELECT`` statement also contains a two-Column select list 
-(``col_1,col_2``). The existence of a select list implies "there are output 
-rows here". (An *output row* consists of one or more Columns in a result set, 
-whose values travel from the DBMS to the application.) The output will happen 
-during ``SQLFetch``. 
+The ``SELECT`` statement also contains a two-Column select list
+(``col_1,col_2``). The existence of a select list implies "there are output
+rows here". (An *output row* consists of one or more Columns in a result set,
+whose values travel from the DBMS to the application.) The output will happen
+during ``SQLFetch``.
 
-What are the addresses of the host variables? How will ``NULL`` values be 
-flagged? What is already known, or can be specified, about the characteristics 
-of each value: <data type>, size, precision, scale, Character set, etc.? 
-Descriptor areas -- or ``desc``\s -- are available to handle such questions, 
-for both parameters and row Columns. 
+What are the addresses of the host variables? How will ``NULL`` values be
+flagged? What is already known, or can be specified, about the characteristics
+of each value: <data type>, size, precision, scale, Character set, etc.?
+Descriptor areas -- or ``desc``\s -- are available to handle such questions,
+for both parameters and row Columns.
 
 *Automatic descs*
 -----------------
 
 There are four automatic ``desc``\s; here's a brief description of each:
 
-* IRD, or Implementation Row Descriptor. Its usual use: to find out what the 
-  DBMS knows about a result set. The IRD is filled in when you call 
-  ``SQLPrepare`` for a ``SELECT`` statement. 
+* IRD, or Implementation Row Descriptor. Its usual use: to find out what the
+  DBMS knows about a result set. The IRD is filled in when you call
+  ``SQLPrepare`` for a ``SELECT`` statement.
 
-* ARD, or Application Row Descriptor. Its usual use: to tell the DBMS how to 
-  transfer a result set to the host. The important fields of the ARD must be 
-  filled in by the host program. 
+* ARD, or Application Row Descriptor. Its usual use: to tell the DBMS how to
+  transfer a result set to the host. The important fields of the ARD must be
+  filled in by the host program.
 
-* IPD, or Implementation Parameter Descriptor. Its usual use: to provide 
-  information about the DBMS's view of parameters. The DBMS may be capable of 
-  "populating" the IPD fields; otherwise, the programmer must take some 
-  responsibility for this job. 
+* IPD, or Implementation Parameter Descriptor. Its usual use: to provide
+  information about the DBMS's view of parameters. The DBMS may be capable of
+  "populating" the IPD fields; otherwise, the programmer must take some
+  responsibility for this job.
 
-* APD, or Application Parameter Descriptor. Its usual use: to the tell the DBMS 
-  how to transfer an input parameter. (Parameters are marked in an SQL 
-  statement with "?" parameter markers.) 
+* APD, or Application Parameter Descriptor. Its usual use: to the tell the DBMS
+  how to transfer an input parameter. (Parameters are marked in an SQL
+  statement with "?" parameter markers.)
 
-Here's a pseudo ``struc`` declaration, for future reference in this chapter's 
+Here's a pseudo ``struc`` declaration, for future reference in this chapter's
 examples.
 
 ::
@@ -123,55 +125,55 @@ examples.
     ARD = desc;
     IRD = desc;
 
-Throughout this chapter, we'll replace long-winded references using 
-program-like conventions. For example, it is often necessary to make statements 
-like this: "Within the Application Parameter Descriptor, in the *n*\th 
-occurrence of the Item Descriptor Area, set the ``SCALE`` attribute to ``5``." 
-We will make such statements this way: 
+Throughout this chapter, we'll replace long-winded references using
+program-like conventions. For example, it is often necessary to make statements
+like this: "Within the Application Parameter Descriptor, in the *n*\th
+occurrence of the Item Descriptor Area, set the ``SCALE`` attribute to ``5``."
+We will make such statements this way:
 
 ::
 
    "Set APD.IDA[n].SQL_DESC_SCALE = 5"
 
-For a programmer, the second statement is shorter, clearer and better. We'll 
-use such statements as convenient conventions, without implying that all DBMSs 
-store ``desc`` information with this structure. 
+For a programmer, the second statement is shorter, clearer and better. We'll
+use such statements as convenient conventions, without implying that all DBMSs
+store ``desc`` information with this structure.
 
 The desc Fields
 ===============
 
-On first reading, we suggest that you skip quickly through this section. But 
-bookmark this page -- you'll have to refer to the ``desc`` field descriptions 
-many times. 
+On first reading, we suggest that you skip quickly through this section. But
+bookmark this page -- you'll have to refer to the ``desc`` field descriptions
+many times.
 
-The first entries in a descriptor area are the ``desc`` "header" fields. Then 
-come the fields of the ``desc`` "item descriptor area" (IDA), which is 
-multiple-occurrence. In our discussions of each group, entries are in 
-alphabetical order. Each entry begins with a field identifier (which is the 
-code used for identification), a <data type> and an indicator of the field's 
-importance. For example: 
+The first entries in a descriptor area are the ``desc`` "header" fields. Then
+come the fields of the ``desc`` "item descriptor area" (IDA), which is
+multiple-occurrence. In our discussions of each group, entries are in
+alphabetical order. Each entry begins with a field identifier (which is the
+code used for identification), a <data type> and an indicator of the field's
+importance. For example:
 
 ::
 
    SQL_DESC_ALLOC_TYPE 1099
          Type: SMALLINT. Importance: Low.
 
-This description should be read as follows: The SQL descriptor field is 
-identified by the code ``SQL_DESC_ALLOC_TYPE``, which is a number. The 
-``sqlcli.h`` line for this field is: 
+This description should be read as follows: The SQL descriptor field is
+identified by the code ``SQL_DESC_ALLOC_TYPE``, which is a number. The
+``sqlcli.h`` line for this field is:
 
 ::
 
    #define SQL_DESC_ALLOC_TYPE 1099
 
-This book uses ``SQL_DESC_ALLOC_TYPE`` as both a field identifier and a field 
-name. The field's <data type> is ``SMALLINT`` (short signed integer). 
-Relatively speaking, the field is of low importance (this is our subjective 
-estimate). 
+This book uses ``SQL_DESC_ALLOC_TYPE`` as both a field identifier and a field
+name. The field's <data type> is ``SMALLINT`` (short signed integer).
+Relatively speaking, the field is of low importance (this is our subjective
+estimate).
 
-Each field entry contains some text description, accompanied by examples if the 
-field is of high importance. Finally, each entry ends with a small chart. For 
-example: 
+Each field entry contains some text description, accompanied by examples if the
+field is of high importance. Finally, each entry ends with a small chart. For
+example:
 
 +-----+------------------------------+---------------------------+
 |     | May be Gotten by ...         | May be Set by ...         |
@@ -185,43 +187,43 @@ example:
 | IPD | ``SQLExecute, user``         | ``SQLPrepare[I], user``   |
 +-----+------------------------------+---------------------------+
 
-This chart should be read as follows: When this field is in the ARD, it may be 
-gotten by the user (presumably with the ``SQLGetDescField`` function) and it 
-may be set by the ``SQLGetData`` function or by the user (presumably with the 
-``SQLSetDescField`` function). And so on for the IRD, APD and IPD. In the 
-chart, the symbol ``[I]`` means "this function is applicable only when the 
-``AUTO POPULATE`` flag is on" -- which usually it isn't, as you may recall from 
-the discussion of ``SQLSetEnvAttr``. The symbol ``[P]`` means "this function is 
-legal only if the statement is prepared". The chart does not show functions 
-which are, in functional effect, containers of other functions. For example, 
-many fields may be affected by ``SQLExecDirect``, but we won't show that; we 
-only show ``SQLPrepare`` and/or ``SQLExecute``. If either "May be Gotten By" or 
-"May be Set by" is blank for a particular automatic ``desc``, that means the 
-field is not affected by any "get" or "set" function (as appropriate) for that 
-``desc``. 
+This chart should be read as follows: When this field is in the ARD, it may be
+gotten by the user (presumably with the ``SQLGetDescField`` function) and it
+may be set by the ``SQLGetData`` function or by the user (presumably with the
+``SQLSetDescField`` function). And so on for the IRD, APD and IPD. In the
+chart, the symbol ``[I]`` means "this function is applicable only when the
+``AUTO POPULATE`` flag is on" -- which usually it isn't, as you may recall from
+the discussion of ``SQLSetEnvAttr``. The symbol ``[P]`` means "this function is
+legal only if the statement is prepared". The chart does not show functions
+which are, in functional effect, containers of other functions. For example,
+many fields may be affected by ``SQLExecDirect``, but we won't show that; we
+only show ``SQLPrepare`` and/or ``SQLExecute``. If either "May be Gotten By" or
+"May be Set by" is blank for a particular automatic ``desc``, that means the
+field is not affected by any "get" or "set" function (as appropriate) for that
+``desc``.
 
 *The desc Header Fields*
 ------------------------
 
-There are five ``desc`` header fields: ``SQL_DESC_ALLOC_TYPE``, 
-``SQL_DESC_COUNT``, ``SQL_DESC_DYNAMIC_FUNCTION``, 
-``SQL_DESC_DYNAMIC_FUNCTION_CODE`` and ``SQL_DESC_KEY_TYPE``. Their 
-descriptions follow. 
+There are five ``desc`` header fields: ``SQL_DESC_ALLOC_TYPE``,
+``SQL_DESC_COUNT``, ``SQL_DESC_DYNAMIC_FUNCTION``,
+``SQL_DESC_DYNAMIC_FUNCTION_CODE`` and ``SQL_DESC_KEY_TYPE``. Their
+descriptions follow.
 
 ::
 
     SQL_DESC_ALLOC_TYPE
     SQL_DESC_ALLOC_TYPE 1099
 
-**Type:** ``SMALLINT``. **Importance:** Low. 
+**Type:** ``SMALLINT``. **Importance:** Low.
 
-**Possible values:** ``SQL_DESC_ALLOC_AUTO (1)`` or ``SQL_DESC_ALLOC_USER 
-(2)``. The value is set permanently when the ``desc`` is created. Those 
-``desc``\s which are made implicitly by a call to 
-``SQLAllocHandle(SQL_HANDLE_STMT,...)`` are automatic ``desc``\s; they will 
-have ``SQL_DESC_ALLOC_AUTO`` in this field. Those ``desc``\s which are made 
-explicitly by a call to ``SQLAllocHandle(SQL_HANDLE_DESC,...)`` are user 
-``desc``\s; they will have ``SQL_DESC_ALLOC_USER`` in this field. 
+**Possible values:** ``SQL_DESC_ALLOC_AUTO (1)`` or ``SQL_DESC_ALLOC_USER
+(2)``. The value is set permanently when the ``desc`` is created. Those
+``desc``\s which are made implicitly by a call to
+``SQLAllocHandle(SQL_HANDLE_STMT,...)`` are automatic ``desc``\s; they will
+have ``SQL_DESC_ALLOC_AUTO`` in this field. Those ``desc``\s which are made
+explicitly by a call to ``SQLAllocHandle(SQL_HANDLE_DESC,...)`` are user
+``desc``\s; they will have ``SQL_DESC_ALLOC_USER`` in this field.
 
 +-----+-------------------------------+-------------------------+
 |     | May be Gotten by ...          | May be Set by ...       |
@@ -242,23 +244,23 @@ explicitly by a call to ``SQLAllocHandle(SQL_HANDLE_DESC,...)`` are user
 
 **Type:** ``SMALLINT``. **Importance:** High
 
-Provides the number of item descriptor areas in the ``desc``. Conceptually, 
-there is a correspondence between the value in ``SQL_DESC_COUNT`` and the 
-number of actual items -- the "number of parameters" (for IPDs and APDs) or 
-"the number of Columns" (for IRDs and ARDs). However, this correspondence is 
-not automatically true. You have to make it so. 
+Provides the number of item descriptor areas in the ``desc``. Conceptually,
+there is a correspondence between the value in ``SQL_DESC_COUNT`` and the
+number of actual items -- the "number of parameters" (for IPDs and APDs) or
+"the number of Columns" (for IRDs and ARDs). However, this correspondence is
+not automatically true. You have to make it so.
 
-Initially, the field value is ``0``. The ``SQLPrepare`` function will set 
-``IRD.SQL_DESC_COUNT =`` <the number of Columns in the select list>. If 
-"populate IPD" is true, the ``SQLPrepare`` function will set 
-``IPD.SQL_DESC_COUNT =`` <the number of parameter markers in SQL statement>. 
+Initially, the field value is ``0``. The ``SQLPrepare`` function will set
+``IRD.SQL_DESC_COUNT =`` <the number of Columns in the select list>. If
+"populate IPD" is true, the ``SQLPrepare`` function will set
+``IPD.SQL_DESC_COUNT =`` <the number of parameter markers in SQL statement>.
 
-If you call a function which effectively creates a new IDA, then the ``COUNT`` 
-field value may go up. For example, if ``ARD.SQL_DESC_COUNT=0`` and you call 
-``SQLBindCol`` for ``COLUMN_1``, then ``ARD.SQL_DESC_COUNT`` is set to ``1``. 
+If you call a function which effectively creates a new IDA, then the ``COUNT``
+field value may go up. For example, if ``ARD.SQL_DESC_COUNT=0`` and you call
+``SQLBindCol`` for ``COLUMN_1``, then ``ARD.SQL_DESC_COUNT`` is set to ``1``.
 
-In ODBC, the value goes down if you "unbind" the last IDA (by setting 
-``desc.IDA[n].SQL_DATA_POINTER=0)``. 
+In ODBC, the value goes down if you "unbind" the last IDA (by setting
+``desc.IDA[n].SQL_DATA_POINTER=0)``.
 
 +-----+------------------------------------+-------------------------------------+
 |     | May be Gotten by ...               | May be Set by ...                   |
@@ -287,14 +289,14 @@ In ODBC, the value goes down if you "unbind" the last IDA (by setting
 
 **Type:** ``VARCHAR``. **Importance:** Low.
 
-This is an SQL3 field only; it's not in ODBC. It provides an ``SQL_TEXT`` 
+This is an SQL3 field only; it's not in ODBC. It provides an ``SQL_TEXT``
 string containing a copy of the prepared statement. For example, after:
 
 ::
 
    SQLPrepare(hstmt,"INSERT INTO Table_1 VALUES (5)",SQL_NTS);
 
-``IRD.SQL_DESC_DYNAMIC_FUNCTION`` will contain ``'INSERT INTO Table_1 VALUES 
+``IRD.SQL_DESC_DYNAMIC_FUNCTION`` will contain ``'INSERT INTO Table_1 VALUES
 (5)'``. You can get the same information with the ``SQLGetDiagField`` function.
 
 +-----+------------------------+---------------------------+
@@ -323,9 +325,9 @@ the prepared statement. For example, after:
 
    SQLPrepare(hstmt,"INSERT INTO Table_1 VALUES (5)",SQL_NTS);
 
-``IRD.SQL_DESC_DYNAMIC_FUNCTION_CODE`` will contain ``50`` (you can find the 
-list of possible codes in our chapter on SQL/CLI diagnostics). You can get the 
-same information with the ``SQLGetDiagField`` function. 
+``IRD.SQL_DESC_DYNAMIC_FUNCTION_CODE`` will contain ``50`` (you can find the
+list of possible codes in our chapter on SQL/CLI diagnostics). You can get the
+same information with the ``SQLGetDiagField`` function.
 
 +-----+------------------------+---------------------+
 |     | May be Gotten by ...   | May be Set by ...   |
@@ -346,12 +348,12 @@ same information with the ``SQLGetDiagField`` function.
 
 **Type:** ``SMALLINT``. **Importance:** Low.
 
-This is an SQL3 field only; it's not in ODBC. If a ``SELECT`` statement's 
-select list contains all the Columns of the Table's primary key, the value is 
-``2``. If it contains all the Columns of one of the Table's preferred candidate 
-keys, the value is ``1``. Otherwise, the value is ``0``. For example, suppose 
-that ``TABLE_1`` has two Columns, ``COL_1`` and ``COL_2``, and that 
-``TABLE_1``\'s primary key is ``(COL_1)``. In that case: 
+This is an SQL3 field only; it's not in ODBC. If a ``SELECT`` statement's
+select list contains all the Columns of the Table's primary key, the value is
+``2``. If it contains all the Columns of one of the Table's preferred candidate
+keys, the value is ``1``. Otherwise, the value is ``0``. For example, suppose
+that ``TABLE_1`` has two Columns, ``COL_1`` and ``COL_2``, and that
+``TABLE_1``\'s primary key is ``(COL_1)``. In that case:
 
 ::
 
@@ -380,7 +382,7 @@ will set ``IRD.SQL_DESC_KEY_TYPE = 0``.
 *The desc Item Descriptor Area (IDA) Fields*
 --------------------------------------------
 
-There are 28 ``desc`` IDA fields: 
+There are 28 ``desc`` IDA fields:
 
 +--------------------------------------------+--------------------------------------------+
 | ``SQL_DESC_CHARACTER_SET_CATALOG``         | ``SQL_DESC_CHARACTER_SET_SCHEMA``          |
@@ -412,8 +414,8 @@ There are 28 ``desc`` IDA fields:
 | ``SQL_DESC_UDT_NAME``                      | ``SQL_DESC_UNNAMED``                       |
 +--------------------------------------------+--------------------------------------------+
 
-These fields are also known as the "Item Fields", the "fields of the Descriptor 
-Record" (an ODBC term) and as the "detail records". Their descriptions follow. 
+These fields are also known as the "Item Fields", the "fields of the Descriptor
+Record" (an ODBC term) and as the "detail records". Their descriptions follow.
 
 
 Character Set Fields
@@ -437,11 +439,11 @@ ____________________
 
 **Type:** ``VARCHAR``. **Importance:** Low.
 
-These three fields are SQL3 fields only; they're not in ODBC. Together, they 
-make up the qualified name of a Character set and are meaningful only if the 
-item's <data type> is ``CHAR``, ``VARCHAR`` or ``CLOB``. Some example values 
-are: ``'OCELOT'``, ``'INFORMATION_SCHEMA'`` and ``'ISO8BIT'`` (for the three 
-fields, respectively). 
+These three fields are SQL3 fields only; they're not in ODBC. Together, they
+make up the qualified name of a Character set and are meaningful only if the
+item's <data type> is ``CHAR``, ``VARCHAR`` or ``CLOB``. Some example values
+are: ``'OCELOT'``, ``'INFORMATION_SCHEMA'`` and ``'ISO8BIT'`` (for the three
+fields, respectively).
 
 +-----+---------------------------+-----------------------------+
 |     | May be Gotten by ...      | May be Set by ...           |
@@ -476,16 +478,16 @@ ________________
 
 **Type:** ``VARCHAR``. **Importance:** Low.
 
-These three fields are ANSI SQL3 fields only; they're not in ISO SQL3 or ODBC. 
-Together, they make up the qualified name of a Collation and are meaningful 
-only if the item's <data type> is ``CHAR``, ``VARCHAR`` or ``CLOB``. The 
-Standard says, ambiguously, that this is "the Character set's Collation". 
-Presumably it is, in fact, the item's Collation. 
+These three fields are ANSI SQL3 fields only; they're not in ISO SQL3 or ODBC.
+Together, they make up the qualified name of a Collation and are meaningful
+only if the item's <data type> is ``CHAR``, ``VARCHAR`` or ``CLOB``. The
+Standard says, ambiguously, that this is "the Character set's Collation".
+Presumably it is, in fact, the item's Collation.
 
-For a select list, a standard DBMS may set these fields to a <Collation name> 
--- for example, ``'OCELOT'``, ``'INFORMATION_SCHEMA'`` and ``'POLISH'`` (for 
-the three fields, respectively). You can change the fields, but it does not 
-matter -- the DBMS never reads them. 
+For a select list, a standard DBMS may set these fields to a <Collation name>
+-- for example, ``'OCELOT'``, ``'INFORMATION_SCHEMA'`` and ``'POLISH'`` (for
+the three fields, respectively). You can change the fields, but it does not
+matter -- the DBMS never reads them.
 
 +-----+------------------------+-----------------------------+
 |     | May be Gotten by ...   | May be Set by ...           |
@@ -506,21 +508,21 @@ matter -- the DBMS never reads them.
 
 **Type:** ``POINTER``. **Importance:** High.
 
-Provides the address of a host variable. Meaningful in the APD (where it points 
-to an input parameter), or in the ARD (where it points to a target for the 
-result-set Column). 
+Provides the address of a host variable. Meaningful in the APD (where it points
+to an input parameter), or in the ARD (where it points to a target for the
+result-set Column).
 
-The initial value is ``0``. When this field is set to a non-zero value, the 
-item is considered to be "bound" -- a "bound parameter", a "bound target". 
-Application programmers must ensure that the address is valid. 
+The initial value is ``0``. When this field is set to a non-zero value, the
+item is considered to be "bound" -- a "bound parameter", a "bound target".
+Application programmers must ensure that the address is valid.
 
-This field is reset to ``0`` if a change is made to a non-pointer field in the 
-same IDA using the ``SQLSetDescField`` function. For example: if, using 
-``SQLSetDescField``, you set ``IPD.IDA[4].SQL_DESC_DATETIME_INTERVAL_CODE = 
-1``, the side effect is that ``IPD.IDA[4].SQL_DESC_DATA_POINTER = 0``. Moral: 
-change this field last. 
+This field is reset to ``0`` if a change is made to a non-pointer field in the
+same IDA using the ``SQLSetDescField`` function. For example: if, using
+``SQLSetDescField``, you set ``IPD.IDA[4].SQL_DESC_DATETIME_INTERVAL_CODE =
+1``, the side effect is that ``IPD.IDA[4].SQL_DESC_DATA_POINTER = 0``. Moral:
+change this field last.
 
-In ODBC: the name is ``SQL_DESC_DATA_PTR``. 
+In ODBC: the name is ``SQL_DESC_DATA_PTR``.
 
 +-----+---------------------------+------------------------------+
 |     | May be Gotten by ...      | May be Set by ...            |
@@ -543,14 +545,14 @@ In ODBC: the name is ``SQL_DESC_DATA_PTR``.
 
 **Type:** ``SMALLINT``. **Importance:** Medium.
 
-This field will only be meaningful if the ``SQL_DESC_TYPE field`` is ``9 
-(SQL_DATETIME)`` or ``10 (SQL_INTERVAL)``. It will contain a datetime subtype 
-(a number between ``1`` and ``5``) or an interval subtype (a number between 
-``1`` and ``13``). For example: if ``SQL_DESC_TYPE = 9`` and 
-``SQL_DESC_DATETIME_INTERVAL_CODE = 5``, then the item's precise <data type> is 
-known to be ``TIMESTAMP WITH TIME ZONE``. If you change the ``SQL_DESC_TYPE`` 
-field to ``9`` or ``10``, you must change ``SQL_DESC_DATETIME_INTERVAL_CODE`` 
-too. 
+This field will only be meaningful if the ``SQL_DESC_TYPE field`` is ``9
+(SQL_DATETIME)`` or ``10 (SQL_INTERVAL)``. It will contain a datetime subtype
+(a number between ``1`` and ``5``) or an interval subtype (a number between
+``1`` and ``13``). For example: if ``SQL_DESC_TYPE = 9`` and
+``SQL_DESC_DATETIME_INTERVAL_CODE = 5``, then the item's precise <data type> is
+known to be ``TIMESTAMP WITH TIME ZONE``. If you change the ``SQL_DESC_TYPE``
+field to ``9`` or ``10``, you must change ``SQL_DESC_DATETIME_INTERVAL_CODE``
+too.
 
 +-----+-------------------------------+---------------------------------+
 |     | May be Gotten by ...          | May be Set by ...               |
@@ -574,15 +576,15 @@ too.
 
 **Type:** ``SMALLINT``. **Importance:** Medium.
 
-This field will only be meaningful if the ``SQL_DESC_TYPE`` field is ``9 
-(SQL_DATETIME)`` or ``10 (SQL_INTERVAL)``. This is the precision of the leading 
-datetime field -- not the fractional-seconds precision. For example, a ``DATE`` 
-value has three fields: ``YEAR``, ``MONTH`` and ``DAY``. The first ("leading") 
-datetime field in a ``DATE`` is ``YEAR``, which always has four positions: 
-``yyyy``. Therefore, ``desc.IDA[n].SQL_DESC_DATETIME_INTERVAL_PRECISION = 4``. 
+This field will only be meaningful if the ``SQL_DESC_TYPE`` field is ``9
+(SQL_DATETIME)`` or ``10 (SQL_INTERVAL)``. This is the precision of the leading
+datetime field -- not the fractional-seconds precision. For example, a ``DATE``
+value has three fields: ``YEAR``, ``MONTH`` and ``DAY``. The first ("leading")
+datetime field in a ``DATE`` is ``YEAR``, which always has four positions:
+``yyyy``. Therefore, ``desc.IDA[n].SQL_DESC_DATETIME_INTERVAL_PRECISION = 4``.
 
-In ODBC, ``SQL_DESC_DATETIME_INTERVAL_PRECISION`` is ``26`` rather than 
-``1014`` and <data type> is ``INTEGER`` rather than ``SMALLINT``. 
+In ODBC, ``SQL_DESC_DATETIME_INTERVAL_PRECISION`` is ``26`` rather than
+``1014`` and <data type> is ``INTEGER`` rather than ``SMALLINT``.
 
 +-----+-------------------------------+--------------------------------+
 |     | May be Gotten by ...          | May be Set by ...              |
@@ -605,15 +607,15 @@ In ODBC, ``SQL_DESC_DATETIME_INTERVAL_PRECISION`` is ``26`` rather than
 
 **Type:** ``POINTER TO INTEGER``. **Importance:** Medium
 
-Provides the address of an indicator. This field is used together with 
-``SQL_DESC_DATA_POINTER``. For example, suppose that you set 
-``ARD.IDA[n].SQL_DESC_INDICATOR_POINTER = &indicator`` (where ``&indicator`` 
-means "the address of a variable named ``indicator`` in the host program"). If 
-``SQLGetData`` retrieves a null value for the *n*\th Column in the select list, 
-``indicator`` is set to ``SQL_NULL_DATA (-1)``. The field's initial value is 
-``0``. 
+Provides the address of an indicator. This field is used together with
+``SQL_DESC_DATA_POINTER``. For example, suppose that you set
+``ARD.IDA[n].SQL_DESC_INDICATOR_POINTER = &indicator`` (where ``&indicator``
+means "the address of a variable named ``indicator`` in the host program"). If
+``SQLGetData`` retrieves a null value for the *n*\th Column in the select list,
+``indicator`` is set to ``SQL_NULL_DATA (-1)``. The field's initial value is
+``0``.
 
-In ODBC, the name is ``SQL_DESC_INDICATOR_PTR``. 
+In ODBC, the name is ``SQL_DESC_INDICATOR_PTR``.
 
 +-----+----------------------------+--------------------------------+
 |     | May be Gotten by ...       | May be Set by ...              |
@@ -644,7 +646,7 @@ the value is ``1`` (true); otherwise it's ``0`` (false). For example:
 
    SQLPrepare(hstmt,"SELECT 5 FROM t",SQL_NTS);
 
-will set ``IRD.IDA[1].SQL_DESC_KEY_MEMBER = 0``. (See also the header field 
+will set ``IRD.IDA[1].SQL_DESC_KEY_MEMBER = 0``. (See also the header field
 ``SQL_DESC_KEY_TYPE``.)
 
 +-----+-----------------------+-----------------------+
@@ -666,14 +668,14 @@ will set ``IRD.IDA[1].SQL_DESC_KEY_MEMBER = 0``. (See also the header field
 
 **Data type:** ``INTEGER``. **Importance:** Medium.
 
-For all character string <data type>s, this is the defined length in characters 
--- for example, it equals ``12`` for a Column defined as ``VARCHAR(12)``. For 
-all bit string <data type>s, this is the defined length in bits. For all 
-temporal <data type>s, this is the defined length in positions -- for example, 
-it equals ``10`` for a Column defined as a ``DATE`` (because 2000-01-01 is 10 
-positions). For a ``BLOB`` <data type>, this is the defined length in octets. 
-In ``ANSI SQL, SQL_DESC_LENGTH`` may be changed with the ``SQLSetDescField`` 
-function. In ISO SQL, it may not be. 
+For all character string <data type>s, this is the defined length in characters
+-- for example, it equals ``12`` for a Column defined as ``VARCHAR(12)``. For
+all bit string <data type>s, this is the defined length in bits. For all
+temporal <data type>s, this is the defined length in positions -- for example,
+it equals ``10`` for a Column defined as a ``DATE`` (because 2000-01-01 is 10
+positions). For a ``BLOB`` <data type>, this is the defined length in octets.
+In ``ANSI SQL, SQL_DESC_LENGTH`` may be changed with the ``SQLSetDescField``
+function. In ISO SQL, it may not be.
 
 +-----+----------------------------------------+---------------------------------+
 |     | May be Gotten by ...                   | May be Set by ...               |
@@ -695,16 +697,16 @@ function. In ISO SQL, it may not be.
 
 **Type:** ``VARCHAR``. **Importance:** Low.
 
-This provides the derived Column name if there's a select list. For example, 
+This provides the derived Column name if there's a select list. For example,
 after:
 
 ::
 
    SQLPrepare(hstmt,"SELECT col_1 FROM Table_1",SQL_NTS);
 
-the DBMS sets ``IRD.IDA[n].SQL_DESC_NAME = "Col_1"``. In ANSI SQL, 
-``SQL_DESC_NAME`` may be changed with the ``SQLSetDescField`` function. In ISO 
-SQL, it may not be. In ODBC, named parameters are supported. 
+the DBMS sets ``IRD.IDA[n].SQL_DESC_NAME = "Col_1"``. In ANSI SQL,
+``SQL_DESC_NAME`` may be changed with the ``SQLSetDescField`` function. In ISO
+SQL, it may not be. In ODBC, named parameters are supported.
 
 +-----+-----------------------------------+---------------------+
 |     | May be Gotten by ...              | May be Set by ...   |
@@ -725,11 +727,11 @@ SQL, it may not be. In ODBC, named parameters are supported.
 
 **Type:** ``SMALLINT``. **Importance:** Medium.
 
-This field is ``1`` (true) (``SQL_NULLABLE``) if the value might be ``NULL``; 
-otherwise it's ``0`` (false) (``SQL_NO_NULLS``). For a populated IPD, 
-``SQL_DESC_NULLABLE`` is ``1``. In ANSI SQL, ``SQL_DESC_NULLABLE`` may be 
-changed with the ``SQLSetDescField`` function. In ISO SQL, it may not be. In 
-ODBC, the value might also be ``2`` (``SQL_NULLABLE_UNKNOWN``). 
+This field is ``1`` (true) (``SQL_NULLABLE``) if the value might be ``NULL``;
+otherwise it's ``0`` (false) (``SQL_NO_NULLS``). For a populated IPD,
+``SQL_DESC_NULLABLE`` is ``1``. In ANSI SQL, ``SQL_DESC_NULLABLE`` may be
+changed with the ``SQLSetDescField`` function. In ISO SQL, it may not be. In
+ODBC, the value might also be ``2`` (``SQL_NULLABLE_UNKNOWN``).
 
 +-----+----------------------------------+--------------------------------+
 |     | May be Gotten by ...             | May be Set by ...              |
@@ -750,19 +752,19 @@ ODBC, the value might also be ``2`` (``SQL_NULLABLE_UNKNOWN``).
 
 **Type:** ``INTEGER``. **Importance:** Medium.
 
-For any character string, bit string or ``BLOB`` <data type>, this is the 
-item's maximum length in octets. 
+For any character string, bit string or ``BLOB`` <data type>, this is the
+item's maximum length in octets.
 
-This field matters for "output": if a ``CHAR`` Column is fetched, the number of 
-octets transferred will be ``<= SQL_DESC_OCTET_LENGTH``. For example, if you 
-intend to fetch into a C host variable defined as ``"char[20]"``, then you 
-should set ``ARD.IDA[n].SQL_DESC_OCTET_LENGTH = 20``. For "input" 
-(``SQL_PARAM_MODE_IN`` parameters), ``SQL_DESC_OCTET_LENGTH`` is not relevant. 
-When the DBMS inputs parameters, it uses the length pointed to by the 
-``SQL_DESC_OCTET_LENGTH_POINTER`` field. 
+This field matters for "output": if a ``CHAR`` Column is fetched, the number of
+octets transferred will be ``<= SQL_DESC_OCTET_LENGTH``. For example, if you
+intend to fetch into a C host variable defined as ``"char[20]"``, then you
+should set ``ARD.IDA[n].SQL_DESC_OCTET_LENGTH = 20``. For "input"
+(``SQL_PARAM_MODE_IN`` parameters), ``SQL_DESC_OCTET_LENGTH`` is not relevant.
+When the DBMS inputs parameters, it uses the length pointed to by the
+``SQL_DESC_OCTET_LENGTH_POINTER`` field.
 
-Despite some contradictions in other documents, we believe that datetime or 
-interval transfers are not affected by the value in this field. 
+Despite some contradictions in other documents, we believe that datetime or
+interval transfers are not affected by the value in this field.
 
 +-----+-----------------------------------+-----------------------------------------------+
 |     | May be Gotten by ...              | May be Set by ...                             |
@@ -784,23 +786,23 @@ interval transfers are not affected by the value in this field.
 
 **Data type:** ``POINTER TO INTEGER``. **Importance:** Medium.
 
-This field provides the address of a length in octets. Its initial value is 
-``0`` (ARD/APD). For ``VARCHAR`` or ``BIT VARYING`` or ``BLOB`` <data type>s, 
-this length is the actual length, which may be less than the defined length. 
-For other character string and bit string <data type>s, the actual and maximum 
-lengths are the same because size is fixed. The size of the ``\0`` terminator 
-is not included in the octet length. For other <data type>s, the value is 
-implementation-defined. 
+This field provides the address of a length in octets. Its initial value is
+``0`` (ARD/APD). For ``VARCHAR`` or ``BIT VARYING`` or ``BLOB`` <data type>s,
+this length is the actual length, which may be less than the defined length.
+For other character string and bit string <data type>s, the actual and maximum
+lengths are the same because size is fixed. The size of the ``\0`` terminator
+is not included in the octet length. For other <data type>s, the value is
+implementation-defined.
 
-This field and the ``SQL_DESC_INDICATOR_POINTER`` field may point to the same 
-place. In ISO SQL, ``IPD.IDA[n].SQL_DESC_LENGTH`` may be changed with the 
-``SQLSetDescField`` function. In ANSI SQL, it may not be. In ODBC, the name is 
-``SQL_DESC_OCTET_LENGTH_PTR``. 
+This field and the ``SQL_DESC_INDICATOR_POINTER`` field may point to the same
+place. In ISO SQL, ``IPD.IDA[n].SQL_DESC_LENGTH`` may be changed with the
+``SQLSetDescField`` function. In ANSI SQL, it may not be. In ODBC, the name is
+``SQL_DESC_OCTET_LENGTH_PTR``.
 
-[Obscure Rule] The rules change if ``SQL_DESC_OCTET_LENGTH_POINTER`` and 
-``SQL_DESC_INDICATOR_POINTER`` contain the same address value (this is actually 
-imprecise: the rules don't really change, but octet length is always set after 
-indicator, and we stop if indicator ``== SQL_NULL_DATA``). 
+[Obscure Rule] The rules change if ``SQL_DESC_OCTET_LENGTH_POINTER`` and
+``SQL_DESC_INDICATOR_POINTER`` contain the same address value (this is actually
+imprecise: the rules don't really change, but octet length is always set after
+indicator, and we stop if indicator ``== SQL_NULL_DATA``).
 
 If they're separate:
 
@@ -842,10 +844,10 @@ If they're the same:
     On Input:
       *SQL_DESC_INDICATOR_POINTER may be 0,-1,SQL_NTS,SQL_DATA_AT_EXEC, or length.
 
-The rules are a little confusing, but that's the price we have to pay for 
-backward compatibility -- some of the older CLI functions allow for only one 
-pointer variable which serves for both "indicator" and "string length" 
-information. 
+The rules are a little confusing, but that's the price we have to pay for
+backward compatibility -- some of the older CLI functions allow for only one
+pointer variable which serves for both "indicator" and "string length"
+information.
 
 +-----+-------------------------------+--------------------------------------------+
 |     | May be Gotten by ...          | May be Set by ...                          |
@@ -868,18 +870,18 @@ information.
 
 **Data type:** ``SMALLINT``. **Importance:** Low.
 
-This field is in SQL3 only; it's not in ODBC. Its possible values are: ``1`` 
-(``SQL_PARAM_MODE_IN``), ``2`` (``SQL_PARAM_MODE_INOUT``) and ``4`` 
-(``SQL_PARAM_MODE_OUT``). If the "populate IPD" flag is true, and the SQL 
-statement is ``"CALL ..."``, and the first parameter of the called routine is 
-input, the DBMS sets ``IPD.IDA[1].SQL_DESC_PARAMETER_MODE=1``. 
+This field is in SQL3 only; it's not in ODBC. Its possible values are: ``1``
+(``SQL_PARAM_MODE_IN``), ``2`` (``SQL_PARAM_MODE_INOUT``) and ``4``
+(``SQL_PARAM_MODE_OUT``). If the "populate IPD" flag is true, and the SQL
+statement is ``"CALL ..."``, and the first parameter of the called routine is
+input, the DBMS sets ``IPD.IDA[1].SQL_DESC_PARAMETER_MODE=1``.
 
-In ANSI SQL, users may only change this field in the IPD (with the 
-``SQLSetDescField`` function). In ISO SQL, users may change this field in the 
-IPD, the APD and the ARD. In ODBC, a field named 
-``IPD.IDA[n].SQL_DESC_PARAMETER_TYPE`` can be set to ``SQL_PARAM_MODE_IN``, 
-``SQL_PARAM_MODE_INOUT`` or ``SQL_PARAM_MODE_OUT``. The default value is 
-``SQL_PARAM_MODE_INPUT``. 
+In ANSI SQL, users may only change this field in the IPD (with the
+``SQLSetDescField`` function). In ISO SQL, users may change this field in the
+IPD, the APD and the ARD. In ODBC, a field named
+``IPD.IDA[n].SQL_DESC_PARAMETER_TYPE`` can be set to ``SQL_PARAM_MODE_IN``,
+``SQL_PARAM_MODE_INOUT`` or ``SQL_PARAM_MODE_OUT``. The default value is
+``SQL_PARAM_MODE_INPUT``.
 
 +-----+-----------------------+-------------------------------+
 |     | May be Gotten by ...  | May be Set by ...             |
@@ -900,15 +902,15 @@ IPD, the APD and the ARD. In ODBC, a field named
 
 **Type:** ``SMALLINT``. **Importance:** Low.
 
-This field is in SQL3 only; it's not in ODBC. It provides an ordinal number, 
-for SQL routine parameters. If this item corresponds to the first parameter in 
-an SQL ``"CALL ..."`` statement, the DBMS sets 
-``IPD.IDA[n].SQL_DESC_PARAMETER_ORDINAL_POSITION=1``. ``SQLPrepare`` sets IPD 
-if "populate IPD" is true. 
+This field is in SQL3 only; it's not in ODBC. It provides an ordinal number,
+for SQL routine parameters. If this item corresponds to the first parameter in
+an SQL ``"CALL ..."`` statement, the DBMS sets
+``IPD.IDA[n].SQL_DESC_PARAMETER_ORDINAL_POSITION=1``. ``SQLPrepare`` sets IPD
+if "populate IPD" is true.
 
-In ANSI SQL, users may only change this field in the IPD (with the 
-``SQLSetDescField`` function). In ISO SQL, users may change this field in the 
-IPD, the APD and the ARD. 
+In ANSI SQL, users may only change this field in the IPD (with the
+``SQLSetDescField`` function). In ISO SQL, users may change this field in the
+IPD, the APD and the ARD.
 
 +-----+----------------------+-------------------------------+
 |     | May be Gotten by ... | May be Set by ...             |
@@ -943,13 +945,13 @@ ________________
 
 **Type:** ``VARCHAR``. **Importance:** Low.
 
-These three fields are SQL3 fields only; they're not in ODBC. Together, they 
-make up the qualified name of a parameter in an SQL ``"CALL ..."`` statement. 
-``SQLPrepare`` sets IPD if "populate IPD" is true. 
+These three fields are SQL3 fields only; they're not in ODBC. Together, they
+make up the qualified name of a parameter in an SQL ``"CALL ..."`` statement.
+``SQLPrepare`` sets IPD if "populate IPD" is true.
 
-In ANSI SQL, users may only change these fields in the IPD (with the 
-``SQLSetDescField`` function). In ISO SQL, users may change these fields in the 
-IPD, the APD and the ARD. 
+In ANSI SQL, users may only change these fields in the IPD (with the
+``SQLSetDescField`` function). In ISO SQL, users may change these fields in the
+IPD, the APD and the ARD.
 
 +-----+----------------------+-------------------------------+
 |     | May be Gotten by ... | May be Set by ...             |
@@ -970,15 +972,15 @@ IPD, the APD and the ARD.
 
 **Type:** ``SMALLINT``. **Importance:** Medium.
 
-For all numeric <data type>s, this is a precision -- that is, for ``DECIMAL`` 
-and ``NUMERIC``, it's the number of digits both before and after the decimal 
-point; for ``INTEGER`` and ``SMALLINT``, it's the fixed implementation-defined 
-number of decimal or binary digits; for ``REAL``, ``FLOAT`` and ``DOUBLE 
-PRECISION``, it's the number of bits or digits in the mantissa. For all 
-temporal <data type>s, this is the fractional seconds precision -- that is, the 
-number of digits after the decimal point in the ``SECOND`` datetime component. 
-The default value in each case is what you'd get if you used the <data type> 
-with its default value in a ``CREATE TABLE`` statement. 
+For all numeric <data type>s, this is a precision -- that is, for ``DECIMAL``
+and ``NUMERIC``, it's the number of digits both before and after the decimal
+point; for ``INTEGER`` and ``SMALLINT``, it's the fixed implementation-defined
+number of decimal or binary digits; for ``REAL``, ``FLOAT`` and ``DOUBLE
+PRECISION``, it's the number of bits or digits in the mantissa. For all
+temporal <data type>s, this is the fractional seconds precision -- that is, the
+number of digits after the decimal point in the ``SECOND`` datetime component.
+The default value in each case is what you'd get if you used the <data type>
+with its default value in a ``CREATE TABLE`` statement.
 
 +-----+----------------------------------------+-----------------------------------------------+
 |     | May be Gotten by ...                   | May be Set by ...                             |
@@ -1030,7 +1032,7 @@ the field on all other occasions. For all other <data type>s, the value of
 
 **Type:** ``SMALLINT``. **Importance:** High.
 
-This field provides the item's <data type>. Its possible values are: 
+This field provides the item's <data type>. Its possible values are:
 
 +--------+--------------------+--------+-----------------------------+
 | ``1``  | ``(SQL_CHAR)``     | ``15`` | ``(SQL_BIT_VARYING)``       |
@@ -1060,7 +1062,7 @@ This field provides the item's <data type>. Its possible values are:
 | ``14`` | ``(SQL_BIT)``      | ``51`` | ``(SQL_ARRAY_LOCATOR)``     |
 +--------+--------------------+--------+-----------------------------+
 
-For datetime and interval items, the subtype is in the 
+For datetime and interval items, the subtype is in the
 ``SQL_DESC_DATETIME_INTERVAL_CODE`` field.
 
 You may set ``ARD.IDA[n].SQL_DESC_TYPE = SQL_C_DEFAULT``. By setting ``SQL_DESC_TYPE``
@@ -1126,26 +1128,26 @@ make up the qualified name of the item's user-defined type, if it has one.
 
 **Type:** ``SMALLINT``. **Importance:** Low.
 
-This field has two possible values: ``1`` (true) (``SQL_UNNAMED``) or ``0`` 
+This field has two possible values: ``1`` (true) (``SQL_UNNAMED``) or ``0``
 (false) (``SQL_NAMED``).
 
-In the IRD: if the select list contains an initially-unnamed Column, then the 
-DBMS makes up a name, returns the made-up name to the ``SQL_DESC_NAME`` field 
-and sets the ``SQL_DESC_UNNAMED`` field to ``SQL_UNNAMED``. For example, after: 
+In the IRD: if the select list contains an initially-unnamed Column, then the
+DBMS makes up a name, returns the made-up name to the ``SQL_DESC_NAME`` field
+and sets the ``SQL_DESC_UNNAMED`` field to ``SQL_UNNAMED``. For example, after:
 
 ::
 
    SQLPrepare(hstmt,"SELECT 5+1 FROM Table_1",SQL_NTS);
 
-the DBMS might set ``IRD.IDA[n].SQL_DESC_NAME = "expr1"`` (this is the value an 
-Access clone would give), and then set ``IRD.IDA[n].SQL_DESC_UNNAMED = 1`` 
-(``SQL_UNNAMED``). 
+the DBMS might set ``IRD.IDA[n].SQL_DESC_NAME = "expr1"`` (this is the value an
+Access clone would give), and then set ``IRD.IDA[n].SQL_DESC_UNNAMED = 1``
+(``SQL_UNNAMED``).
 
-In the IPD: if "auto-populate" happens, then the DBMS sets 
-``IPD.IDA[n].SQL_DESC_UNNAMED = 1`` (``SQL_UNNAMED``). 
+In the IPD: if "auto-populate" happens, then the DBMS sets
+``IPD.IDA[n].SQL_DESC_UNNAMED = 1`` (``SQL_UNNAMED``).
 
-In ANSI SQL, users may change this field (with the ``SQLSetDescField`` 
-function). In ISO SQL, they may not. 
+In ANSI SQL, users may change this field (with the ``SQLSetDescField``
+function). In ISO SQL, they may not.
 
 +-----+----------------------+-------------------------------+
 |     | May be Gotten by ... | May be Set by ...             |
@@ -1162,13 +1164,13 @@ function). In ISO SQL, they may not.
 The desc Functions
 ==================
 
-We are now ready to describe the individual ``desc`` functions. There is a good 
-deal of redundancy here, because several functions are available which do the 
-same thing. If you're a beginner, we suggest that you pay particular attention 
-to ``SQLSetDescField`` and ``SQLGetDescField``, because it is possible to do 
-nearly everything with those two low-level functions alone. 
+We are now ready to describe the individual ``desc`` functions. There is a good
+deal of redundancy here, because several functions are available which do the
+same thing. If you're a beginner, we suggest that you pay particular attention
+to ``SQLSetDescField`` and ``SQLGetDescField``, because it is possible to do
+nearly everything with those two low-level functions alone.
 
-There are 14 ``desc`` functions. Their descriptions follow. 
+There are 14 ``desc`` functions. Their descriptions follow.
 
 *SQLAllocHandle(SQL_HANDLE_DESC,...)*
 -------------------------------------
@@ -1183,7 +1185,7 @@ There are 14 ``desc`` functions. Their descriptions follow.
     SQLINTEGER *OutputHandle    /* 32-bit output, a hdesc */
     );
 
-**Job:** Allocate a user ``desc``. (Note: User ``desc``\s are unimportant. We 
+**Job:** Allocate a user ``desc``. (Note: User ``desc``\s are unimportant. We
 start off with this function for symmetry reasons.)
 
 **Algorithm:**
@@ -1211,29 +1213,29 @@ start off with this function for symmetry reasons.)
 
 **Notes:**
 
-* In early prototypes of the CLI there were separate calls for different 
-  resource types (see ``SQLAllocEnv``, ``SQLAllocConnect``, ``SQLAllocStmt``). 
-  Eventually people realized that the number of handle types might grow 
-  indefinitely, so ``SQLAllocHandle`` was defined as a generalized "allocate 
-  handle" function for all current and future resource types. 
+* In early prototypes of the CLI there were separate calls for different
+  resource types (see ``SQLAllocEnv``, ``SQLAllocConnect``, ``SQLAllocStmt``).
+  Eventually people realized that the number of handle types might grow
+  indefinitely, so ``SQLAllocHandle`` was defined as a generalized "allocate
+  handle" function for all current and future resource types.
 
-* Call this function after you have allocated a ``dbc`` and after you have 
-  connected, since the ``InputHandle`` parameter is a ``hdbc``. 
+* Call this function after you have allocated a ``dbc`` and after you have
+  connected, since the ``InputHandle`` parameter is a ``hdbc``.
 
-* This function is only for user ``desc``\s. There are two kinds of ``desc``\s: 
-  automatic ``desc``\s and user ``desc``\s. The DBMS implicitly sets up 4 
-  automatic ``desc``\s (ARD, APD, IRD, IPD) when 
-  ``SQLAllocHandle(SQL_HANDLE_STMT,...)`` is called, and associates them with 
-  the ``stmt``. You explicitly set up user ``desc``\s with 
-  ``SQLAllocHandle(SQL_HANDLE_DESC,...)``, and they are associated with the 
-  ``dbc``. 
+* This function is only for user ``desc``\s. There are two kinds of ``desc``\s:
+  automatic ``desc``\s and user ``desc``\s. The DBMS implicitly sets up 4
+  automatic ``desc``\s (ARD, APD, IRD, IPD) when
+  ``SQLAllocHandle(SQL_HANDLE_STMT,...)`` is called, and associates them with
+  the ``stmt``. You explicitly set up user ``desc``\s with
+  ``SQLAllocHandle(SQL_HANDLE_DESC,...)``, and they are associated with the
+  ``dbc``.
 
-* Using another function (``SQLSetStmtAttr``), you can replace one of the 
-  automatic ``desc``\s with a user ``desc``. Such ``desc``\s can be shared 
-  among multiple ``stmt``\s. 
+* Using another function (``SQLSetStmtAttr``), you can replace one of the
+  automatic ``desc``\s with a user ``desc``. Such ``desc``\s can be shared
+  among multiple ``stmt``\s.
 
-* Using another function (``SQLCopyDescRec``), you can save the contents of an 
-  automatic ``desc`` in a user ``desc``, for backup purposes. 
+* Using another function (``SQLCopyDescRec``), you can save the contents of an
+  automatic ``desc`` in a user ``desc``, for backup purposes.
 
 **Example:**
 
@@ -1248,7 +1250,7 @@ start off with this function for symmetry reasons.)
  ...
  SQLAllocHandle(SQL_HANDLE_DESC,hdbc,&hdesc);
 
-**ODBC:** The ``SQLAllocHandle`` function is new in ODBC 3.5; in ODBC 2.0 the 
+**ODBC:** The ``SQLAllocHandle`` function is new in ODBC 3.5; in ODBC 2.0 the
 ``desc`` resource could not be explicitly allocated.
 
 *SQLFreeHandle(SQL_HANDLE_DESC,...)*
@@ -1263,10 +1265,10 @@ start off with this function for symmetry reasons.)
     SQLINTEGER Handle         /* 32-bit input, must be a hdesc */
     );
 
-**Job:** Destroy a user ``desc``. (Remember that the ``SQLFreeHandle`` function 
-can be used to destroy any resource: an ``env``, a ``dbc``, a ``stmt`` or a 
-``desc``. We are treating the four variants as four separate functions. In this 
-section, our sole concern is ``desc``.) 
+**Job:** Destroy a user ``desc``. (Remember that the ``SQLFreeHandle`` function
+can be used to destroy any resource: an ``env``, a ``dbc``, a ``stmt`` or a
+``desc``. We are treating the four variants as four separate functions. In this
+section, our sole concern is ``desc``.)
 
 **Algorithm:**
 
@@ -1299,16 +1301,16 @@ section, our sole concern is ``desc``.)
 
 **Notes:**
 
-* If ``SQLFreeHandle`` returns ``SQL_ERROR``, then the handle is still live and 
-  you can get diagnostics. 
+* If ``SQLFreeHandle`` returns ``SQL_ERROR``, then the handle is still live and
+  you can get diagnostics.
 
-* This function is the reverse of the ``SQLAllocHandle(SQL_HANDLE_DESC,...)`` 
-  function. Only user ``desc``\s are destructible with 
-  ``SQLFreeHandle(SQL_HANDLE_DESC,...)``. 
+* This function is the reverse of the ``SQLAllocHandle(SQL_HANDLE_DESC,...)``
+  function. Only user ``desc``\s are destructible with
+  ``SQLFreeHandle(SQL_HANDLE_DESC,...)``.
 
-* The ``SQLDisconnect`` function will automatically destroy all ``desc``\s 
-  which are associated with a ``dbc``. So technically you don't need to call 
-  ``SQLFreeHandle(SQL_HANDLE_DESC...)`` if you are about to disconnect. 
+* The ``SQLDisconnect`` function will automatically destroy all ``desc``\s
+  which are associated with a ``dbc``. So technically you don't need to call
+  ``SQLFreeHandle(SQL_HANDLE_DESC...)`` if you are about to disconnect.
 
 **Example:**
 
@@ -1377,25 +1379,25 @@ section, our sole concern is ``desc``.)
 
 **Notes:**
 
-* ``SQLGetDescField`` is a fundamental ``desc`` routine. There are several 
-  other routines which are, conceptually, wrappers for one or more 
-  ``SQLGetDescField`` calls. For example, the ``SQLColAttribute`` function will 
-  implicitly call ``SQLGetDescField`` after finding the IRD; ``SQLGetDescRec`` 
-  will retrieve seven ``desc`` fields at once (name, type, subtype, length, 
-  precision, scale and nullable). 
+* ``SQLGetDescField`` is a fundamental ``desc`` routine. There are several
+  other routines which are, conceptually, wrappers for one or more
+  ``SQLGetDescField`` calls. For example, the ``SQLColAttribute`` function will
+  implicitly call ``SQLGetDescField`` after finding the IRD; ``SQLGetDescRec``
+  will retrieve seven ``desc`` fields at once (name, type, subtype, length,
+  precision, scale and nullable).
 
-* In our descriptions of the ``desc`` fields, the included charts of functions 
-  that affect the field use the word "user" to identify those cases where 
-  ``SQLGetDescField`` may be called to retrieve a single value after explicitly 
-  passing the field's numeric identifier. 
+* In our descriptions of the ``desc`` fields, the included charts of functions
+  that affect the field use the word "user" to identify those cases where
+  ``SQLGetDescField`` may be called to retrieve a single value after explicitly
+  passing the field's numeric identifier.
 
-* The first ``SQLGetDescField`` parameter is a ``hdesc``. To get this handle, 
-  save the handle when you call ``SQLAllocHandle`` (if it's a user ``desc``) 
-  and call ``SQLGetStmtAttr`` (if it's an automatic ``desc``). 
+* The first ``SQLGetDescField`` parameter is a ``hdesc``. To get this handle,
+  save the handle when you call ``SQLAllocHandle`` (if it's a user ``desc``)
+  and call ``SQLGetStmtAttr`` (if it's an automatic ``desc``).
 
-* The second parameter -- ``FieldIdentifier`` -- is unnecessary for a header 
-  field. For an IDA, it's an index to the multiple-occurrence structure and 
-  should contain a value between 1 and "count". 
+* The second parameter -- ``FieldIdentifier`` -- is unnecessary for a header
+  field. For an IDA, it's an index to the multiple-occurrence structure and
+  should contain a value between 1 and "count".
 
 **Example:** Assume you have just called:
 
@@ -1403,7 +1405,7 @@ section, our sole concern is ``desc``.)
 
    SQLExecDirect(hstmt,"SELECT * FROM Table_1",SQL_NTS);
 
-Since ``SQLExecDirect`` implies a ``SQLPrepare`` phase, the DBMS has filled in 
+Since ``SQLExecDirect`` implies a ``SQLPrepare`` phase, the DBMS has filled in
 some of the IRD fields, as follows:
 
 ::
@@ -1426,18 +1428,18 @@ some of the IRD fields, as follows:
     -
     ---------------------------------------------------------------------------
 
-For space reasons, we've shown only a few fields in this diagram. But there's 
-enough to make it clear that: *(a)* the DBMS found three Columns in the result 
-set (as indicated by ``SQL_DESC_COUNT == 3``), *(b)* the first Column is named 
-``COL_1``, its <data type> is ``NUMERIC`` (as indicated by ``SQL_DESC_TYPE == 
-2``) and its precision is ``5``, *(c)* the second Column is named ``COL_2``, 
-its <data type> is ``DECIMAL`` (as indicated by ``SQL_DESC_TYPE == 3``) and its 
-precision is ``4``, and *(d)* the third Column is named ``COL_3``, its <data 
-type> is ``CHAR`` (as indicated by ``SQL_DESC_TYPE == 1``) and its precision is 
-unset because ``CHAR`` Columns have no precision (they have a length instead). 
+For space reasons, we've shown only a few fields in this diagram. But there's
+enough to make it clear that: *(a)* the DBMS found three Columns in the result
+set (as indicated by ``SQL_DESC_COUNT == 3``), *(b)* the first Column is named
+``COL_1``, its <data type> is ``NUMERIC`` (as indicated by ``SQL_DESC_TYPE ==
+2``) and its precision is ``5``, *(c)* the second Column is named ``COL_2``,
+its <data type> is ``DECIMAL`` (as indicated by ``SQL_DESC_TYPE == 3``) and its
+precision is ``4``, and *(d)* the third Column is named ``COL_3``, its <data
+type> is ``CHAR`` (as indicated by ``SQL_DESC_TYPE == 1``) and its precision is
+unset because ``CHAR`` Columns have no precision (they have a length instead).
 
-Here are some ``SQLGetDescField`` calls -- and what will be put into the 
-``Value`` variable: 
+Here are some ``SQLGetDescField`` calls -- and what will be put into the
+``Value`` variable:
 
 ::
 
@@ -1457,7 +1459,7 @@ Here are some ``SQLGetDescField`` calls -- and what will be put into the
 
 -- gets ``4``
 
-And here is a larger code snippet, which finds out the ``hdesc`` value (a 
+And here is a larger code snippet, which finds out the ``hdesc`` value (a
 necessary preliminary!), then displays the name of every Column in ``TABLE_1``:
 
 ::
@@ -1478,11 +1480,11 @@ necessary preliminary!), then displays the name of every Column in ``TABLE_1``:
        printf("%s\n",col_name); }
      ...
 
-**ODBC:** The ``SQLGetDescField`` function is new in ODBC 3.5. There are some 
-implementation-defined additional fields. The expected behaviour is somewhat 
-different if you ask for a field which has no defined value: a 
-standard-conformant DBMS would return ``SQL_ERROR``, an ODBC-conformant DBMS 
-would return ``SQL_SUCCESS`` and an undefined value. 
+**ODBC:** The ``SQLGetDescField`` function is new in ODBC 3.5. There are some
+implementation-defined additional fields. The expected behaviour is somewhat
+different if you ask for a field which has no defined value: a
+standard-conformant DBMS would return ``SQL_ERROR``, an ODBC-conformant DBMS
+would return ``SQL_SUCCESS`` and an undefined value.
 
 *SQLSetDescField*
 -----------------
@@ -1574,35 +1576,35 @@ would return ``SQL_SUCCESS`` and an undefined value.
 
 **Notes:**
 
-* Sometimes ``Value`` is a pointer; sometimes it's an integer; sometimes it's 
+* Sometimes ``Value`` is a pointer; sometimes it's an integer; sometimes it's
   a smallint; depending on ``FieldIdentifier``.
 
 * If you must change multiple fields in one IDA, do them in this order:
-  
+
    * Change the ``SQL_DESC_TYPE field`` first.
-   
+
    * Change the ``SQL_DESC_DATETIME_INTERVAL_CODE`` field second.
-   
+
    * Change the other fields (except for ``SQL_DESC_DATA_POINTER``) in any order.
-   
+
    * Change the ``SQL_DESC_DATA_POINTER`` field last.
-  
+
   If you don't set fields in this order, you'll get errors. It's deliberate.
 
 * If an error happens, the value of the field may be changed anyway.
 
-* If you change a header field, you should pass ``RecordNumber = 0`` (otherwise, 
+* If you change a header field, you should pass ``RecordNumber = 0`` (otherwise,
   in theory, you could inadvertently changed the ``SQL_DESC_COUNT`` field).
 
-* The <data type> of ``Value`` should correspond to the <data type> of the 
-  field being changed. For example, if changing the ``SQL_DESC_SCALE`` field, 
-  ``Value`` should contain a ``SMALLINT`` value. For a list of the <data type> 
-  correspondences between the SQL predefined <data type>s and host variables, 
-  see our chapter on embedded SQL. Because there are some differences between 
-  embedded SQL and the SQL/CLI, here is a concise summary for the SQL/C <data 
-  type> correspondences, with some adjustments and notes that are specific to 
-  SQL/CLI: 
-  
+* The <data type> of ``Value`` should correspond to the <data type> of the
+  field being changed. For example, if changing the ``SQL_DESC_SCALE`` field,
+  ``Value`` should contain a ``SMALLINT`` value. For a list of the <data type>
+  correspondences between the SQL predefined <data type>s and host variables,
+  see our chapter on embedded SQL. Because there are some differences between
+  embedded SQL and the SQL/CLI, here is a concise summary for the SQL/C <data
+  type> correspondences, with some adjustments and notes that are specific to
+  SQL/CLI:
+
   +----------------------------+-----------------------+----------------------------------------+
   | SQL                        | C                     | Notes                                  |
   +============================+=======================+========================================+
@@ -1654,23 +1656,23 @@ would return ``SQL_SUCCESS`` and an undefined value.
   +----------------------------+-----------------------+----------------------------------------+
   | ``UDT LOCATOR``            | ``long``              |                                        |
   +----------------------------+-----------------------+----------------------------------------+
-  
-  Note: The symbol "-" means there is no official correspondence according to 
-  the   Standard, but some DBMSs will try to do an implicit cast. 
-  
-  Note: In a similar list for Delphi, we would find that SQL's ``REAL`` 
-  corresponds to Delphi's ``Float`` (not Delphi's ``Real``), and that SQL's 
-  ``CHAR`` corresponds to Delphi's ``Pchar`` (not Delphi's packed array of 
-  char). 
 
-* The ``SQLSetDescField`` function can only set one field at a time. Therefore, 
-  it is a "fundamental" function. There are other functions which can be used 
-  to change multiple fields (``SQLSetDescRec``, ``SQLBindParameter`` and 
-  ``SQLBindCol``). 
+  Note: The symbol "-" means there is no official correspondence according to
+  the   Standard, but some DBMSs will try to do an implicit cast.
 
-* Default Values -- A change to ``SQL_DESC_TYPE`` will cause other IDA fields 
-  to be reset to their "default values". This chart shows what the changes are. 
-  Any fields not shown are reset to implementation-dependent values. 
+  Note: In a similar list for Delphi, we would find that SQL's ``REAL``
+  corresponds to Delphi's ``Float`` (not Delphi's ``Real``), and that SQL's
+  ``CHAR`` corresponds to Delphi's ``Pchar`` (not Delphi's packed array of
+  char).
+
+* The ``SQLSetDescField`` function can only set one field at a time. Therefore,
+  it is a "fundamental" function. There are other functions which can be used
+  to change multiple fields (``SQLSetDescRec``, ``SQLBindParameter`` and
+  ``SQLBindCol``).
+
+* Default Values -- A change to ``SQL_DESC_TYPE`` will cause other IDA fields
+  to be reset to their "default values". This chart shows what the changes are.
+  Any fields not shown are reset to implementation-dependent values.
 
   +-------------------------------------------------+-------------------------------------------------+
   | If ``SQL_DESC_TYPE`` is changed to ...          | ... Then these fields change too                |
@@ -1690,106 +1692,106 @@ would return ``SQL_SUCCESS`` and an undefined value.
   | ``SQL_FLOAT``                                   | ``SQL_PRECISION: default precision [Note 2]``   |
   +-------------------------------------------------+-------------------------------------------------+
 
-  ``[Note 1]`` The "maximum length" is not the usual default value for a 
+  ``[Note 1]`` The "maximum length" is not the usual default value for a
   ``CHAR`` <data type>. If you say ``CREATE TABLE Table_1 (col_1 CHAR);``, the
-  default length is ``1``. That is why, in ODBC, if you set ``SQL_DESC_TYPE`` 
-  to ``SQL_CHAR``, the ``SQL_LENGTH`` field changes to ``1``. But in standard 
-  SQL, it becomes a character string <data type>'s "maximum possible length", 
+  default length is ``1``. That is why, in ODBC, if you set ``SQL_DESC_TYPE``
+  to ``SQL_CHAR``, the ``SQL_LENGTH`` field changes to ``1``. But in standard
+  SQL, it becomes a character string <data type>'s "maximum possible length",
   which is an implementation-defined size.
 
-  ``[Note 2]`` The "default precision" of ``SQL_DECIMAL``, ``SQL_NUMERIC`` and 
+  ``[Note 2]`` The "default precision" of ``SQL_DECIMAL``, ``SQL_NUMERIC`` and
   ``SQL_FLOAT`` <data type>s is implementation-defined.
 
-* The Standard has omitted mention of all other <data type>s in relation to 
-  ``SQLSetDescField``, and ends with a note that says an error will be returned 
-  for any type not shown in the chart. In effect, this means that all <data 
-  types> other than ``SQL_CHAR``, ``SQL_VARCHAR``, ``SQL_CLOB``, ``SQL_BIT``, 
-  ``SQL_BIT_VARYING``, ``SQL_BLOB``, ``SQL_DATETIME``, ``SQL_INTERVAL``, 
-  ``SQL_DECIMAL``, ``SQL_NUMERIC`` and ``SQL_FLOAT`` are technically illegal 
-  here. The wise programmer will assume that these matters will be resolved by 
-  the DBMS vendor -- not being able to use ``SQL_INTEGER``, for example, seems 
-  too severe a restriction to be followed. 
+* The Standard has omitted mention of all other <data type>s in relation to
+  ``SQLSetDescField``, and ends with a note that says an error will be returned
+  for any type not shown in the chart. In effect, this means that all <data
+  types> other than ``SQL_CHAR``, ``SQL_VARCHAR``, ``SQL_CLOB``, ``SQL_BIT``,
+  ``SQL_BIT_VARYING``, ``SQL_BLOB``, ``SQL_DATETIME``, ``SQL_INTERVAL``,
+  ``SQL_DECIMAL``, ``SQL_NUMERIC`` and ``SQL_FLOAT`` are technically illegal
+  here. The wise programmer will assume that these matters will be resolved by
+  the DBMS vendor -- not being able to use ``SQL_INTEGER``, for example, seems
+  too severe a restriction to be followed.
 
-* Consistency check -- While you're changing descriptor fields, you might cause 
-  temporary inconstancy. Here's how: 
+* Consistency check -- While you're changing descriptor fields, you might cause
+  temporary inconstancy. Here's how:
 
-   * [Step 1] You change ``SQL_DESC_TYPE`` to ``SQL_DECIMAL``. Changing the 
-     <data type> triggers a wholesale resetting of all other IDA fields to 
-     default values. For example, the ``SQL_DESC_PRECISION`` field becomes 
-     ``1`` (an implementation-defined default), the ``SQL_DESC_SCALE`` field 
+   * [Step 1] You change ``SQL_DESC_TYPE`` to ``SQL_DECIMAL``. Changing the
+     <data type> triggers a wholesale resetting of all other IDA fields to
+     default values. For example, the ``SQL_DESC_PRECISION`` field becomes
+     ``1`` (an implementation-defined default), the ``SQL_DESC_SCALE`` field
      becomes ``0`` and the ``SQL_DESC_DATA_POINTER`` becomes a null pointer.
 
-   * [Step 2] You change ``SQL_DESC_SCALE`` to ``5``. Now the scale is greater 
-     than the precision. That is inconsistent -- a ``DECIMAL(1,5)`` definition 
+   * [Step 2] You change ``SQL_DESC_SCALE`` to ``5``. Now the scale is greater
+     than the precision. That is inconsistent -- a ``DECIMAL(1,5)`` definition
      is illegal. But don't worry -- the DBMS won't reject your change.
 
-   * [Step 3] You change ``SQL_DESC_PRECISION`` to ``6``. Now the fields are 
+   * [Step 3] You change ``SQL_DESC_PRECISION`` to ``6``. Now the fields are
      consistent again.
 
-   * [Step 4] You change ``SQL_DESC_DATA_POINTER`` to a host-variable address. 
-     Changing the data pointer triggers a consistency check. The rationale 
-     for delaying the consistency check until you change the data pointer is 
-     that temporary inconsistencies are inevitable if you change one field at a 
-     time, but don't matter as long as the data pointer is a null pointer. When 
-     you set the data pointer, you "bind the Column" to the host variable. At 
-     that point the DBMS cannot allow any further inconsistency. If you've read 
-     our chapters about the various SQL predefined <data type>s, you'll find 
-     that the consistency check is merely an enforcement of the rules you 
-     already know. And there are no \**GOTCHAs because the DBMS only checks 
-     what's relevant. It looks for these things: 
+   * [Step 4] You change ``SQL_DESC_DATA_POINTER`` to a host-variable address.
+     Changing the data pointer triggers a consistency check. The rationale
+     for delaying the consistency check until you change the data pointer is
+     that temporary inconsistencies are inevitable if you change one field at a
+     time, but don't matter as long as the data pointer is a null pointer. When
+     you set the data pointer, you "bind the Column" to the host variable. At
+     that point the DBMS cannot allow any further inconsistency. If you've read
+     our chapters about the various SQL predefined <data type>s, you'll find
+     that the consistency check is merely an enforcement of the rules you
+     already know. And there are no \**GOTCHAs because the DBMS only checks
+     what's relevant. It looks for these things:
 
-      * ``SQL_DESC_PRECISION``, ``SQL_DESC_SCALE``, ``SQL_DESC_LENGTH``, 
-        ``SQL_DESC_DESC_DATETIME_INTERVAL_CODE`` and 
-        ``SQL_DESC_DATETIME_INTERVAL_PRECISION`` must be valid if it's possible 
-        to specify precision, scale, length and/or specific datetime or 
-        interval leading-field precision when you're defining a Column of the 
-        given <data type>. For example, ``FLOAT(precision)`` is legal in 
-        definitions, therefore ``SQL_DESC_PRECISION`` must have a valid value 
-        if ``SQL_DESC_TYPE = SQL_FLOAT``. On the other hand, precision is not 
-        specifiable for ``REAL`` Columns, so there is no check of 
-        ``SQL_DESC_PRECISION`` if ``SQL_DESC_TYPE = SQL_REAL``. If 
-        ``SQL_DESC_TYPE`` is ``NUMERIC`` or ``DECIMAL``, then scale and 
-        precision must be valid for the <data type> (e.g. scale cannot be 
-        greater than precision). (Warning: this description is of the SQL 
-        Standard "Consistency Check" definition. The ODBC "Consistency Check" 
-        is more picky.) 
+      * ``SQL_DESC_PRECISION``, ``SQL_DESC_SCALE``, ``SQL_DESC_LENGTH``,
+        ``SQL_DESC_DESC_DATETIME_INTERVAL_CODE`` and
+        ``SQL_DESC_DATETIME_INTERVAL_PRECISION`` must be valid if it's possible
+        to specify precision, scale, length and/or specific datetime or
+        interval leading-field precision when you're defining a Column of the
+        given <data type>. For example, ``FLOAT(precision)`` is legal in
+        definitions, therefore ``SQL_DESC_PRECISION`` must have a valid value
+        if ``SQL_DESC_TYPE = SQL_FLOAT``. On the other hand, precision is not
+        specifiable for ``REAL`` Columns, so there is no check of
+        ``SQL_DESC_PRECISION`` if ``SQL_DESC_TYPE = SQL_REAL``. If
+        ``SQL_DESC_TYPE`` is ``NUMERIC`` or ``DECIMAL``, then scale and
+        precision must be valid for the <data type> (e.g. scale cannot be
+        greater than precision). (Warning: this description is of the SQL
+        Standard "Consistency Check" definition. The ODBC "Consistency Check"
+        is more picky.)
 
-      * For IDAs within application descriptors (ARDs or APDs), 
-        ``SQL_DESC_TYPE`` must be a <data type> that's representable in the 
-        host language. In our charts of <data type> correspondences (see our 
-        chapter on embedded SQL), we showed you that the SQL ``INTEGER`` <data 
-        type> translates directly to a C data type: long. Easy times. Now what 
-        about the ``NUMERIC`` <data type>? Well you'd have to ``CAST`` it to 
-        something that C can handle: either a floating-point or a 
-        character-string. Casting is easy -- just change the <data type> as we 
-        described in each <data type> chapter. 
+      * For IDAs within application descriptors (ARDs or APDs),
+        ``SQL_DESC_TYPE`` must be a <data type> that's representable in the
+        host language. In our charts of <data type> correspondences (see our
+        chapter on embedded SQL), we showed you that the SQL ``INTEGER`` <data
+        type> translates directly to a C data type: long. Easy times. Now what
+        about the ``NUMERIC`` <data type>? Well you'd have to ``CAST`` it to
+        something that C can handle: either a floating-point or a
+        character-string. Casting is easy -- just change the <data type> as we
+        described in each <data type> chapter.
 
-      * If the DBMS detects an inconsistency during execution of 
-        ``SQLSetDescField`` or ``SQLSetDescRec``, the ``SQLSTATE`` error return 
-        is ``HY021 "CLI-specific condition-inconsistent descriptor 
-        information."`` 
-        
+      * If the DBMS detects an inconsistency during execution of
+        ``SQLSetDescField`` or ``SQLSetDescRec``, the ``SQLSTATE`` error return
+        is ``HY021 "CLI-specific condition-inconsistent descriptor
+        information."``
+
         .. TIP::
-        
-            Even though you never need an ``SQL_DESC_DATA_POINTER`` value in an 
-            IPD IDA, set it anyway. That will force a consistency check. It's 
-            better to check for inconsistency in advance, rather than waiting for 
-            the consistency error to happen when you try to execute the 
-            statement. 
 
-* The DBMS may also detect inconsistency during execution of 
-  ``SQLBindParameter`` or ``SQLBindCol``, but usually there is a final 
-  Consistency Check during ``SQLExecute``. If the DBMS detects an inconsistency 
-  during execution of ``SQLExecute``, the ``SQLSTATE`` error return is either 
-  ``07001 "Dynamic SQL error-using clause does not match dynamic parameters."`` 
-  or ``07002 "Dynamic SQL error-using clause does not match target 
-  specifications."`` (There appears to be an error in the Standard; this is 
-  what we believe is the intended meaning.) 
+            Even though you never need an ``SQL_DESC_DATA_POINTER`` value in an
+            IPD IDA, set it anyway. That will force a consistency check. It's
+            better to check for inconsistency in advance, rather than waiting for
+            the consistency error to happen when you try to execute the
+            statement.
 
-**Example:** You have an SQL statement which uses an integer input parameter. 
-You want to tell the DBMS about it, by setting certain fields of the APD. 
-Assume that the "auto-populate IPD" flag is off, so you'll have to set some 
-fields in the IPD too. Here's how. 
+* The DBMS may also detect inconsistency during execution of
+  ``SQLBindParameter`` or ``SQLBindCol``, but usually there is a final
+  Consistency Check during ``SQLExecute``. If the DBMS detects an inconsistency
+  during execution of ``SQLExecute``, the ``SQLSTATE`` error return is either
+  ``07001 "Dynamic SQL error-using clause does not match dynamic parameters."``
+  or ``07002 "Dynamic SQL error-using clause does not match target
+  specifications."`` (There appears to be an error in the Standard; this is
+  what we believe is the intended meaning.)
+
+**Example:** You have an SQL statement which uses an integer input parameter.
+You want to tell the DBMS about it, by setting certain fields of the APD.
+Assume that the "auto-populate IPD" flag is off, so you'll have to set some
+fields in the IPD too. Here's how.
 
 ::
 
@@ -1826,7 +1828,7 @@ Here is a picture of the APD after the ``SQLSetDescField`` calls are done:
     -  1-&input_variable     | 00004         | ........ |
     - ----------------------------------------------------
 
-We will revisit "parameter passing" again after discussing the ``SQLBindCol`` 
+We will revisit "parameter passing" again after discussing the ``SQLBindCol``
 function.
 
 *SQLGetDescRec*
@@ -1850,7 +1852,7 @@ function.
        SQLSMALLINT *Nullable           /* 16-bit output */
        );
 
-**Job:** Retrieve the values of several fields from one Item Descriptor Area of 
+**Job:** Retrieve the values of several fields from one Item Descriptor Area of
 a ``desc``.
 
 **Algorithm:**
@@ -1879,30 +1881,30 @@ a ``desc``.
 
 **Notes:**
 
-* In effect, calling ``SQLGetDescRec`` is equivalent to calling 
-  ``SQLGetDescField`` several times, with different field identifiers: 
-  ``SQL_DESC_NAME``, ``SQL_DESC_TYPE``, ``SQL_DESC_DATETIME_INTERVAL_CODE``, 
-  ``SQL_DESC_OCTET_LENGTH``, ``SQL_DESC_PRECISION``, ``SQL_DESC_SCALE`` and 
-  ``SCALE_NULLABLE``. 
+* In effect, calling ``SQLGetDescRec`` is equivalent to calling
+  ``SQLGetDescField`` several times, with different field identifiers:
+  ``SQL_DESC_NAME``, ``SQL_DESC_TYPE``, ``SQL_DESC_DATETIME_INTERVAL_CODE``,
+  ``SQL_DESC_OCTET_LENGTH``, ``SQL_DESC_PRECISION``, ``SQL_DESC_SCALE`` and
+  ``SCALE_NULLABLE``.
 
-* Regarding the value of ``*Length``, what the Standard actually says is that 
-  it should be set to "the length (in octets or positions, as appropriate)" ... 
-  which is ambiguous. We have taken the ODBC specification as our guide here -- 
-  it says ``*Length`` should be set to ``SQL_DESC_OCTET_LENGTH``. Probably you 
-  should use another function if the setting of Length is important to you. 
+* Regarding the value of ``*Length``, what the Standard actually says is that
+  it should be set to "the length (in octets or positions, as appropriate)" ...
+  which is ambiguous. We have taken the ODBC specification as our guide here --
+  it says ``*Length`` should be set to ``SQL_DESC_OCTET_LENGTH``. Probably you
+  should use another function if the setting of Length is important to you.
 
-* For fields which are "not applicable", pass null parameters. For example, the 
-  ``SQL_DESC_NAME`` field is usually meaningless within an ARD or an APD. So, 
-  for ``*Name``, ``BufferLength`` and ``*Namelength``, pass null if you're 
-  retrieving from an ARD or APD. By passing null pointers, you can limit the 
-  values you get, to fill only the fields you really want. 
+* For fields which are "not applicable", pass null parameters. For example, the
+  ``SQL_DESC_NAME`` field is usually meaningless within an ARD or an APD. So,
+  for ``*Name``, ``BufferLength`` and ``*Namelength``, pass null if you're
+  retrieving from an ARD or APD. By passing null pointers, you can limit the
+  values you get, to fill only the fields you really want.
 
-* ``SQLGetDescRec``\'s ``BufferLength`` parameter is defined as ``SMALLINT`` 
-  (16-bit). ``SQLGetDescField``\'s ``BufferLength`` parameter in defined as 
-  ``INTEGER`` (32-bit). However, the apparent inconsistency causes no problems: 
-  the length of a Name string is typically only a few octets. 
+* ``SQLGetDescRec``\'s ``BufferLength`` parameter is defined as ``SMALLINT``
+  (16-bit). ``SQLGetDescField``\'s ``BufferLength`` parameter in defined as
+  ``INTEGER`` (32-bit). However, the apparent inconsistency causes no problems:
+  the length of a Name string is typically only a few octets.
 
-**Example:** The following code snippet is an exact copy of the example used 
+**Example:** The following code snippet is an exact copy of the example used
 for the ``SQLGetDescField`` function, with only one line changed:
 
 ::
@@ -1930,12 +1932,12 @@ is replaced by a call to ``SQLGetDescRec`` which gets only the name.
        printf("%s\n",col_name); }
      ...
 
-**ODBC:** The ``SQLGetDescRec`` function is new in ODBC 3.5. (In ODBC 2.0 the 
-``desc`` fields were always retrieved via other functions, such as 
-``SQLDescribeCol``.) ``SQLGetDescRec`` is apparently short for "Get Descriptor 
-Record". "Descriptor record" is ODBC jargon; "Item Descriptor Area" (IDA) is 
-the standard term. The fact that the name is ``SQLGetDescRec``, rather than 
-``SQLGetIDA``, illustrates the influence of ODBC over the Standard. 
+**ODBC:** The ``SQLGetDescRec`` function is new in ODBC 3.5. (In ODBC 2.0 the
+``desc`` fields were always retrieved via other functions, such as
+``SQLDescribeCol``.) ``SQLGetDescRec`` is apparently short for "Get Descriptor
+Record". "Descriptor record" is ODBC jargon; "Item Descriptor Area" (IDA) is
+the standard term. The fact that the name is ``SQLGetDescRec``, rather than
+``SQLGetIDA``, illustrates the influence of ODBC over the Standard.
 
 *SQLSetDescRec*
 ---------------
@@ -1957,7 +1959,7 @@ the standard term. The fact that the name is ``SQLGetDescRec``, rather than
    SQLINTEGER *Indicator      /* 32-bit output */
    );
 
-**Job:** Set the values for several fields in one Item Descriptor Area of a 
+**Job:** Set the values for several fields in one Item Descriptor Area of a
 ``desc``.
 
 **Algorithm:**
@@ -1996,36 +1998,36 @@ the standard term. The fact that the name is ``SQLGetDescRec``, rather than
 
 **Notes:**
 
-* In effect, calling ``SQLSetDescRec`` is equivalent to calling 
-  ``SQLSetDescField`` several times, with different field identifiers: 
-  ``SQL_DESC_TYPE``, ``SQL_DESC_PRECISION``, ``SQL_DESC_SCALE``, 
-  ``SQL_DESC_DATETIME_INTERVAL_CODE``, ``SQL_DESC_LENGTH`` or 
-  ``SQL_DESC_OCTET_LENGTH``, ``SQL_DESC_OCTET_LENGTH_POINTER``, 
-  ``SQL_DESC_DATA_POINTER`` and ``SQL_DESC_DATA_POINTER``. 
+* In effect, calling ``SQLSetDescRec`` is equivalent to calling
+  ``SQLSetDescField`` several times, with different field identifiers:
+  ``SQL_DESC_TYPE``, ``SQL_DESC_PRECISION``, ``SQL_DESC_SCALE``,
+  ``SQL_DESC_DATETIME_INTERVAL_CODE``, ``SQL_DESC_LENGTH`` or
+  ``SQL_DESC_OCTET_LENGTH``, ``SQL_DESC_OCTET_LENGTH_POINTER``,
+  ``SQL_DESC_DATA_POINTER`` and ``SQL_DESC_DATA_POINTER``.
 
-* Using ``SQLSetDescRec`` on an ARD is somewhat similar to using ``SQLBindCol`` 
-  on the ``stmt`` which contains the ARD. 
+* Using ``SQLSetDescRec`` on an ARD is somewhat similar to using ``SQLBindCol``
+  on the ``stmt`` which contains the ARD.
 
-* Using ``SQLSetDescRec`` on an APD is somewhat similar to using 
-  ``SQLBindParameter`` on the ``stmt`` which contains the APD. 
+* Using ``SQLSetDescRec`` on an APD is somewhat similar to using
+  ``SQLBindParameter`` on the ``stmt`` which contains the APD.
 
-* The parameters of ``SQLGetDescRec`` do not correspond to the parameters of 
-  ``SQLGetDescRec``. For example, there is no way to set the ``SQL_DESC_NAME`` 
-  field. 
+* The parameters of ``SQLGetDescRec`` do not correspond to the parameters of
+  ``SQLGetDescRec``. For example, there is no way to set the ``SQL_DESC_NAME``
+  field.
 
-* Because of the peculiar algorithm logic, it is impossible to set 
-  ``SQL_DESC_OCTET_LENGTH_POINTER`` or ``SQL_DESC_INDICATOR_POINTER`` to null 
-  values. 
+* Because of the peculiar algorithm logic, it is impossible to set
+  ``SQL_DESC_OCTET_LENGTH_POINTER`` or ``SQL_DESC_INDICATOR_POINTER`` to null
+  values.
 
-* A Consistency Check always happens. Therefore, if there are other fields that 
-  you want to set, you should call ``SQLSetDescField`` before you call 
-  ``SQLSetDescRec``. 
+* A Consistency Check always happens. Therefore, if there are other fields that
+  you want to set, you should call ``SQLSetDescField`` before you call
+  ``SQLSetDescRec``.
 
-**Example:** This is an efficient way to execute an SQL statement many times, 
-varying only the input parameter (represented in the statement by "?"). The 
-code will insert 50 rows, with values between ``1`` and ``50``. We have 
-deliberately varied some names and parameter-declarations, to show a style 
-preferred by other programmers. 
+**Example:** This is an efficient way to execute an SQL statement many times,
+varying only the input parameter (represented in the statement by "?"). The
+code will insert 50 rows, with values between ``1`` and ``50``. We have
+deliberately varied some names and parameter-declarations, to show a style
+preferred by other programmers.
 
 ::
 
@@ -2055,16 +2057,16 @@ preferred by other programmers.
 
 .. WARNING::
 
-   This code is "efficient" because it calls ``SQLPrepare`` and the 
-   ``SQLSetDescRec`` functions only once, for an SQL statement that is executed 
-   50 times. Usually, taking code out of loops is the right thing to do. But 
-   for at least one DBMS, it's better to bind ``i`` (as a deferred parameter) 
+   This code is "efficient" because it calls ``SQLPrepare`` and the
+   ``SQLSetDescRec`` functions only once, for an SQL statement that is executed
+   50 times. Usually, taking code out of loops is the right thing to do. But
+   for at least one DBMS, it's better to bind ``i`` (as a deferred parameter)
    after the call to ``SQLExecute``.
 
-**ODBC:** ``SQLSetDescRec`` is new in ODBC 3.0. You can set 
-``SQL_DESC_OCTET_LENGTH_POINTER`` or ``SQL_DESC_INDICATOR_POINTER`` to null, by 
-passing null pointers in the ``StringLength`` or ``Indicator`` parameters. In 
-standard SQL, the DBMS ignores null pointers in those parameters. 
+**ODBC:** ``SQLSetDescRec`` is new in ODBC 3.0. You can set
+``SQL_DESC_OCTET_LENGTH_POINTER`` or ``SQL_DESC_INDICATOR_POINTER`` to null, by
+passing null pointers in the ``StringLength`` or ``Indicator`` parameters. In
+standard SQL, the DBMS ignores null pointers in those parameters.
 
 *SQLCopyDesc*
 -------------
@@ -2104,77 +2106,77 @@ standard SQL, the DBMS ignores null pointers in those parameters.
 
 **Notes:**
 
-* There are other ways to copy an entire ``desc``. For example, you could call 
-  the ``SQLGetDescField`` and ``SQLSetDescField`` functions repeatedly. But 
-  ``SQLCopyDesc`` is the easy way. 
+* There are other ways to copy an entire ``desc``. For example, you could call
+  the ``SQLGetDescField`` and ``SQLSetDescField`` functions repeatedly. But
+  ``SQLCopyDesc`` is the easy way.
 
-* If you're thinking of copying ``stmt`` #1's APD to ``stmt`` #2's APD, there's 
-  an alternative: you can allocate a user ``desc`` and share it. Here's how: 
-  
+* If you're thinking of copying ``stmt`` #1's APD to ``stmt`` #2's APD, there's
+  an alternative: you can allocate a user ``desc`` and share it. Here's how:
+
    * Make a user ``desc``:
-     
+
      ::
-     
+
         SQLAllocHandle(SQL_HANDLE_DESC,hdbc,&hdesc_user);
-   
+
    * Say that ``stmt`` #1's APD is the user ``desc``:
-     
+
      ::
-     
+
         SQLSetStmtAttr(hstmt1,SQL_ATTR_APP_ROW_DESC,&hdesc_user,NULL);
-     
+
    * Fill in the fields of ``stmt`` #1's APD (using ``SQLSetDescRec`` etc.)
-   
+
    * Say that ``stmt`` #2's APD is the user ``desc``:
-     
+
      ::
-     
+
         SQLSetStmtAttr(hstmt2,SQL_ATTR_APP_ROW_DESC,&hdesc_user,NULL);
-     
-     Now there's no need to copy, because ``stmt`` #2's APD is ``stmt`` #1's 
+
+     Now there's no need to copy, because ``stmt`` #2's APD is ``stmt`` #1's
      APD.
 
-* One possible use of ``SQLCopyDesc`` is to copy an IRD to an ARD. The point 
-  is: the IRD and the IRD fields are supposed to be similar; the IRD is set up 
-  automatically; so after the copy the ARD will have the values that the DBMS 
-  thinks should be there. If you want to change these values slightly, you can 
-  fine-tune using ``SQLSetDescField``. 
+* One possible use of ``SQLCopyDesc`` is to copy an IRD to an ARD. The point
+  is: the IRD and the IRD fields are supposed to be similar; the IRD is set up
+  automatically; so after the copy the ARD will have the values that the DBMS
+  thinks should be there. If you want to change these values slightly, you can
+  fine-tune using ``SQLSetDescField``.
 
-* Another possible use of ``SQLCopyDesc`` is to save ``desc`` information -- 
-  if, for example, you have a small number of queries that are executed 
-  repeatedly using the same ``stmt``. Here's how: 
-  
+* Another possible use of ``SQLCopyDesc`` is to save ``desc`` information --
+  if, for example, you have a small number of queries that are executed
+  repeatedly using the same ``stmt``. Here's how:
+
    * Allocate a user descriptor with
-     
+
      ::
-     
+
         SQLAllocHandle(SQL_HANDLE_DESC,...).
-   
+
    * Copy an automatic ``desc`` to the user ``desc``, with ``SQLCopyDesc``.
-   
+
    * Change the automatic ``desc`` for some temporary purpose.
-   
-   * Copy the user ``desc`` back to the automatic ``desc``, with 
-     ``SQLCopyDesc``. This is like "pushing" all the ``desc`` fields to a 
+
+   * Copy the user ``desc`` back to the automatic ``desc``, with
+     ``SQLCopyDesc``. This is like "pushing" all the ``desc`` fields to a
      stack, making changes, then "popping" to restore the original values.
 
-Some DBMSs will perform a consistency check on the target ``desc``\'s IDAs if 
-any ``target_desc.IDA[n].SQL_DESC_DATA_POINTER`` is not a null pointer. 
+Some DBMSs will perform a consistency check on the target ``desc``\'s IDAs if
+any ``target_desc.IDA[n].SQL_DESC_DATA_POINTER`` is not a null pointer.
 
-The copy is possible even if the source and target ``desc``\s are in 
-different connections. 
+The copy is possible even if the source and target ``desc``\s are in
+different connections.
 
-**Example:** This shows how to copy values from one Table to another. The trick 
+**Example:** This shows how to copy values from one Table to another. The trick
 works like this:
 
-* Step 1: Prepare a ``SELECT`` statement from the source Table. This yields the 
-  IRD of the source. Bind the result set with ``SQLSetDescRec``. This yields 
-  the ARD of the source. 
+* Step 1: Prepare a ``SELECT`` statement from the source Table. This yields the
+  IRD of the source. Bind the result set with ``SQLSetDescRec``. This yields
+  the ARD of the source.
 
-* Step 2: Prepare an ``INSERT`` statement on the target Table. This yields the 
-  IPD of the target. 
+* Step 2: Prepare an ``INSERT`` statement on the target Table. This yields the
+  IPD of the target.
 
-* Step 3: Copy the source RDs to the target PDs. 
+* Step 3: Copy the source RDs to the target PDs.
 
 The trick would work for any pair of Tables, provided Columns have compatible
 <data type>s.
@@ -2218,8 +2220,8 @@ The trick would work for any pair of Tables, provided Columns have compatible
      SQLCloseCursor(hstmt_source);
      ...
 
-**ODBC:** The ``SQLCopyDesc`` function arrived with ODBC 3.0. ODBC's Driver 
-Manager will handle copying if the source and target handles are associated 
+**ODBC:** The ``SQLCopyDesc`` function arrived with ODBC 3.0. ODBC's Driver
+Manager will handle copying if the source and target handles are associated
 with different drivers.
 
 *SQLBindCol*
@@ -2269,51 +2271,51 @@ with different drivers.
 
 **Notes:**
 
-* Technically, a host variable is "bound" when it is associated with a 
-  host-variable address. Since ``SQLBindCol`` causes a setting of 
-  ``ARD.IDA[ColumnNumber].SQL_DESC_DATA_POINTER``, we can describe it thus: 
-  "``SQLBindCol`` performs a binding of an output host variable for a 
-  result-set Column; specifically the result-set Column indicated by the 
-  ``ColumnNumber`` parameter." 
+* Technically, a host variable is "bound" when it is associated with a
+  host-variable address. Since ``SQLBindCol`` causes a setting of
+  ``ARD.IDA[ColumnNumber].SQL_DESC_DATA_POINTER``, we can describe it thus:
+  "``SQLBindCol`` performs a binding of an output host variable for a
+  result-set Column; specifically the result-set Column indicated by the
+  ``ColumnNumber`` parameter."
 
-* Technically, this host variable is called a "target specification". 
-  ``SQLBindCol`` is for values that flow out from the DBMS to a host variable. 
+* Technically, this host variable is called a "target specification".
+  ``SQLBindCol`` is for values that flow out from the DBMS to a host variable.
 
-* The usual idea is that what you set up with ``SQLBindCol`` will later be used 
-  by ``SQLFetch`` or ``SQLFetchScroll``. Alternatively, you could bind after 
-  fetching, using the ``SQLGetData`` function. 
+* The usual idea is that what you set up with ``SQLBindCol`` will later be used
+  by ``SQLFetch`` or ``SQLFetchScroll``. Alternatively, you could bind after
+  fetching, using the ``SQLGetData`` function.
 
-* You need a valid ``hstmt``, but you don't need a result set yet. That is, you 
-  can ``SELECT`` either before or after you call ``SQLBindCol``. 
+* You need a valid ``hstmt``, but you don't need a result set yet. That is, you
+  can ``SELECT`` either before or after you call ``SQLBindCol``.
 
-* Calling ``SQLBindCol`` for a ``stmt`` is conceptually similar to calling 
-  ``SQLSetDescRec`` for the ``stmt``\'s ARD. In fact, everything that you can 
-  do with ``SQLBindCol``, and more, can be done with ``SQLSetDescRec``. 
-  However, ``SQLBindCol`` is seen far more often than ``SQLSetDescRec``. 
-  
+* Calling ``SQLBindCol`` for a ``stmt`` is conceptually similar to calling
+  ``SQLSetDescRec`` for the ``stmt``\'s ARD. In fact, everything that you can
+  do with ``SQLBindCol``, and more, can be done with ``SQLSetDescRec``.
+  However, ``SQLBindCol`` is seen far more often than ``SQLSetDescRec``.
+
   .. WARNING::
-  
+
     You are passing addresses. The DBMS will write to those
     addresses. So there are two easy ways to cause GPFs:
-    
+
     * Pass the address of a local variable, exit from the procedure
       that the local variable is defined in, then call ``SQLFetch``.
-    
-    * Pass a buffer which is too small to hold the result. For ``CHAR`` and 
-      ``BIT`` <data type>s there is a guard against this (you pass 
-      ``BufferLength`` to tell the DBMS when it must stop). For numeric <data 
-      type>s there is also a guard against this (if you say that ``BufferType`` 
-      is ``SQL_SMALLINT`` the DBMS won't move a 32-bit value to it). But if you 
-      enter the wrong value for ``DataType`` ... Ka-Boom! As a safeguard, some 
-      programmers deliberately "unbind" when they finish fetching -- see the 
-      description of ``SQLFreeStmt(...SQL_UNBIND)``. 
 
-* ``SQLBindCol`` does not set every defined field in the ARD. You might have to 
-  follow up with a call to ``SQLSetDescField`` if for some reason you have to 
-  change a low-importance field, like ``SQL_DESC_DATETIME_INTERVAL_PRECISION``. 
+    * Pass a buffer which is too small to hold the result. For ``CHAR`` and
+      ``BIT`` <data type>s there is a guard against this (you pass
+      ``BufferLength`` to tell the DBMS when it must stop). For numeric <data
+      type>s there is also a guard against this (if you say that ``BufferType``
+      is ``SQL_SMALLINT`` the DBMS won't move a 32-bit value to it). But if you
+      enter the wrong value for ``DataType`` ... Ka-Boom! As a safeguard, some
+      programmers deliberately "unbind" when they finish fetching -- see the
+      description of ``SQLFreeStmt(...SQL_UNBIND)``.
 
-* The value of ``BufferLength`` is irrelevant for non-string <data type>s. 
-  Nevertheless, you must always pass a value greater than zero. 
+* ``SQLBindCol`` does not set every defined field in the ARD. You might have to
+  follow up with a call to ``SQLSetDescField`` if for some reason you have to
+  change a low-importance field, like ``SQL_DESC_DATETIME_INTERVAL_PRECISION``.
+
+* The value of ``BufferLength`` is irrelevant for non-string <data type>s.
+  Nevertheless, you must always pass a value greater than zero.
 
 **Example:**
 
@@ -2330,7 +2332,7 @@ with different drivers.
      SQLFetch(hstmt);
      /* At this point, value has "ABCDE\0", value_indicator has zero. */
      ...
-     
+
      /* This example shows a retrieval of a floating-point variable. The C data
     type is float, but we use SQL_REAL -- for explanation, see the list of data
     correspondences. We'd like to pass NULL as the BufferLength parameter -- it's
@@ -2346,7 +2348,7 @@ with different drivers.
      SQLFetch(hstmt);
      /* At this point, value has 1.5E5, value_indicator has zero. */
      ...
-     
+
      /* This example shows a retrieval of two Columns from the first row of
     TABLE_1. It displays their values, or displays "NULL". */
      #include "sqlcli.h"
@@ -2402,35 +2404,35 @@ Here is a picture of the IRD after the ``SQLExecDirect`` call is done:
     -  2-'Col_2'          | 00001         | ........ |
     -----------------------------------------------------
 
-[Obscure Rule] In this example, ``COL_1`` is actually a ``SMALLINT`` 
-(``SQL_DESC_TYPE == 5``), but it's being transferred to an ``INTEGER`` 
-(``SQL_DESC_TYPE == 4``). That is not a problem -- the DBMS will automatically 
-"``CAST`` (<smallint Column value> ``TO INTEGER``)". In fact, the DBMS will 
-automatically cast from the IRD type to the ARD type. If the cast is 
-syntactically impossible, an ``SQLSTATE`` error appears: ``07006 "Dynamic SQL 
-error-restricted data type attribute violation."`` 
+[Obscure Rule] In this example, ``COL_1`` is actually a ``SMALLINT``
+(``SQL_DESC_TYPE == 5``), but it's being transferred to an ``INTEGER``
+(``SQL_DESC_TYPE == 4``). That is not a problem -- the DBMS will automatically
+"``CAST`` (<smallint Column value> ``TO INTEGER``)". In fact, the DBMS will
+automatically cast from the IRD type to the ARD type. If the cast is
+syntactically impossible, an ``SQLSTATE`` error appears: ``07006 "Dynamic SQL
+error-restricted data type attribute violation."``
 
-**ODBC:** ``SQLBindCol`` always triggers a consistency check. The value of 
-``BufferLength`` must be ``>= 0`` (standard SQL says the value of 
-``BufferLength`` must be ``> 0``). The difference looks trivial, but the 
-majority of ODBC application programs would collapse tomorrow if a DBMS vendor 
-decided to enforce the standard SQL rule. 
+**ODBC:** ``SQLBindCol`` always triggers a consistency check. The value of
+``BufferLength`` must be ``>= 0`` (standard SQL says the value of
+``BufferLength`` must be ``> 0``). The difference looks trivial, but the
+majority of ODBC application programs would collapse tomorrow if a DBMS vendor
+decided to enforce the standard SQL rule.
 
 SQL_C_DEFAULT
 _____________
 
-There is a lazy way to bind numbers. Instead of passing a real <data type>, 
-pass ``99`` (``SQL_C_DEFAULT``). Here is an example using ``SQLBindCol`` -- 
-notice that the third parameter is ``SQL_C_DEFAULT``, so, after ``SQLBindCol``, 
-the value in ``ARD.IDA[n].SQL_DESC_TYPE == SQL_C_DEFAULT``. When ``SQLFetch`` 
-occurs, it handles the default request like this: 
+There is a lazy way to bind numbers. Instead of passing a real <data type>,
+pass ``99`` (``SQL_C_DEFAULT``). Here is an example using ``SQLBindCol`` --
+notice that the third parameter is ``SQL_C_DEFAULT``, so, after ``SQLBindCol``,
+the value in ``ARD.IDA[n].SQL_DESC_TYPE == SQL_C_DEFAULT``. When ``SQLFetch``
+occurs, it handles the default request like this:
 
 * Set ``ARD.IDA[n].SQL_DESC_TYPE = IRD.IDA[n].SQL_DESC_TYPE``.
 
 * Set ``ARD.IDA[n].SQL_DESC_PRECISION = IRD.IDA[n].SQL_DESC_PRECISION``.
 
-* Set ``ARD.IDA[n].SQL_DESC_SCALE = IRD.IDA[n].SQL_DESC_SCALE``. (These are 
-  temporary settings. ``SQLFetch`` never makes permanent changes to any 
+* Set ``ARD.IDA[n].SQL_DESC_SCALE = IRD.IDA[n].SQL_DESC_SCALE``. (These are
+  temporary settings. ``SQLFetch`` never makes permanent changes to any
   ``desc`` fields.) Now there is enough information to continue the fetch:
 
 ::
@@ -2445,21 +2447,21 @@ occurs, it handles the default request like this:
 
 And now, a few words of urgent warning:
 
-* The only fields involved are type, precision and  scale -- not length or 
+* The only fields involved are type, precision and  scale -- not length or
   octet_length.
 
 * There is no check for possible overflow of the target output.
 
-* The ODBC specification does not agree with the Standard about what the 
+* The ODBC specification does not agree with the Standard about what the
   default <data type> codes should be.
 
 Retrieving Column Values
 ________________________
 
-Column retrieval involves executing a ``SELECT`` statement, then fetching from 
-the result set to variables defined in your host program. The Columns in the 
-select list must be "bound" to the host-variable addresses. The problems you 
-must solve -- with the DBMS's help -- are: 
+Column retrieval involves executing a ``SELECT`` statement, then fetching from
+the result set to variables defined in your host program. The Columns in the
+select list must be "bound" to the host-variable addresses. The problems you
+must solve -- with the DBMS's help -- are:
 
 * The impedance mismatch between SQL <data type>s and host language types.
 
@@ -2471,24 +2473,24 @@ must solve -- with the DBMS's help -- are:
 
 There are two solutions to these problems:
 
-1. Call ``SQLBindCol``, ``SQLSetDescField`` or ``SQLSetDescRec``, then fetch 
+1. Call ``SQLBindCol``, ``SQLSetDescField`` or ``SQLSetDescRec``, then fetch
    using ``SQLFetch`` or ``SQLFetchScroll``.
 
 2. Fetch using ``SQLFetch`` or ``SQLFetchScroll``, then call ``SQLGetData``.
 
 The most popular option is to call ``SQLBindCol``, then ``SQLFetch``.
 
-There are two ``desc``\s involved here -- the IRD (which the DBMS sets up when 
-the ``SELECT`` statement is executed), and the ARD (which the host program sets 
-up at any time before the fetch). The programmer's job, then, can be seen as 
-making sure that the ARD matches the IRD, and setting up appropriate buffers 
-for the DBMS to fetch data into. 
+There are two ``desc``\s involved here -- the IRD (which the DBMS sets up when
+the ``SELECT`` statement is executed), and the ARD (which the host program sets
+up at any time before the fetch). The programmer's job, then, can be seen as
+making sure that the ARD matches the IRD, and setting up appropriate buffers
+for the DBMS to fetch data into.
 
 Fetch Loops Revisited
 _____________________
 
 Once more into the "fetch", dear friends! Now that you know about binding, you
-can fetch ``INTO`` something. Here is a program which does so. Most functions 
+can fetch ``INTO`` something. Here is a program which does so. Most functions
 are shown in skeletal form. There is a test for truncation.
 
 ::
@@ -2544,7 +2546,7 @@ are shown in skeletal form. There is a test for truncation.
        SQLINTEGER *StrLen_or_Ind  /* 32-bit output */
        );
 
-**Job:** Get a value from one Column of a result set. Call ``SQLGetData`` after 
+**Job:** Get a value from one Column of a result set. Call ``SQLGetData`` after
 calling ``SQLFetch`` or ``SQLFetchScroll``.
 
 **Algorithm:**
@@ -2576,56 +2578,56 @@ calling ``SQLFetch`` or ``SQLFetchScroll``.
 
 **Notes:**
 
-* ``SQLGetData`` does not make permanent changes to the ARD. But it can be 
-  thought of as a function which makes a temporary binding for a specified 
-  Column in a result set, and transferring the Column value to the bound target 
-  variable. 
+* ``SQLGetData`` does not make permanent changes to the ARD. But it can be
+  thought of as a function which makes a temporary binding for a specified
+  Column in a result set, and transferring the Column value to the bound target
+  variable.
 
-* It looks like there are two possible strategies for retrieving data -- with 
-  ``SQLBindCol`` or with ``SQLGetData``. Let's compare the two: 
-  
+* It looks like there are two possible strategies for retrieving data -- with
+  ``SQLBindCol`` or with ``SQLGetData``. Let's compare the two:
+
   The ``SQLBindCol`` strategy:
-  
+
   ::
-  
+
     SQLExecDirect(...,"SELECT ...",...);
      SQLBindCol(...,1,&var_1,...);
      SQLBindCol(...,2,&var_2,...);
      for (;;) {
       if (SQLFetch(...)==100) break; }
       SQLGetData(...,2,...,&var_2,...); }
-  
+
   The ``SQLGetData`` strategy:
-  
+
   ::
-  
+
     SQLExecDirect(...,"SELECT ...",...);
     for (;;) {
        if (SQLFetch(...)==100) break;
        SQLGetData(...,1,...,&var_1,...);
-  
-  Look hard at where the loop is. The ``SQLBindCol`` strategy is apparently 
-  more efficient, because the binding happens only once. If you use 
-  ``SQLGetData``, you'll have to use it for every iteration of the ``SQLFetch`` 
-  loop. On the other hand, maybe that's exactly what you want to do. There are 
-  times when you have to be flexible, and change some factor (such as the 
-  variable's address) while inside the loop. Then ``SQLGetData`` is the choice. 
 
-* Suppose you bind Column #1 (using ``SQLBindCol``), then you fetch, then you 
-  get Column #2 (using ``SQLGetData``). That's legal. But it might not be legal 
-  to skip Columns, to get Columns out of order or to get Columns twice. The 
-  ability to get Columns in any order is called the "``SQLGetData`` Extensions" 
-  feature. You can check whether your DBMS supports it (you'll see how when we 
-  describe the ``SQLGetInfo`` function). But usually there's nothing difficult 
-  about getting Columns in ascending Column-number order. 
+  Look hard at where the loop is. The ``SQLBindCol`` strategy is apparently
+  more efficient, because the binding happens only once. If you use
+  ``SQLGetData``, you'll have to use it for every iteration of the ``SQLFetch``
+  loop. On the other hand, maybe that's exactly what you want to do. There are
+  times when you have to be flexible, and change some factor (such as the
+  variable's address) while inside the loop. Then ``SQLGetData`` is the choice.
 
-* ``*StrLen_or_Ind`` points to a 32-bit integer, not a 16-bit integer. Thus the 
-  final three parameters -- ``*TargetValue``, ``BufferLength``, 
-  ``*StrLen_or_Ind`` -- do not form a typical example of Character String 
-  Retrieval parameters. 
+* Suppose you bind Column #1 (using ``SQLBindCol``), then you fetch, then you
+  get Column #2 (using ``SQLGetData``). That's legal. But it might not be legal
+  to skip Columns, to get Columns out of order or to get Columns twice. The
+  ability to get Columns in any order is called the "``SQLGetData`` Extensions"
+  feature. You can check whether your DBMS supports it (you'll see how when we
+  describe the ``SQLGetInfo`` function). But usually there's nothing difficult
+  about getting Columns in ascending Column-number order.
 
-* Since ``SQLGetData`` cannot take advantage of the full set of ARD fields, it 
-  only gets used for simple situations. 
+* ``*StrLen_or_Ind`` points to a 32-bit integer, not a 16-bit integer. Thus the
+  final three parameters -- ``*TargetValue``, ``BufferLength``,
+  ``*StrLen_or_Ind`` -- do not form a typical example of Character String
+  Retrieval parameters.
+
+* Since ``SQLGetData`` cannot take advantage of the full set of ARD fields, it
+  only gets used for simple situations.
 
 **Example:**
 
@@ -2654,12 +2656,12 @@ calling ``SQLFetch`` or ``SQLFetchScroll``.
      SQLCloseCursor(hstmt);
      ...
 
-**ODBC:** ``SQLGetData`` has been around since ODBC version 1.0. ``SQLGetData`` 
-can be used, with char or bit <data type>s, to get data in pieces. This is done 
-by calling ``SQLGetData`` with ``BufferLength == 1000`` (to ask for the first 
-1000 octets), calling again -- for the same Column number with ``BufferLength 
-== 1000`` (to ask for the next 1000 octets), and so on. In the days of 16-bit 
-operating systems, this was a useful feature. 
+**ODBC:** ``SQLGetData`` has been around since ODBC version 1.0. ``SQLGetData``
+can be used, with char or bit <data type>s, to get data in pieces. This is done
+by calling ``SQLGetData`` with ``BufferLength == 1000`` (to ask for the first
+1000 octets), calling again -- for the same Column number with ``BufferLength
+== 1000`` (to ask for the next 1000 octets), and so on. In the days of 16-bit
+operating systems, this was a useful feature.
 
 *SQLBindParameter*
 ------------------
@@ -2687,50 +2689,50 @@ operating systems, this was a useful feature.
        SQLINTEGER *StrLen_or_Ind        /* DEF */
        );
 
-**Job:** Describe one "dynamic parameter specification" (in the IPD), and its 
-host variable (in the APD). ``SQLBindParameter`` is useful if you pass 
-parameters from the application to the DBMS. Such parameters are marked by 
-parameter markers (question marks) in SQL statements. 
+**Job:** Describe one "dynamic parameter specification" (in the IPD), and its
+host variable (in the APD). ``SQLBindParameter`` is useful if you pass
+parameters from the application to the DBMS. Such parameters are marked by
+parameter markers (question marks) in SQL statements.
 
 **Algorithm:**
 
 The algorithm is to complex to show in the usual manner. For this function, we
 will have to make heavy use of texts and charts. What happens --
 
-* If the function fails and returns ``-1`` (``SQL_ERROR``): see ``07009``, 
-  ``HY015`` and ``HY090`` in our chapter on SQL/CLI diagnostics. (Note: If 
-  errors happen, some of the IPD and APD fields may be garbaged, although 
-  ``SQL_DESC_COUNT`` won't change.) 
+* If the function fails and returns ``-1`` (``SQL_ERROR``): see ``07009``,
+  ``HY015`` and ``HY090`` in our chapter on SQL/CLI diagnostics. (Note: If
+  errors happen, some of the IPD and APD fields may be garbaged, although
+  ``SQL_DESC_COUNT`` won't change.)
 
-* If the function succeeds: some IPD and APD fields are set. The precise 
-  setting depends on a combination of factors, but in general we can say that: 
-  
-   * ``hstmt`` designates which ``stmt``. The affected ``desc``\s are the 
+* If the function succeeds: some IPD and APD fields are set. The precise
+  setting depends on a combination of factors, but in general we can say that:
+
+   * ``hstmt`` designates which ``stmt``. The affected ``desc``\s are the
      ``stmt``\'s IPD and APD.
-   
-   * ``ParameterNumber`` designates which item descriptor area, within a 
-     ``desc``. If ``ParameterNumber`` is ``n``, then the affected IDAs are 
+
+   * ``ParameterNumber`` designates which item descriptor area, within a
+     ``desc``. If ``ParameterNumber`` is ``n``, then the affected IDAs are
      ``IPD.IDA[n]`` and ``APD.IDA[n]``.
-   
-   * ``ParameterType``, ``Columnsize`` and ``DecimalDigits`` affect 
+
+   * ``ParameterType``, ``Columnsize`` and ``DecimalDigits`` affect
      ``IPD.IDA[n]``.
-   
-   * ``ValueType``, ``BufferLength``, ``ParameterValue`` and ``Strlen_Or_Ind`` 
+
+   * ``ValueType``, ``BufferLength``, ``ParameterValue`` and ``Strlen_Or_Ind``
      affect ``APD.IDA[n]``.
-   
-   * If ``ParameterNumber`` is greater than an APD or IPD's ``SQL_DESC_COUNT`` 
-     field, then that ``SQL_DESC_COUNT`` field gets the value in 
+
+   * If ``ParameterNumber`` is greater than an APD or IPD's ``SQL_DESC_COUNT``
+     field, then that ``SQL_DESC_COUNT`` field gets the value in
      ``ParameterNumber``.
-   
+
    * Sometimes passed values are ignored.
-   
-   * Values should be consistent, but some DBMSs won't perform a consistency 
+
+   * Values should be consistent, but some DBMSs won't perform a consistency
      check until ``SQLExecute`` happens.
 
-In the charts which follow, we show the effects on particular APD or IPD 
-fields. Notice that the usual effect is that the field simply receives the 
-value of a parameter that you pass, but that sometimes special calculations are 
-necessary. Particularly complex are "datetime" and "interval" settings. 
+In the charts which follow, we show the effects on particular APD or IPD
+fields. Notice that the usual effect is that the field simply receives the
+value of a parameter that you pass, but that sometimes special calculations are
+necessary. Particularly complex are "datetime" and "interval" settings.
 
 SQLBindParameter effect on APD Fields
 _____________________________________
@@ -2751,16 +2753,16 @@ _____________________________________
 | ``SQL_DESC_OCTET_LENGTH_POINTER`` | ``StrLen_or_Ind (an address)``    |
 +-----------------------------------+-----------------------------------+
 
-For example, if you call ``SQLBindParameter`` with ``ParameterNumber=2``, 
-``InputOutputMode = OUT``, ``ValueType=1`` (the code for ``CHAR`` <data type>), 
-``BufferLength=5``, ``ParameterValue =`` address of ``x_char_buffer`` and 
-``Strlen_Or_Ind =`` address of ``x_char_buffer_indicator``, the result is that, 
-in the ``APD.IDA[2]`` (i.e.: the second item descriptor area in the application 
-parameter ``desc``), the settings are as follows: ``SQL_DESC_PARAMETER_MODE = 
-OUT``, ``SQL_DESC_TYPE = 1``, ``SQL_DESC_OCTET_LENGTH = BufferLength``, 
-``SQL_DESC_DATA_POINTER = x_char_buffer`` address, ``SQL_DESC_INDICATOR_POINTER 
-= x_char_buffer_indicator`` address and ``SQL_DESC_OCTET_LENGTH_POINTER = 
-x_char_buffer_indicator`` address. 
+For example, if you call ``SQLBindParameter`` with ``ParameterNumber=2``,
+``InputOutputMode = OUT``, ``ValueType=1`` (the code for ``CHAR`` <data type>),
+``BufferLength=5``, ``ParameterValue =`` address of ``x_char_buffer`` and
+``Strlen_Or_Ind =`` address of ``x_char_buffer_indicator``, the result is that,
+in the ``APD.IDA[2]`` (i.e.: the second item descriptor area in the application
+parameter ``desc``), the settings are as follows: ``SQL_DESC_PARAMETER_MODE =
+OUT``, ``SQL_DESC_TYPE = 1``, ``SQL_DESC_OCTET_LENGTH = BufferLength``,
+``SQL_DESC_DATA_POINTER = x_char_buffer`` address, ``SQL_DESC_INDICATOR_POINTER
+= x_char_buffer_indicator`` address and ``SQL_DESC_OCTET_LENGTH_POINTER =
+x_char_buffer_indicator`` address.
 
 SQLBindParameter Effect on IPD.IDA Fields for Numeric <data type>s
 __________________________________________________________________
@@ -2775,15 +2777,15 @@ __________________________________________________________________
 | ``SQL_DESC_SCALE``       | ``DecimalDigits``    |
 +--------------------------+----------------------+
 
-This chart shows the effect on ``IPD.IDA[n]`` fields if the value of the passed 
-``ParameterType`` is ``2`` or ``3`` or ``4`` or ``5`` or ``6`` or ``7`` or 
-``8`` (``SQL_NUMERIC`` or ``SQL_DECIMAL`` or ``SQL_INTEGER`` or 
-``SQL_SMALLINT`` or ``SQL_FLOAT`` or ``SQL_REAL`` or ``SQL_DOUBLE``). For 
-example, if you call ``SQLBindParameter`` with ``ParameterNumber = 1``, 
-``ParameterType = 3``, ``Columnsize=5`` and ``DecimalDigits=4``, the result is 
-that, in the ``IPD.IDA[1]`` (i.e.: the first item descriptor area in the 
-Implementation Parameter Desc), the settings are as follows: 
-``SQL_DESC_TYPE=3``, ``SQL_DESC_PRECISION=5`` and ``SQL_DESC_SCALE=4``. 
+This chart shows the effect on ``IPD.IDA[n]`` fields if the value of the passed
+``ParameterType`` is ``2`` or ``3`` or ``4`` or ``5`` or ``6`` or ``7`` or
+``8`` (``SQL_NUMERIC`` or ``SQL_DECIMAL`` or ``SQL_INTEGER`` or
+``SQL_SMALLINT`` or ``SQL_FLOAT`` or ``SQL_REAL`` or ``SQL_DOUBLE``). For
+example, if you call ``SQLBindParameter`` with ``ParameterNumber = 1``,
+``ParameterType = 3``, ``Columnsize=5`` and ``DecimalDigits=4``, the result is
+that, in the ``IPD.IDA[1]`` (i.e.: the first item descriptor area in the
+Implementation Parameter Desc), the settings are as follows:
+``SQL_DESC_TYPE=3``, ``SQL_DESC_PRECISION=5`` and ``SQL_DESC_SCALE=4``.
 
 SQLBindParameter Effect IPD.IDA Fields for Datetime <data type>s
 ________________________________________________________________
@@ -2802,15 +2804,15 @@ ________________________________________________________________
 | ``SQL_DESC_PRECISION (frac-sec)``    | ``0``          | ``DecimalDigits`` | ``DecimalDigits``  |
 +--------------------------------------+----------------+-------------------+--------------------+
 
-This chart shows the effect on ``IPD.IDA[n]`` fields if the value of the passed 
-``ParameterType`` is ``91`` or ``92`` or ``93`` (date or time or timestamp). 
-``SQL_DESC_LENGTH`` is the length in "positions". ``SQL_DESC_PRECISION`` is the 
-"fractional-seconds" precision. For example, if you call ``SQLBindParameter`` 
-with ``ParameterNumber = 5``, ``ParameterType=92``, ``Columnsize=8`` and 
-``DecimalDigits=0``, the result is that, in the ``IPD.IDA[5]`` (i.e.: the fifth 
-item descriptor area in the Implementation Parameter Desc), the settings are as 
-follows: ``SQL_DESC_TYPE=9``, ``SQL_DESC_DATETIME_INTERVAL_CODE=2``, 
-``SQL_DESC_LENGTH=8`` and ``SQL_DESC_PRECISION=0``. 
+This chart shows the effect on ``IPD.IDA[n]`` fields if the value of the passed
+``ParameterType`` is ``91`` or ``92`` or ``93`` (date or time or timestamp).
+``SQL_DESC_LENGTH`` is the length in "positions". ``SQL_DESC_PRECISION`` is the
+"fractional-seconds" precision. For example, if you call ``SQLBindParameter``
+with ``ParameterNumber = 5``, ``ParameterType=92``, ``Columnsize=8`` and
+``DecimalDigits=0``, the result is that, in the ``IPD.IDA[5]`` (i.e.: the fifth
+item descriptor area in the Implementation Parameter Desc), the settings are as
+follows: ``SQL_DESC_TYPE=9``, ``SQL_DESC_DATETIME_INTERVAL_CODE=2``,
+``SQL_DESC_LENGTH=8`` and ``SQL_DESC_PRECISION=0``.
 
 SQLBindParameter Effect on IPD.IDA Fields for Interval Year/Month <data type>s
 ______________________________________________________________________________
@@ -2848,18 +2850,18 @@ ______________________________________________________________________________
 | ``SQL_DESC_DATETIME_INTERVAL_PRECISION`` | ``Columnsize-4``     |
 +------------------------------------------+----------------------+
 
-The charts show the effect on ``IPD.IDA[n]`` fields if the value of the passed 
-``ParameterType`` is ``101`` or ``102`` or ``107`` (interval year or interval 
-month or interval year-to-month). ``SQL_DESC_LENGTH`` is the length in 
-"positions". ``SQL_DESC_PRECISION`` is the "fractional-seconds" precision. 
-``SQL_DESC_DATETIME_INTERVAL_PRECISION`` is the "leading field" precision. For 
-example, if you call ``SQLBindParameter`` with ``ParameterNumber = 2``, 
-``ParameterType=107``, ``Columnsize=8`` and ``DecimalDigits=0``, the result is 
-that, in the ``IPD.IDA[2]`` (i.e.: the second item descriptor area in the 
-Implementation Parameter Desc), the settings are as follows: 
-``SQL_DESC_TYPE=10``, ``SQL_DESC_DATETIME_INTERVAL_CODE=7``, 
-``SQL_DESC_LENGTH=8``, ``SQL_DESC_PRECISION=0`` and 
-``SQL_DESC_DATETIME_INTERVAL_PRECISION=(8-4)=4``. 
+The charts show the effect on ``IPD.IDA[n]`` fields if the value of the passed
+``ParameterType`` is ``101`` or ``102`` or ``107`` (interval year or interval
+month or interval year-to-month). ``SQL_DESC_LENGTH`` is the length in
+"positions". ``SQL_DESC_PRECISION`` is the "fractional-seconds" precision.
+``SQL_DESC_DATETIME_INTERVAL_PRECISION`` is the "leading field" precision. For
+example, if you call ``SQLBindParameter`` with ``ParameterNumber = 2``,
+``ParameterType=107``, ``Columnsize=8`` and ``DecimalDigits=0``, the result is
+that, in the ``IPD.IDA[2]`` (i.e.: the second item descriptor area in the
+Implementation Parameter Desc), the settings are as follows:
+``SQL_DESC_TYPE=10``, ``SQL_DESC_DATETIME_INTERVAL_CODE=7``,
+``SQL_DESC_LENGTH=8``, ``SQL_DESC_PRECISION=0`` and
+``SQL_DESC_DATETIME_INTERVAL_PRECISION=(8-4)=4``.
 
 SQLBindParameter Effect on IPD.IDA Fields for Interval Day/Time <data type>s with No SECONDs
 ____________________________________________________________________________________________
@@ -2913,19 +2915,19 @@ ________________________________________________________________________________
 | ``SQL_DESC_DATETIME_INTERVAL_PRECISION`` | ``Columnsize-4``     |
 +------------------------------------------+----------------------+
 
-The charts show the effect on ``IPD.IDA[n]`` fields if the value of the passed 
-``ParameterType`` is ``103`` or ``104`` or ``105`` or ``108`` or ``109`` or 
-``111`` (interval day or interval hour or interval minute or interval day to 
-hour or interval day to minute or interval hour to minute). ``SQL_DESC_LENGTH`` 
-is the length in "positions". ``SQL_DESC_PRECISION`` is the 
-"fractional-seconds" precision. ``SQL_DESC_DATETIME_INTERVAL_PRECISION`` is the 
-"leading field" precision. For example, if you call ``SQLBindParameter`` with 
-``ParameterNumber = 2``, ``ParameterType=104``, ``Columnsize=3`` and 
-``DecimalDigits=0``, the result is that, in the ``IPD.IDA[2]`` (i.e.: the 
-second item descriptor area in the Implementation Parameter Desc), the settings 
-are as follows: ``SQL_DESC_TYPE=10``, ``SQL_DESC_DATETIME_INTERVAL_CODE=4``, 
-``SQL_DESC_LENGTH=3``, ``SQL_DESC_PRECISION=0`` and 
-``SQL_DESC_DATETIME_INTERVAL_PRECISION=(3-1)=2``. 
+The charts show the effect on ``IPD.IDA[n]`` fields if the value of the passed
+``ParameterType`` is ``103`` or ``104`` or ``105`` or ``108`` or ``109`` or
+``111`` (interval day or interval hour or interval minute or interval day to
+hour or interval day to minute or interval hour to minute). ``SQL_DESC_LENGTH``
+is the length in "positions". ``SQL_DESC_PRECISION`` is the
+"fractional-seconds" precision. ``SQL_DESC_DATETIME_INTERVAL_PRECISION`` is the
+"leading field" precision. For example, if you call ``SQLBindParameter`` with
+``ParameterNumber = 2``, ``ParameterType=104``, ``Columnsize=3`` and
+``DecimalDigits=0``, the result is that, in the ``IPD.IDA[2]`` (i.e.: the
+second item descriptor area in the Implementation Parameter Desc), the settings
+are as follows: ``SQL_DESC_TYPE=10``, ``SQL_DESC_DATETIME_INTERVAL_CODE=4``,
+``SQL_DESC_LENGTH=3``, ``SQL_DESC_PRECISION=0`` and
+``SQL_DESC_DATETIME_INTERVAL_PRECISION=(3-1)=2``.
 
 SQLBindParameter Effect on IPD.IDA Fields for Interval Day/Time <data type>s with SECONDs
 _________________________________________________________________________________________
@@ -2998,24 +3000,24 @@ ________________________________________________________________________________
 |                                          | ``Columnsize-4``                     |
 +------------------------------------------+--------------------------------------+
 
-The charts show the effect on ``IPD.IDA[n]`` fields if the value of the passed 
-``ParameterType`` is ``106`` or ``110`` or ``112`` or ``113`` (interval second 
-or interval day-to-second or interval hour-to-second or interval 
-minute-to-second). ``SQL_DESC_LENGTH`` is the length in "positions". 
-``SQL_DESC_PRECISION`` is the "fractional-seconds" precision. 
-``SQL_DESC_DATETIME_INTERVAL_PRECISION`` is the "leading field" precision. The 
-Column size must include one position for a "." if there is a 
-fractional-seconds amount -- that is, ``INTERVAL '+5.00' SECOND`` has a length 
-of ``5`` (``Columnsize=5``) and a fractional seconds precision of ``2`` 
-(``DecimalDigits=2``), so the precision of the leading field is 
-``(Columnsize-DecimalDigits-2) = (5-2-2) = 1``. For example, if you call 
-``SQLBindParameter`` with ``ParameterNumber = 1``, ``ParameterType=110``, 
-``Columnsize=12`` and ``DecimalDigits=0``, the result is that, in the 
-``IPD.IDA[1]`` (i.e.: the first item descriptor area in the Implementation 
-Parameter Desc), the settings are as follows: ``SQL_DESC_TYPE=10``, 
-``SQL_DESC_DATETIME_INTERVAL_CODE=10``, ``SQL_DESC_LENGTH=12``, 
-``SQL_DESC_PRECISION=0`` and 
-``SQL_DESC_DATETIME_INTERVAL_PRECISION=(12-10)=2``. 
+The charts show the effect on ``IPD.IDA[n]`` fields if the value of the passed
+``ParameterType`` is ``106`` or ``110`` or ``112`` or ``113`` (interval second
+or interval day-to-second or interval hour-to-second or interval
+minute-to-second). ``SQL_DESC_LENGTH`` is the length in "positions".
+``SQL_DESC_PRECISION`` is the "fractional-seconds" precision.
+``SQL_DESC_DATETIME_INTERVAL_PRECISION`` is the "leading field" precision. The
+Column size must include one position for a "." if there is a
+fractional-seconds amount -- that is, ``INTERVAL '+5.00' SECOND`` has a length
+of ``5`` (``Columnsize=5``) and a fractional seconds precision of ``2``
+(``DecimalDigits=2``), so the precision of the leading field is
+``(Columnsize-DecimalDigits-2) = (5-2-2) = 1``. For example, if you call
+``SQLBindParameter`` with ``ParameterNumber = 1``, ``ParameterType=110``,
+``Columnsize=12`` and ``DecimalDigits=0``, the result is that, in the
+``IPD.IDA[1]`` (i.e.: the first item descriptor area in the Implementation
+Parameter Desc), the settings are as follows: ``SQL_DESC_TYPE=10``,
+``SQL_DESC_DATETIME_INTERVAL_CODE=10``, ``SQL_DESC_LENGTH=12``,
+``SQL_DESC_PRECISION=0`` and
+``SQL_DESC_DATETIME_INTERVAL_PRECISION=(12-10)=2``.
 
 SQLBindParameter Effect on IPD.IDA Fields for Other <data type>s
 ________________________________________________________________
@@ -3028,14 +3030,14 @@ ________________________________________________________________
 | ``SQL_DESC_LENGTH (in chars or bits)`` | ``Columnsize``     |
 +----------------------------------------+--------------------+
 
-The chart shows the effect on ``IPD.IDA[n]`` fields if the value of the passed 
-``ParameterType`` is ``1`` or ``12`` or ``14`` or ``15`` or ``30`` or ``40`` 
-(``CHAR`` or ``CHAR VARYING`` or ``BIT`` or ``BIT VARYING`` or ``BLOB`` or 
-``CLOB``). For example, if you call ``SQLBindParameter`` with ``ParameterNumber 
-= 8``, ``ParameterType = 1`` and ``Columnsize = 50``, the result is that, in 
-the ``IPD.IDA[8]`` (i.e.: the eighth item descriptor area in the Implementation 
-Parameter Desc), the settings are as follows: ``SQL_DESC_TYPE = 1`` and 
-``SQL_DESC_LENGTH = 50``. 
+The chart shows the effect on ``IPD.IDA[n]`` fields if the value of the passed
+``ParameterType`` is ``1`` or ``12`` or ``14`` or ``15`` or ``30`` or ``40``
+(``CHAR`` or ``CHAR VARYING`` or ``BIT`` or ``BIT VARYING`` or ``BLOB`` or
+``CLOB``). For example, if you call ``SQLBindParameter`` with ``ParameterNumber
+= 8``, ``ParameterType = 1`` and ``Columnsize = 50``, the result is that, in
+the ``IPD.IDA[8]`` (i.e.: the eighth item descriptor area in the Implementation
+Parameter Desc), the settings are as follows: ``SQL_DESC_TYPE = 1`` and
+``SQL_DESC_LENGTH = 50``.
 
 **Notes:**
 
@@ -3049,27 +3051,27 @@ Parameter Desc), the settings are as follows: ``SQL_DESC_TYPE = 1`` and
   specification was changed a few years ago. Make sure, especially, that
   ``ParameterType`` is one of the "Concise Codes" for datetimes.
 
-* The DBMS does not have to perform a consistency check at this time. Contrast 
-  ``SQLSetDescField`` and ``SQLSetDescRec``, which require a consistency check 
-  as soon as ``SQL_DATA_POINTER`` contents change to a non-zero value. 
+* The DBMS does not have to perform a consistency check at this time. Contrast
+  ``SQLSetDescField`` and ``SQLSetDescRec``, which require a consistency check
+  as soon as ``SQL_DATA_POINTER`` contents change to a non-zero value.
 
 * Beware if you prepare before you bind. For example:
-  
+
   ::
-  
+
      SQLPrepare(hstmt,"UPDATE Table_1 SET int_column =?+5;",SQL_NTS);
      SQLBindParameter(hstmt,...);
      SQLExecute(hstmt);
      ...
-  
-  This sequence is okay according to standard SQL rules. But a DBMS exists 
-  which evaluates input parameters while processing ``SQLPrepare``, instead of 
-  waiting and evaluating parameters while processing ``SQLExecute``. In that 
-  case, the above example won't work. Or -- even worse -- it will appear to 
-  work because ``SQLPrepare`` picks up an input parameter that you made for a 
-  completely different statement! It's difficult to fix this problem by 
-  changing the order of the statements, but you could at least get rid of 
-  leftover bound parameters by calling ``SQLFreeStmt(...SQL_RESET_PARAMS)``. 
+
+  This sequence is okay according to standard SQL rules. But a DBMS exists
+  which evaluates input parameters while processing ``SQLPrepare``, instead of
+  waiting and evaluating parameters while processing ``SQLExecute``. In that
+  case, the above example won't work. Or -- even worse -- it will appear to
+  work because ``SQLPrepare`` picks up an input parameter that you made for a
+  completely different statement! It's difficult to fix this problem by
+  changing the order of the statements, but you could at least get rid of
+  leftover bound parameters by calling ``SQLFreeStmt(...SQL_RESET_PARAMS)``.
 
 **Example:**
 
@@ -3083,45 +3085,45 @@ Parameter Desc), the settings are as follows: ``SQL_DESC_TYPE = 1`` and
        hstmt,1,SQL_PARAM_MODE_INPUT,SQL_C_CHAR,SQL_CHAR,5,NULL,c,NULL,NULL);
     SQLExecDirect(hstmt,"UPDATE Table_1 SET col_1 = ?;",-3);
 
-This example shows how to bind a character parameter. Here, ``SQLExecDirect`` 
-contains an SQL statement with a single parameter marker (``?`` is a parameter 
-marker). Before executing the SQL statement, we must bind that parameter. Let's 
-look at the ``SQLBindParameter`` arguments, in order: 
+This example shows how to bind a character parameter. Here, ``SQLExecDirect``
+contains an SQL statement with a single parameter marker (``?`` is a parameter
+marker). Before executing the SQL statement, we must bind that parameter. Let's
+look at the ``SQLBindParameter`` arguments, in order:
 
-* ``[hstmt]`` is the ``stmt`` handle -- same as in the ``SQLExecDirect`` 
+* ``[hstmt]`` is the ``stmt`` handle -- same as in the ``SQLExecDirect``
   function.
 
-* ``[1]`` is ``ParameterNumber`` -- it's 1 because we're binding parameter 
+* ``[1]`` is ``ParameterNumber`` -- it's 1 because we're binding parameter
   number 1.
 
-* ``[SQL_PARAM_MODE_INPUT]`` is ``InputOutputMode`` -- this is "input" (from 
+* ``[SQL_PARAM_MODE_INPUT]`` is ``InputOutputMode`` -- this is "input" (from
   host to DBMS).
 
-* ``[SQL_C_CHAR]`` is ``ValueType -- SQL_C_CHAR = 1``, that is, the input is a 
+* ``[SQL_C_CHAR]`` is ``ValueType -- SQL_C_CHAR = 1``, that is, the input is a
   host ``char`` field.
 
-* ``[SQL_CHAR]`` is ``ParameterType -- SQL_CHAR = 1``, that is, the input is an 
+* ``[SQL_CHAR]`` is ``ParameterType -- SQL_CHAR = 1``, that is, the input is an
   SQL ``CHAR`` field.
 
 * ``[5]`` is ``Columnsize`` -- the input is 5 characters long.
 
-* ``[NULL]`` is ``DecimalDigits`` -- the value here doesn't matter because 
+* ``[NULL]`` is ``DecimalDigits`` -- the value here doesn't matter because
   we're dealing with a ``char`` field.
 
-* ``[c]`` is ``ParameterValue`` -- what we're actually passing here is the 
+* ``[c]`` is ``ParameterValue`` -- what we're actually passing here is the
   address of ``c``.
 
-* ``[NULL]`` is ``BufferLength`` -- the value here doesn't matter. (Note: Many 
-  programmers would pass ``[6]`` here -- i.e.: the number of octets in ``c``. 
-  We deplore this misleading practice. If the parameter mode is 
-  ``SQL_PARAM_MODE_INPUT``, the "octet length" is not determined by what is 
-  passed for ``BufferLength``.) 
+* ``[NULL]`` is ``BufferLength`` -- the value here doesn't matter. (Note: Many
+  programmers would pass ``[6]`` here -- i.e.: the number of octets in ``c``.
+  We deplore this misleading practice. If the parameter mode is
+  ``SQL_PARAM_MODE_INPUT``, the "octet length" is not determined by what is
+  passed for ``BufferLength``.)
 
-* ``[NULL]`` is ``*StrLen_or_Ind`` -- in this case we won't supply an indicator 
+* ``[NULL]`` is ``*StrLen_or_Ind`` -- in this case we won't supply an indicator
   pointer.
-  
+
   ::
-  
+
       ...
       SQLHSTMT hstmt;
       SQLCHAR date [] = "1994-01-31";
@@ -3129,20 +3131,20 @@ look at the ``SQLBindParameter`` arguments, in order:
       SQLBindParameter(
          hstmt,1,SQL_PARAM_MODE_INPUT,SQL_C_CHAR,SQL_TYPE_DATE,10,0,date,11,0);
       SQLExecDirect(hstmt,"SELECT * FROM Table_1 WHERE date_field = ?;",SQL_NTS);
-  
-This example shows how to bind a date parameter. This is much like the previous 
-example, but this time ``ParameterType`` is ``SQL_TYPE_DATE``. (Note: 
-``ParameterType`` is ``SQL_TYPE_DATE (91)`` -- not ``SQL_DATE (9)``. 
-``Columnsize`` is ``10``, because the number of positions in a date is 10: 
-``'yyyy-mm-dd'``.) In such bindings, there is an implicit ``CAST`` to ``DATE``. 
-One of the strengths of ``SQLBindParameter`` is that it makes implicit casts 
-easy. So here's what most programmers do: 
+
+This example shows how to bind a date parameter. This is much like the previous
+example, but this time ``ParameterType`` is ``SQL_TYPE_DATE``. (Note:
+``ParameterType`` is ``SQL_TYPE_DATE (91)`` -- not ``SQL_DATE (9)``.
+``Columnsize`` is ``10``, because the number of positions in a date is 10:
+``'yyyy-mm-dd'``.) In such bindings, there is an implicit ``CAST`` to ``DATE``.
+One of the strengths of ``SQLBindParameter`` is that it makes implicit casts
+easy. So here's what most programmers do:
 
 * Store everything in the host program as character strings.
 
 * Pass ``ValueType = SQL_C_CHAR`` for every ``SQLBindParameter`` call.
 
-* Set ``ParameterType =`` desired SQL <data type>, forcing the DBMS to perform 
+* Set ``ParameterType =`` desired SQL <data type>, forcing the DBMS to perform
   appropriate conversions.
 
 ::
@@ -3167,9 +3169,9 @@ easy. So here's what most programmers do:
     i_indicator=SQL_NULL_DATA;    /* sqlcli.h has "#define SQL_NULL_DATA -1" */
     SQLExecute(hstmt);
 
-This example shows how to bind a nullable integer parameter. Here, the value of 
-``i`` does not matter because the indicator variable's value is -1. Ultimately, 
-what gets inserted is a ``NULL`` value. 
+This example shows how to bind a nullable integer parameter. Here, the value of
+``i`` does not matter because the indicator variable's value is -1. Ultimately,
+what gets inserted is a ``NULL`` value.
 
 ::
 
@@ -3208,19 +3210,19 @@ what gets inserted is a ``NULL`` value.
      SQLFreeHandle(SQL_HANDLE_ENV,henv);
     }
 
-This example shows how to bind two parameters in a loop: it contains calls to 
-``SQLPrepare`` and ``SQLBindParameter`` before the loop starts. Note that, for 
-the ``Columnsize`` of the measurement parameter, we used 24. In fact, the 
-precision of a ``REAL`` is implementation-defined; for some DBMSs, the 
-appropriate value here is 7. 
+This example shows how to bind two parameters in a loop: it contains calls to
+``SQLPrepare`` and ``SQLBindParameter`` before the loop starts. Note that, for
+the ``Columnsize`` of the measurement parameter, we used 24. In fact, the
+precision of a ``REAL`` is implementation-defined; for some DBMSs, the
+appropriate value here is 7.
 
-**ODBC:** The ``SQLBindParameter`` function is new in ODBC 3.0. An ODBC 2.0 
-function named ``SQLSetParam`` was pretty well the same except that it had no 
-``InputOutputMode`` parameter. ODBC uses the abbreviation ``SQL_PARAM_INPUT`` 
-rather than ``SQL_PARAM_MODE_INPUT``. ODBC, in addition to the actions 
-described for standard SQL, will change ``ARD.IDA[n].SQL_DESC_SCALE`` and 
-``ARD.IDA[n].SQL_DESC_PRECISION`` to "default" values if 
-``ARD.IDA[n].SQL_DESC_TYPE`` becomes ``SQL_NUMERIC``. 
+**ODBC:** The ``SQLBindParameter`` function is new in ODBC 3.0. An ODBC 2.0
+function named ``SQLSetParam`` was pretty well the same except that it had no
+``InputOutputMode`` parameter. ODBC uses the abbreviation ``SQL_PARAM_INPUT``
+rather than ``SQL_PARAM_MODE_INPUT``. ODBC, in addition to the actions
+described for standard SQL, will change ``ARD.IDA[n].SQL_DESC_SCALE`` and
+``ARD.IDA[n].SQL_DESC_PRECISION`` to "default" values if
+``ARD.IDA[n].SQL_DESC_TYPE`` becomes ``SQL_NUMERIC``.
 
 Who should populate the IPD?
 ____________________________
@@ -3237,25 +3239,25 @@ If the DBMS supports auto-population of the IPD, then:
 
 * The IPD IDA fields will be populated by ``SQLPrepare``.
 
-The action is analogous to what ``SQLPrepare`` does to an IRD (for a ``SELECT`` 
-statement), so what's the problem? Why don't all DBMSs support auto-population? 
+The action is analogous to what ``SQLPrepare`` does to an IRD (for a ``SELECT``
+statement), so what's the problem? Why don't all DBMSs support auto-population?
 After all, in an SQL statement like this:
 
 ::
 
    UPDATE Table_1 SET col_1 = 5.1E4 + ?
 
-the DBMS must know the definition of the parameter (represented by ``?``), 
-because it "knows" the <data type> of both ``TABLE_1.COL_1`` and of the 
-<literal>. Well, to answer that, we must remind you that a DBMS is often two 
-quite different programs: the client (driver) and the server (data source). 
-Now, it's true that the server can figure out what a parameter must be. But the 
-client knows nothing about ``TABLE_1.COL_1`` unless the server tells it. As 
-Microsoft puts it: "... most data sources do not provide a way for the driver 
-to discover parameter metadata." What it comes down to, then, is: Yes, the DBMS 
-should populate the IPD. But it won't, so you should. Luckily, since you're 
-setting up the host variables anyway, you usually have all the information you 
-need to set up the IPD at the time you write your application. 
+the DBMS must know the definition of the parameter (represented by ``?``),
+because it "knows" the <data type> of both ``TABLE_1.COL_1`` and of the
+<literal>. Well, to answer that, we must remind you that a DBMS is often two
+quite different programs: the client (driver) and the server (data source).
+Now, it's true that the server can figure out what a parameter must be. But the
+client knows nothing about ``TABLE_1.COL_1`` unless the server tells it. As
+Microsoft puts it: "... most data sources do not provide a way for the driver
+to discover parameter metadata." What it comes down to, then, is: Yes, the DBMS
+should populate the IPD. But it won't, so you should. Luckily, since you're
+setting up the host variables anyway, you usually have all the information you
+need to set up the IPD at the time you write your application.
 
 *SQLColAttribute*
 -----------------
@@ -3301,28 +3303,28 @@ need to set up the IPD at the time you write your application.
 
 **Notes:**
 
-* ``SQLColAttribute`` stands for "[get] Column Attribute". The word "attribute" 
-  here means "a field in the Implementation Row Descriptor (IRD)". 
+* ``SQLColAttribute`` stands for "[get] Column Attribute". The word "attribute"
+  here means "a field in the Implementation Row Descriptor (IRD)".
 
-* The IRD is populated by preparing or executing a ``SELECT`` statement. For 
-  example, when displaying on the screen, it is useful to know the <Column 
-  name> and the <data type>. Those are two of the pieces of information that 
-  ``SQLColAttribute`` will provide you. 
+* The IRD is populated by preparing or executing a ``SELECT`` statement. For
+  example, when displaying on the screen, it is useful to know the <Column
+  name> and the <data type>. Those are two of the pieces of information that
+  ``SQLColAttribute`` will provide you.
 
-* All of the information that ``SQLColAttribute`` returns can also be found via 
-  the ``SQLGetDescField`` function. 
+* All of the information that ``SQLColAttribute`` returns can also be found via
+  the ``SQLGetDescField`` function.
 
-* With some DBMSs, it is a bad idea to retrieve IRD fields after 
-  ``SQLPrepare``, but before ``SQLExecute``. The reason, once again, is that 
-  the driver may not have an easy time querying the data source for such 
-  "metadata" information. In this case, the driver may actually execute a dummy 
-  SQL statement merely in order to find out what fields the data source 
-  returns. Such a process is inefficient. Therefore, it is commonly recommended 
-  that the IRD-information functions -- ``SQLColAttribute``, ``SQLDescribeCol`` 
-  and sometimes ``SQLGetDescField`` or ``SQLGetDescRec`` -- should be deferred 
-  until the SQL statement is executed. If the ``SQLExecute`` function call is 
-  in a loop, then you should set flags appropriately so that the 
-  IRD-information function is only called once. 
+* With some DBMSs, it is a bad idea to retrieve IRD fields after
+  ``SQLPrepare``, but before ``SQLExecute``. The reason, once again, is that
+  the driver may not have an easy time querying the data source for such
+  "metadata" information. In this case, the driver may actually execute a dummy
+  SQL statement merely in order to find out what fields the data source
+  returns. Such a process is inefficient. Therefore, it is commonly recommended
+  that the IRD-information functions -- ``SQLColAttribute``, ``SQLDescribeCol``
+  and sometimes ``SQLGetDescField`` or ``SQLGetDescRec`` -- should be deferred
+  until the SQL statement is executed. If the ``SQLExecute`` function call is
+  in a loop, then you should set flags appropriately so that the
+  IRD-information function is only called once.
 
 **Example:**
 
@@ -3349,17 +3351,17 @@ need to set up the IPD at the time you write your application.
         the diagnostics we would see sqlstate='01004' (truncation). The
         value in name is "column_NA\0". The value in name_length is 11. */
 
-**ODBC:** ``SQLColAttribute`` arrived with ODBC 3.0. In ODBC 2.x there was a 
-similar function, ``SQLColAttributes``, which is now deprecated. Syntactically, 
-ODBC 3.0's ``SQLColAttribute`` function is nearly standard CLI. But ODBC 
-supports only 14 of the standard ``FieldIdentifier`` values (``1001`` through 
-``1013`` and ``1099``). ODBC also has 15 non-standard values in the 
-"implementation-defined" range, for items like "the name of the Base table" or 
-"whether the Column is case sensitive". In standard SQL, the fields of an IRD 
-are still valid even after a Cursor is closed -- but this is not the case with 
-ODBC. In earlier versions, ODBC and the standard CLI had different type 
-specifications for the ``BufferLength`` and ``StringLength`` parameters. These 
-differences have now been resolved. 
+**ODBC:** ``SQLColAttribute`` arrived with ODBC 3.0. In ODBC 2.x there was a
+similar function, ``SQLColAttributes``, which is now deprecated. Syntactically,
+ODBC 3.0's ``SQLColAttribute`` function is nearly standard CLI. But ODBC
+supports only 14 of the standard ``FieldIdentifier`` values (``1001`` through
+``1013`` and ``1099``). ODBC also has 15 non-standard values in the
+"implementation-defined" range, for items like "the name of the Base table" or
+"whether the Column is case sensitive". In standard SQL, the fields of an IRD
+are still valid even after a Cursor is closed -- but this is not the case with
+ODBC. In earlier versions, ODBC and the standard CLI had different type
+specifications for the ``BufferLength`` and ``StringLength`` parameters. These
+differences have now been resolved.
 
 *SQLDescribeCol*
 ----------------
@@ -3379,8 +3381,8 @@ differences have now been resolved.
        SQLSMALLINT *DecimalDigits,      /* 16-bit output */
        SQLSMALLINT *Nullable);          /* 16-bit output */
 
-**Job:** Get the following information about one Column in a result set: the 
-<Column name>, the <data type>, the Column size, the scale and whether the 
+**Job:** Get the following information about one Column in a result set: the
+<Column name>, the <data type>, the Column size, the scale and whether the
 Column might contain nulls.
 
 **Algorithm:**
@@ -3433,37 +3435,37 @@ Column might contain nulls.
 
 **Notes:**
 
-* Most of the information that ``SQLDescribeCol`` returns can also be found via 
-  the ``SQLGetDescField`` function, or via the ``SQLColAttribute`` function. So 
-  ``SQLDescribeCol`` is a redundancy. It continues to be popular because it's a 
-  handy wrapper: the information that ``SQLDescribeCol`` returns is what's 
-  commonly needed for simple applications. 
+* Most of the information that ``SQLDescribeCol`` returns can also be found via
+  the ``SQLGetDescField`` function, or via the ``SQLColAttribute`` function. So
+  ``SQLDescribeCol`` is a redundancy. It continues to be popular because it's a
+  handy wrapper: the information that ``SQLDescribeCol`` returns is what's
+  commonly needed for simple applications.
 
-* The SQL Standard does not provide for the possibility that people may wish to 
-  pass null pointers for unwanted parameters. 
+* The SQL Standard does not provide for the possibility that people may wish to
+  pass null pointers for unwanted parameters.
 
-* Sometimes ``SQLDescribeCol`` is called in order to provide information for a 
-  reporting program. In that case, ``ColumnName`` and ``NameLength`` are used 
-  for the report-Column headers, ``DataType`` is used to determine whether 
-  right justification is needed, ``ColumnLength+2`` is the maximum Column 
-  width, ``DecimalDigits`` helps COBOL programs decide what the totallers' PICs 
-  are and ``Nullable``, if true, may cause creation of a separate "null?" 
-  Column. 
+* Sometimes ``SQLDescribeCol`` is called in order to provide information for a
+  reporting program. In that case, ``ColumnName`` and ``NameLength`` are used
+  for the report-Column headers, ``DataType`` is used to determine whether
+  right justification is needed, ``ColumnLength+2`` is the maximum Column
+  width, ``DecimalDigits`` helps COBOL programs decide what the totallers' PICs
+  are and ``Nullable``, if true, may cause creation of a separate "null?"
+  Column.
 
-* Sometimes ``SQLDescribeCol`` is called in order to provide information that 
-  can be used by ``SQLBindCol``. In that case, ``DataType`` can be passed 
-  directly, ``ColumnLength`` can be passed directly, ``ColumnLength`` can be 
-  used to decide how big a buffer must be malloc'd, ``DecimalDigits`` can be 
-  passed directly and ``Nullable`` can be used to decide whether an indicator 
-  is necessary. However, such a scheme cannot be carried out without some 
-  advance checking. For example, not all <data type>s can be passed directly -- 
-  some must be ``CAST`` to a "char" with length equal to ``ColumnLength`` 
-  (usually). 
+* Sometimes ``SQLDescribeCol`` is called in order to provide information that
+  can be used by ``SQLBindCol``. In that case, ``DataType`` can be passed
+  directly, ``ColumnLength`` can be passed directly, ``ColumnLength`` can be
+  used to decide how big a buffer must be malloc'd, ``DecimalDigits`` can be
+  passed directly and ``Nullable`` can be used to decide whether an indicator
+  is necessary. However, such a scheme cannot be carried out without some
+  advance checking. For example, not all <data type>s can be passed directly --
+  some must be ``CAST`` to a "char" with length equal to ``ColumnLength``
+  (usually).
 
-* The source field for ``Columnsize`` will depend on the <data type>. This 
-  chart shows what the effects are of the calculation in the "Algorithm" 
-  section: 
-  
+* The source field for ``Columnsize`` will depend on the <data type>. This
+  chart shows what the effects are of the calculation in the "Algorithm"
+  section:
+
   +-----------------------------------+----------------------------+------------------------+--------------------+
   | <data type>                       | field                      | example definition     | example Columnsize |
   +===================================+============================+========================+====================+
@@ -3490,8 +3492,8 @@ Column might contain nulls.
 
   **Note 1:** This <data type> usually has a binary-radix precision, so the
   value in ``SQL_DESC_PRECISION`` is in bits. When this is the case, the DBMS
-  converts to the number of decimal digits that would be needed to represent 
-  the <data type>'s largest literal (not including space for sign, decimal 
+  converts to the number of decimal digits that would be needed to represent
+  the <data type>'s largest literal (not including space for sign, decimal
   point or exponent).
 
   **Note 2:** The ``INTERVAL`` example is based on an assumption that the
@@ -3540,12 +3542,12 @@ Column might contain nulls.
        ...
        }
 
-**ODBC:** The ``SQLDescribeCol`` function has been around since ODBC 1.0. The 
-differences between the ODBC and Standard's specifications are only minor. 
-Unlike Standard-conformant drivers, ODBC drivers can accept 0 for a Column 
-number, can return a blank string in ``ColumnName``, can return 
-``SQL_NULLABLE_UNKNOWN`` in ``Nullable`` and return ``SQL_DESC_OCTET_LENGTH`` 
-for ``ColumnLength`` of datetime, interval or bit <data type>s. 
+**ODBC:** The ``SQLDescribeCol`` function has been around since ODBC 1.0. The
+differences between the ODBC and Standard's specifications are only minor.
+Unlike Standard-conformant drivers, ODBC drivers can accept 0 for a Column
+number, can return a blank string in ``ColumnName``, can return
+``SQL_NULLABLE_UNKNOWN`` in ``Nullable`` and return ``SQL_DESC_OCTET_LENGTH``
+for ``ColumnLength`` of datetime, interval or bit <data type>s.
 
 *SQLNumResultCols*
 ------------------
@@ -3571,23 +3573,23 @@ for ``ColumnLength`` of datetime, interval or bit <data type>s.
 
 **Notes:**
 
-* All this function does is retrieve the "count" field in the IRD, which is 
-  zero if the last prepared/executed SQL statement was a non-query, or -- if 
-  the last prepared/executed SQL statement was a query -- is the number of 
-  Columns in the select list. 
+* All this function does is retrieve the "count" field in the IRD, which is
+  zero if the last prepared/executed SQL statement was a non-query, or -- if
+  the last prepared/executed SQL statement was a query -- is the number of
+  Columns in the select list.
 
 * ``SQLNumResultCols(hstmt,&column_count)`` is effectively the same as:
-  
+
   ::
-  
+
      SQLGetStmtAttr(hstmt,SQL_ATTR_IMP_ROW_DESC,&hdesc,NULL,NULL);
      SQLGetDescField(hdesc,NULL,SQL_DESC_COUNT,&column_count,NULL,NULL);
 
-* Some applications call ``SQLNumResultCols`` in order to find out whether the 
-  last executed statement was a query. If it was something else -- ``INSERT``, 
-  for instance -- then ``*ColumnCount`` would be 0. This is a reliable test, 
-  but SQL3 programmers can use ``desc.SQL_DESC_DYNAMIC_FUNCTION_CODE`` for a 
-  slightly more precise answer. 
+* Some applications call ``SQLNumResultCols`` in order to find out whether the
+  last executed statement was a query. If it was something else -- ``INSERT``,
+  for instance -- then ``*ColumnCount`` would be 0. This is a reliable test,
+  but SQL3 programmers can use ``desc.SQL_DESC_DYNAMIC_FUNCTION_CODE`` for a
+  slightly more precise answer.
 
 **Example:**
 
@@ -3622,15 +3624,15 @@ for ``ColumnLength`` of datetime, interval or bit <data type>s.
        SQLINTEGER *StrLen_or_Ind        /* 32-bit output */
        );
 
-**Job:** Get the value of an unbound <output parameter. ``SQLGetParamData`` is 
+**Job:** Get the value of an unbound <output parameter. ``SQLGetParamData`` is
 rare. You only need it if all these things are true:
 
 * You have executed an SQL statement which begins with the word ``CALL``.
 
-* The called procedure has "output parameters" (direction of flow is from DBMS 
+* The called procedure has "output parameters" (direction of flow is from DBMS
   to host-language buffers).
 
-* You did not bind the output parameters in advance with ``SQLBindParameter``, 
+* You did not bind the output parameters in advance with ``SQLBindParameter``,
   ``SQLSetDescRec`` or ``SQLSetDescField``.
 
 **Algorithm:**
@@ -3649,18 +3651,18 @@ rare. You only need it if all these things are true:
 
 **Note:**
 
-* It is implementation-defined whether the parameters must be accessed in 
-  ascending parameter-number order. You can call 
-  ``SQLGetInfo(...SQL_GETPARAMDATA_EXTENSIONS...)`` to find out whether your 
-  DBMS supports getting any parameter in any order. 
+* It is implementation-defined whether the parameters must be accessed in
+  ascending parameter-number order. You can call
+  ``SQLGetInfo(...SQL_GETPARAMDATA_EXTENSIONS...)`` to find out whether your
+  DBMS supports getting any parameter in any order.
 
-* The "source" is already described in the IPD; you only need to pass a 
-  description of the "target". 
+* The "source" is already described in the IPD; you only need to pass a
+  description of the "target".
 
-* The possible values of TargetType are: 
-  
+* The possible values of TargetType are:
+
   ::
-  
+
     SQL_C_CHARACTER    1
     SQL_C_INTEGER      4
     SQL_C_SMALLINT     5
@@ -3669,7 +3671,7 @@ rare. You only need it if all these things are true:
     SQL_C_DEFAULT     99 (use IPD <data type>, precision, scale)
     SQL_APD_TYPE     -99 (APD specifies <data type> already)
 
-We recommend against using ``SQL_C_DEFAULT`` because "type, precision, scale" 
+We recommend against using ``SQL_C_DEFAULT`` because "type, precision, scale"
 is often insufficient information.
 
 **Example:**
@@ -3706,10 +3708,10 @@ output parameter which you will pick up with ``SQLGetParamData``.
           100,                          /* BufferLength */
           &message2_indicator);         /* *StrLen_or_Ind */
 
-A possible result from this code would be: ``message2`` contains the 
+A possible result from this code would be: ``message2`` contains the
 null-terminated string ``"abc"`` and ``message2_indicator`` contains 3.
 
 **ODBC:** The ``SQLGetParamData`` function is not part of ODBC 3.0.
 
-And that's it for the ``desc`` functions. In the next chapter, we'll take a 
+And that's it for the ``desc`` functions. In the next chapter, we'll take a
 look at the diagnostic functions.

--- a/docs/chapters/47.rst
+++ b/docs/chapters/47.rst
@@ -4,11 +4,13 @@
 Chapter 47 -- SQL/CLI: Diagnostic Functions
 ===========================================
 
-What if something goes wrong? Every ``env`` and ``dbc`` and ``stmt`` and 
-``desc`` has a structure called the Diagnostics Area. The DBMS fills it with 
-information about what happened during the last function call. The diagnostics 
-area has one "header" and zero or more "status records". This partial 
-illustration shows only the most important fields: 
+.. include:: ../_include/note.rst
+
+What if something goes wrong? Every ``env`` and ``dbc`` and ``stmt`` and
+``desc`` has a structure called the Diagnostics Area. The DBMS fills it with
+information about what happened during the last function call. The diagnostics
+area has one "header" and zero or more "status records". This partial
+illustration shows only the most important fields:
 
 ::
 
@@ -26,7 +28,7 @@ illustration shows only the most important fields:
     -   3 - 01008      | Warning - implicit zero-bit padding             | ... |
     -     ---------------------------------------------------------------------
 
-This diagram shows the diagnostics area of a ``stmt``, just after this function 
+This diagram shows the diagnostics area of a ``stmt``, just after this function
 call:
 
 ::
@@ -34,47 +36,47 @@ call:
    sqlreturn = SQLExecDirect(
       hstmt,"UPDATE T SET a=(SELECT MAX(b) FROM X),c=X'5'",SQL_NTS);
 
-Looking at the header, we can see that the function failed because the 
-``SQL_DIAG_RETURNCODE`` field is -1, which is ``SQL_ERROR`` (``sqlreturn`` will 
-also equal -1). Also, from the fact that the header's ``SQL_DIAG_NUMBER`` field 
-is 3, we can see that there are three status records. 
+Looking at the header, we can see that the function failed because the
+``SQL_DIAG_RETURNCODE`` field is -1, which is ``SQL_ERROR`` (``sqlreturn`` will
+also equal -1). Also, from the fact that the header's ``SQL_DIAG_NUMBER`` field
+is 3, we can see that there are three status records.
 
-Looking at the status records, we can see that three different things went 
-wrong during the execution of the SQL statement. Two of them were merely 
-warnings ("completion conditions"). Probably the DBMS encountered these 
-conditions while it was setting up for the ``UPDATE``, but it kept on going. 
-Then it hit a showstopper: an "exception condition". Although this "integrity 
-Constraint violation" error was the third condition encountered, it is the 
-first in order among the status records because an error's priority is higher 
-than a warning's. 
+Looking at the status records, we can see that three different things went
+wrong during the execution of the SQL statement. Two of them were merely
+warnings ("completion conditions"). Probably the DBMS encountered these
+conditions while it was setting up for the ``UPDATE``, but it kept on going.
+Then it hit a showstopper: an "exception condition". Although this "integrity
+Constraint violation" error was the third condition encountered, it is the
+first in order among the status records because an error's priority is higher
+than a warning's.
 
-The ``SQL_DIAG_SQLSTATE`` field contains a code for a reasonably precise 
-categorization of the condition. This code is called the *status code*, or 
-``SQLSTATE`` value (because the DBMS always puts the status code in the 
-``SQL_DIAG_SQLSTATE`` field). You can see what the ``SQLSTATE`` codes mean by 
-looking at the chart of codes at the end of this chapter. 
+The ``SQL_DIAG_SQLSTATE`` field contains a code for a reasonably precise
+categorization of the condition. This code is called the *status code*, or
+``SQLSTATE`` value (because the DBMS always puts the status code in the
+``SQL_DIAG_SQLSTATE`` field). You can see what the ``SQLSTATE`` codes mean by
+looking at the chart of codes at the end of this chapter.
 
-The ``SQL_DIAG_MESSAGE_TEXT`` field might be the sort of text you'd like to 
-send to the user's screen for this condition. Unlike the status code, the 
-message text is implementation-dependent: it's not standardized. It might be 
-internationalized; that is, it might not be in English. So there is a lot more 
-information here than a mere "failed" return code. And there are many more 
-fields than the ones in the picture, which can help you get an even more 
-precise diagnosis of "why didn't the ``SQLExecDirect`` function work". In order 
-to retrieve the diagnostics-area information into your application program, you 
-need to use one of these CLI functions: 
+The ``SQL_DIAG_MESSAGE_TEXT`` field might be the sort of text you'd like to
+send to the user's screen for this condition. Unlike the status code, the
+message text is implementation-dependent: it's not standardized. It might be
+internationalized; that is, it might not be in English. So there is a lot more
+information here than a mere "failed" return code. And there are many more
+fields than the ones in the picture, which can help you get an even more
+precise diagnosis of "why didn't the ``SQLExecDirect`` function work". In order
+to retrieve the diagnostics-area information into your application program, you
+need to use one of these CLI functions:
 
-* ``SQLGetDiagField`` -- You'll need this function to get any field from any 
+* ``SQLGetDiagField`` -- You'll need this function to get any field from any
   part of the diagnostics area, one field at a time.
 
-* ``SQLGetDiagRec`` -- With this function, you can pick up several of the most 
-  popular fields, including ``SQL_DIAG_SQLSTATE`` and 
+* ``SQLGetDiagRec`` -- With this function, you can pick up several of the most
+  popular fields, including ``SQL_DIAG_SQLSTATE`` and
   ``SQL_DIAG_MESSAGE_TEXT``.
 
-* ``SQLError`` -- You'll want to know about this slightly obsolescent function 
+* ``SQLError`` -- You'll want to know about this slightly obsolescent function
   because it appears frequently in legacy code.
 
-* SQLRowCount -- This isn't exactly a diagnostics function, but it does get a 
+* SQLRowCount -- This isn't exactly a diagnostics function, but it does get a
   value from a particular diagnostics-area field: ``SQL_DIAG_ROW_COUNT``.
 
 The descriptions of these four functions follow.
@@ -101,38 +103,38 @@ SQLGetDiagField
       SQLSMALLINT *StringLength     /* 16-bit output */
       );
 
-**Job:** Get one piece of information from a diagnostics area, for example, the 
-``SQLSTATE`` of a warning that was posted for the last function call. 
+**Job:** Get one piece of information from a diagnostics area, for example, the
+``SQLSTATE`` of a warning that was posted for the last function call.
 
-There are 50 variations of ``SQLGetDiagField``, depending on the diagnostics 
-field whose value you want to examine. Here's an example and short description 
-of each variation; each uses these shorthands: 
+There are 50 variations of ``SQLGetDiagField``, depending on the diagnostics
+field whose value you want to examine. Here's an example and short description
+of each variation; each uses these shorthands:
 
-* The words "last call" mean "the last function called using this handle, other 
-  than ``SQLGetDiagField`` or ``SQLGetDiagRec`` or ``SQLError``". The principle 
-  (anti-Heisenbergian) here is that the act of observation must not affect the 
-  thing observed, so the diagnostics routines don't themselves post diagnostics 
-  information. 
+* The words "last call" mean "the last function called using this handle, other
+  than ``SQLGetDiagField`` or ``SQLGetDiagRec`` or ``SQLError``". The principle
+  (anti-Heisenbergian) here is that the act of observation must not affect the
+  thing observed, so the diagnostics routines don't themselves post diagnostics
+  information.
 
-* The punctuation ...,..., at the beginning of each function example's 
-  parameter list means "assume there is a valid handle type and handle here". 
-  The ``HandleType`` parameter must be ``SQL_HANDLE_ENV``, ``SQL_HANDLE_DBC``, 
-  ``SQL_HANDLE_STMT`` or ``SQL_HANDLE_DESC``. The corresponding Handle 
-  parameter must be a ``henv`` or ``hdbc`` or ``hstmt`` or ``hdesc``. Where the 
-  only acceptable value is a ``hstmt``, the parameter list starts with 
-  ``SQL_HANDLE_STMT,hstmt``. 
+* The punctuation ...,..., at the beginning of each function example's
+  parameter list means "assume there is a valid handle type and handle here".
+  The ``HandleType`` parameter must be ``SQL_HANDLE_ENV``, ``SQL_HANDLE_DBC``,
+  ``SQL_HANDLE_STMT`` or ``SQL_HANDLE_DESC``. The corresponding Handle
+  parameter must be a ``henv`` or ``hdbc`` or ``hstmt`` or ``hdesc``. Where the
+  only acceptable value is a ``hstmt``, the parameter list starts with
+  ``SQL_HANDLE_STMT,hstmt``.
 
-* The name used for the ``DiagInfo`` parameter gives an indication of the <data 
-  type> that ``SQLGetDiagField`` returns: smallint, integer or character 
-  string. 
+* The name used for the ``DiagInfo`` parameter gives an indication of the <data
+  type> that ``SQLGetDiagField`` returns: smallint, integer or character
+  string.
 
-* The word ``NULL`` in a function's argument list means "doesn't matter". None 
-  of the diagnostics fields contain ``NULL`` in the SQL sense. 
+* The word ``NULL`` in a function's argument list means "doesn't matter". None
+  of the diagnostics fields contain ``NULL`` in the SQL sense.
 
-* The four-digit number at the beginning of each paragraph is the code for the 
-  ``DiagIdentifier`` parameter. We have done the same thing here that we did in 
-  our chapter on the ``desc`` functions; namely, treating the name of the 
-  ``sqlcli.h`` code constant as the name of the field. 
+* The four-digit number at the beginning of each paragraph is the code for the
+  ``DiagIdentifier`` parameter. We have done the same thing here that we did in
+  our chapter on the ``desc`` functions; namely, treating the name of the
+  ``sqlcli.h`` code constant as the name of the field.
 
 *Diagnostics Fields -- Header*
 ------------------------------
@@ -142,19 +144,19 @@ matter what you pass for the ``RecordNumber`` parameter.
 
 ``0001``
     ::
-    
+
       SQLGetDiagField(...,...,NULL,SQL_DIAG_RETURNCODE,&smallint,NULL,NULL);
-    
-    This field gives you the last call's return code: ``SQL_SUCCESS``, 
-    ``SQL_ERROR``, ``SQL_SUCCESS_WITH_INFO``, ``SQL_NEED_DATA`` or ``SQL_NO_DATA``. 
-    You need to call this if you failed to save the return code in an ``sqlreturn`` 
-    variable. 
+
+    This field gives you the last call's return code: ``SQL_SUCCESS``,
+    ``SQL_ERROR``, ``SQL_SUCCESS_WITH_INFO``, ``SQL_NEED_DATA`` or ``SQL_NO_DATA``.
+    You need to call this if you failed to save the return code in an ``sqlreturn``
+    variable.
 
 ``0002``
     ::
-    
+
       SQLGetDiagField(...,...,NULL,SQL_DIAG_NUMBER,&integer,NULL,NULL);
-    
+
     This field gives you the number of Status Records (exception or completion
     conditions) that the DBMS generated for the last call. The value will be zero
     if the return code is ``SQL_SUCCESS``, and will probably (but not certainly) be
@@ -162,90 +164,90 @@ matter what you pass for the ``RecordNumber`` parameter.
 
 ``0003``
     ::
-    
+
       SQLGetDiagField(
          SQL_HANDLE_STMT,hstmt,NULL,SQL_DIAG_ROW_COUNT,&integer,NULL,NULL);
-    
-    If the last call was ``SQLExecDirect`` or ``SQLExecute`` for an ``UPDATE``, 
-    ``DELETE`` or ``INSERT`` statement, this field gives you the number of rows 
-    affected. Read about the ``SQLRowCount`` function, which returns the same 
-    information. You must call this function immediately after calling 
-    ``SQLExecDirect`` or ``SQLExecute``. 
+
+    If the last call was ``SQLExecDirect`` or ``SQLExecute`` for an ``UPDATE``,
+    ``DELETE`` or ``INSERT`` statement, this field gives you the number of rows
+    affected. Read about the ``SQLRowCount`` function, which returns the same
+    information. You must call this function immediately after calling
+    ``SQLExecDirect`` or ``SQLExecute``.
 
 ``0007``
     ::
-    
+
       SQLGetDiagField(
          SQL_HANDLE_STMT,hstmt,NULL,SQL_DIAG_DYNAMIC_FUNCTION,charstring,
          sizeof(charstring),&charstring_size);
-    
-    If the last call was ``SQLExecDirect`` or ``SQLExecute``, this field gives 
-    you a string that describes the type of SQL statement executed. Usually 
-    this is the first two or three <keyword>s in the statement. The official 
-    list of SQL statements and their function codes is shown at the end of this 
-    section. 
+
+    If the last call was ``SQLExecDirect`` or ``SQLExecute``, this field gives
+    you a string that describes the type of SQL statement executed. Usually
+    this is the first two or three <keyword>s in the statement. The official
+    list of SQL statements and their function codes is shown at the end of this
+    section.
 
 ``0012``
     ::
-    
+
       SQLGetDiagField(
          SQL_HANDLE_STMT,hstmt,NULL,SQL_DIAG_DYNAMIC_FUNCTION_CODE,
          &integer,NULL,NULL);
-    
-    If the last call was ``SQLExecDirect`` or ``SQLExecute``, this field gives 
-    you the code value for the type of SQL statement executed; see the codes in 
-    the "``DYNAMIC_FUNCTION`` and ``DYNAMIC_FUNCTION_CODE``" lists, above. If 
-    you allow users to type in SQL statements, it's handy to call 
-    ``SQLPrepare`` and then call this function, so you know what kind of SQL 
-    statement it is before you call ``SQLExecute``. 
+
+    If the last call was ``SQLExecDirect`` or ``SQLExecute``, this field gives
+    you the code value for the type of SQL statement executed; see the codes in
+    the "``DYNAMIC_FUNCTION`` and ``DYNAMIC_FUNCTION_CODE``" lists, above. If
+    you allow users to type in SQL statements, it's handy to call
+    ``SQLPrepare`` and then call this function, so you know what kind of SQL
+    statement it is before you call ``SQLExecute``.
 
 ``0013``
     ::
-    
+
       SQLGetDiagField(SQL_HANDLE_STMT,hstmt,NULL,SQL_DIAG_MORE,&integer,NULL,NULL);
-    
-    The return value for this field is either 1 "true" or 0 "false": if there 
-    are more status records than would fit in the diagnostics area, you get a 
-    "true" code here. (Actually the Standard says that the returned value is 
-    'Y' or 'N' but that must be an error.) You may or may not be able to change 
-    the maximum size of the diagnostics area with ``SET TRANSACTION ... 
-    DIAGNOSTICS SIZE`` statement. 
+
+    The return value for this field is either 1 "true" or 0 "false": if there
+    are more status records than would fit in the diagnostics area, you get a
+    "true" code here. (Actually the Standard says that the returned value is
+    'Y' or 'N' but that must be an error.) You may or may not be able to change
+    the maximum size of the diagnostics area with ``SET TRANSACTION ...
+    DIAGNOSTICS SIZE`` statement.
 
 ``0034``
     ::
-    
+
       SQLGetDiagField(
          ...,...,NULL,SQL_DIAG_TRANSACTIONS_COMMITTED,&integer,NULL,NULL);
-    
+
     This field gives you the number of transactions committed.
 
 ``0035``
     ::
-    
+
       SQLGetDiagField(
          ...,...,NULL,SQL_DIAG_TRANSACTIONS_ROLLED_BACK,&integer,NULL,NULL);
-    
+
     This field gives you the number of transactions rolled back.
 
 ``0036``
     ::
-    
+
       SQLGetDiagField(...,...,NULL,SQL_DIAG_TRANSACTION_ACTIVE,&integer,NULL,NULL);
-    
-    This field gives you a 1 "true" if a transaction is currently active. (A 
-    transaction is active if a Cursor is open or the DBMS is waiting for a 
-    deferred parameter.) 
+
+    This field gives you a 1 "true" if a transaction is currently active. (A
+    transaction is active if a Cursor is open or the DBMS is waiting for a
+    deferred parameter.)
 
 SQL_DIAG_DYNAMIC_FUNCTION Codes
 _______________________________
 
-If the last call was ``SQLExecDirect`` or ``SQLExecute``, 
-``SQLGetDiagField``\'s ``SQL_DIAG_DYNAMIC_FUNCTION`` gives you a string that 
-describes the type of SQL statement executed. As we said earlier, this is 
-usually the first two or three <keyword>s in the SQL statement. Here's the 
-official list of SQL statements and their function codes (note that not all 
-these SQL statements are executable in a CLI context; we have given a full list 
-here so as to avoid repetition elsewhere). 
+If the last call was ``SQLExecDirect`` or ``SQLExecute``,
+``SQLGetDiagField``\'s ``SQL_DIAG_DYNAMIC_FUNCTION`` gives you a string that
+describes the type of SQL statement executed. As we said earlier, this is
+usually the first two or three <keyword>s in the SQL statement. Here's the
+official list of SQL statements and their function codes (note that not all
+these SQL statements are executable in a CLI context; we have given a full list
+here so as to avoid repetition elsewhere).
 
 List of SQL Statements and Codes in SQL-92, but not in CLI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -390,20 +392,20 @@ List of Additional SQL Statements and Codes in SQL3 and CLI
     SET SESSION CHARACTERISTICS  109       SQL_DIAG_SET_SESSION_CHARACTERISTICS
     START TRANSACTION            111       SQL_DIAG_START_TRANSACTION
 
-(Note: In some contexts, the names ``DYNAMIC_FUNCTION`` and 
-``DYNAMIC_FUNCTION_CODE`` are ``COMMAND_FUNCTION`` and 
-``COMMAND_FUNCTION_CODE``, respectively.) 
+(Note: In some contexts, the names ``DYNAMIC_FUNCTION`` and
+``DYNAMIC_FUNCTION_CODE`` are ``COMMAND_FUNCTION`` and
+``COMMAND_FUNCTION_CODE``, respectively.)
 
 *Diagnostics Fields -- Status Records*
 --------------------------------------
 
-The 28 "status records" in a diagnostics area can occur multiple times. You 
-must pass a record number between 1 and ``SQL_DIAG_NUMBER`` (or you can pass 
-any positive number and see whether ``SQLGetDiagField`` returns 
-``SQL_NO_DATA``). Other terms for Status Record are: "Descriptor Record" 
-(preferred by Microsoft) and Condition Information Item (preferred by the SQL 
-Standard in non-CLI contexts). Strings are returned according to the rules of 
-Character String Retrieval. 
+The 28 "status records" in a diagnostics area can occur multiple times. You
+must pass a record number between 1 and ``SQL_DIAG_NUMBER`` (or you can pass
+any positive number and see whether ``SQLGetDiagField`` returns
+``SQL_NO_DATA``). Other terms for Status Record are: "Descriptor Record"
+(preferred by Microsoft) and Condition Information Item (preferred by the SQL
+Standard in non-CLI contexts). Strings are returned according to the rules of
+Character String Retrieval.
 
 ``< 0``
     A status record with a number less than zero identifies an
@@ -411,281 +413,281 @@ Character String Retrieval.
 
 ``0004``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_SQLSTATE,charstring,sizeof(charstring),
          &charstring_size);
-    
-    This field gives you a 5-character status code -- remember to allow 6 
-    characters because of the null terminator. ``SQLSTATE`` is the most 
-    important diagnostics field. You'll find the complete list of ``SQLSTATE`` 
-    values, often called simply *status codes*, at the end of this chapter. 
-    Quite often, the ``SQLSTATE`` class determines whether the other 
-    diagnostics fields have meaningful values. 
+
+    This field gives you a 5-character status code -- remember to allow 6
+    characters because of the null terminator. ``SQLSTATE`` is the most
+    important diagnostics field. You'll find the complete list of ``SQLSTATE``
+    values, often called simply *status codes*, at the end of this chapter.
+    Quite often, the ``SQLSTATE`` class determines whether the other
+    diagnostics fields have meaningful values.
 
 ``0005``
     ::
-    
+
       SQLGetDiagField(...,...,n,SQL_DIAG_NATIVE,&integer,NULL,NULL);
-    
-    This field gives you an integer which has an implementation-defined numeric 
-    code for the error type. If your DBMS has been around for a few years, this 
-    will be the same as the ``SQLCODE`` value. It was once standard for DBMSs 
-    to return ``SQLCODE``, and sometimes (for instance with IBM's DB2) the 
-    ``SQLCODE`` is more informative than the ``SQLSTATE`` value. But there is 
-    no standardized interpretation for the codes, except that values less than 
-    zero are "errors", equal to zero is "success", greater than zero are 
-    "warnings", and specifically +100 is "warning-no data". 
+
+    This field gives you an integer which has an implementation-defined numeric
+    code for the error type. If your DBMS has been around for a few years, this
+    will be the same as the ``SQLCODE`` value. It was once standard for DBMSs
+    to return ``SQLCODE``, and sometimes (for instance with IBM's DB2) the
+    ``SQLCODE`` is more informative than the ``SQLSTATE`` value. But there is
+    no standardized interpretation for the codes, except that values less than
+    zero are "errors", equal to zero is "success", greater than zero are
+    "warnings", and specifically +100 is "warning-no data".
 
 ``0006``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_MESSAGE_TEXT,charstring,sizeof(charstring),
          &charstring_size);
-    
-    This field gives you an error message -- sometimes merely an explanation of 
-    the ``SQLSTATE`` meaning, but the better DBMSs have context-sensitive tips. 
-    Useful for displays. Often, due to an ODBC requirement, messages start with 
-    bracketed information about the server and driver. 
+
+    This field gives you an error message -- sometimes merely an explanation of
+    the ``SQLSTATE`` meaning, but the better DBMSs have context-sensitive tips.
+    Useful for displays. Often, due to an ODBC requirement, messages start with
+    bracketed information about the server and driver.
 
 ``0008``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_CLASS_ORIGIN,charstring,sizeof(charstring),
          &charstring_size);
-    
-    This field gives you the naming authority responsible for the definition of 
-    the class (the first two letters of ``SQLSTATE``). Example: 'ISO 9075' 
-    would mean that the condition is documented in ISO/IEC 9075:1992 and is 
-    therefore "standard". 
+
+    This field gives you the naming authority responsible for the definition of
+    the class (the first two letters of ``SQLSTATE``). Example: 'ISO 9075'
+    would mean that the condition is documented in ISO/IEC 9075:1992 and is
+    therefore "standard".
 
 ``0009``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_SUBCLASS_ORIGIN,charstring,sizeof(charstring),
          &charstring_size);
-    
-    This field gives you the naming authority responsible for the definition of 
-    the subclass (the last three letters of ``SQLSTATE``). Example: 'ODBC 3.0' 
-    would mean that the condition is documented in Microsoft's ODBC manual 
-    version 3.0 but is not in any ISO specification, and is therefore "not 
-    standard". 
+
+    This field gives you the naming authority responsible for the definition of
+    the subclass (the last three letters of ``SQLSTATE``). Example: 'ODBC 3.0'
+    would mean that the condition is documented in Microsoft's ODBC manual
+    version 3.0 but is not in any ISO specification, and is therefore "not
+    standard".
 
 ``0010``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_CONNECTION_NAME,charstring,sizeof(charstring),
          &charstring_size);
-    
-    This field gives you the <Connection name>. With the CLI this field is 
-    of minor importance, because the primary identifier for an 
-    SQL-Connection is the ``hdbc``. 
+
+    This field gives you the <Connection name>. With the CLI this field is
+    of minor importance, because the primary identifier for an
+    SQL-Connection is the ``hdbc``.
 
 ``0011``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_SERVER_NAME,charstring,sizeof(charstring),
          &charstring_size);
-    
-    If the last SQL statement was a failed ``CONNECT``, ``DISCONNECT`` or 
-    ``SET CONNECTION``, this field gives you the server that the attempt 
-    failed with. Otherwise, you get the same information that you'd get by 
-    calling ``SQLGetInfo(...,SQL_DATA_SOURCE_NAME,...)``. 
+
+    If the last SQL statement was a failed ``CONNECT``, ``DISCONNECT`` or
+    ``SET CONNECTION``, this field gives you the server that the attempt
+    failed with. Otherwise, you get the same information that you'd get by
+    calling ``SQLGetInfo(...,SQL_DATA_SOURCE_NAME,...)``.
 
 ``0014``
     ::
-    
+
       SQLGetDiagField(...,...,n,SQL_DIAG_CONDITION_NUMBER,&integer,NULL,NULL);
-    
-    This field gives you the number of the Status Record (the terms 
-    "condition number" and "status record number" are synonymous). This will 
-    be the same thing as the ``RecordNumber`` parameter, so you won't find 
-    out anything new here. 
+
+    This field gives you the number of the Status Record (the terms
+    "condition number" and "status record number" are synonymous). This will
+    be the same thing as the ``RecordNumber`` parameter, so you won't find
+    out anything new here.
 
 ``0015``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_CONSTRAINT_CATALOG,charstring,sizeof(charstring),
          &charstring_size);
 
 ``0016``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_CONSTRAINT_SCHEMA,charstring,sizeof(charstring),
          &charstring_size);
 
 ``0017``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_CONSTRAINT_NAME,charstring,sizeof(charstring),
          &charstring_size);
-    
-    If ``SQLSTATE`` is ``'23000'`` (integrity constraint violation) or 
-    ``'27000'`` (triggered data change violation) or ``'40002'`` 
-    (transaction rollback-integrity constraint violation), then fields 
-    ``0015``, ``0016`` and ``0017`` give you the Catalog, Schema and name of 
-    the violated Constraint. 
+
+    If ``SQLSTATE`` is ``'23000'`` (integrity constraint violation) or
+    ``'27000'`` (triggered data change violation) or ``'40002'``
+    (transaction rollback-integrity constraint violation), then fields
+    ``0015``, ``0016`` and ``0017`` give you the Catalog, Schema and name of
+    the violated Constraint.
 
 ``0018``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_CATALOG_NAME,charstring,sizeof(charstring),
          &charstring_size);
 
 ``0019``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_SCHEMA_NAME,charstring,sizeof(charstring),
          &charstring_size);
 
 ``0020``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_TABLE_NAME,charstring,sizeof(charstring),
          &charstring_size);
 
 ``0021``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_COLUMN_NAME,charstring,sizeof(charstring),
          &charstring_size);
-    
-    Fields ``0018``, ``0019``, ``0020`` and ``0021`` give you the Catalog, 
-    Schema and Table identifiers, plus the Column identifier if applicable, 
-    for what "caused" the problem. If ``SQLSTATE = '23000'`` or ``'27000'`` 
-    or ``'40002'``, these fields will identify the Table that the violated 
-    Constraint is associated with (assuming there is one such Table). If 
-    ``SQLSTATE = '42000'``, this is the Object that couldn't be found or 
-    that you lack Privileges on (the Standard contains some ambiguities 
-    here, but it seems that these fields may be blank for access 
-    violations). If ``SQLSTATE = '44000'``, this is the View that has a 
-    violated ``WITH CHECK OPTION``. If ``SQLSTATE = '09000'`` or 
-    ``'40004'``, this is the Table with the Trigger that can't be executed. 
-    If ``SQLSTATE`` is any other value, results are 
-    implementation-dependent. 
+
+    Fields ``0018``, ``0019``, ``0020`` and ``0021`` give you the Catalog,
+    Schema and Table identifiers, plus the Column identifier if applicable,
+    for what "caused" the problem. If ``SQLSTATE = '23000'`` or ``'27000'``
+    or ``'40002'``, these fields will identify the Table that the violated
+    Constraint is associated with (assuming there is one such Table). If
+    ``SQLSTATE = '42000'``, this is the Object that couldn't be found or
+    that you lack Privileges on (the Standard contains some ambiguities
+    here, but it seems that these fields may be blank for access
+    violations). If ``SQLSTATE = '44000'``, this is the View that has a
+    violated ``WITH CHECK OPTION``. If ``SQLSTATE = '09000'`` or
+    ``'40004'``, this is the Table with the Trigger that can't be executed.
+    If ``SQLSTATE`` is any other value, results are
+    implementation-dependent.
 
 ``0022``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_CURSOR_NAME,charstring,sizeof(charstring),
          &charstring_size);
-    
-    If ``SQLSTATE = '01001'`` or ``'24000'``, this field gives you the 
-    identifier of a Cursor. If ``SQLSTATE`` is anything else, results are 
-    implementation-dependent. 
+
+    If ``SQLSTATE = '01001'`` or ``'24000'``, this field gives you the
+    identifier of a Cursor. If ``SQLSTATE`` is anything else, results are
+    implementation-dependent.
 
 ``0023``
     ::
-    
+
       SQLGetDiagField(...,...,n,SQL_DIAG_MESSAGE_LENGTH,&integer,NULL,NULL);
-    
-    This field gives you the character length of the implementation-defined 
-    message string. You can get the same information using 
-    ``SQL_DIAG_MESSAGE_TEXT``. By the way, the C include file ``sqlcli.h`` 
-    says "``#define SQL_MAXIMUM_MESSAGE_LENGTH 512``" so the suggestion is 
-    that you allow 512 bytes for the message -- but it's only a suggestion. 
-    It might be interesting to compare ``SQL_MAXIMUM_MESSAGE_LENGTH`` with 
-    what ``SQLGetDiagField`` returns for ``SQL_DIAG_MESSAGE_LENGTH``. 
+
+    This field gives you the character length of the implementation-defined
+    message string. You can get the same information using
+    ``SQL_DIAG_MESSAGE_TEXT``. By the way, the C include file ``sqlcli.h``
+    says "``#define SQL_MAXIMUM_MESSAGE_LENGTH 512``" so the suggestion is
+    that you allow 512 bytes for the message -- but it's only a suggestion.
+    It might be interesting to compare ``SQL_MAXIMUM_MESSAGE_LENGTH`` with
+    what ``SQLGetDiagField`` returns for ``SQL_DIAG_MESSAGE_LENGTH``.
 
 ``0024``
     ::
-    
+
       SQLGetDiagField(...,...,n,SQL_DIAG_MESSAGE_OCTET_LENGTH,&integer,NULL,NULL);
-    
-    This field gives you the octet length of the implementation-defined 
-    message string. This will be the same as the message length in 
-    characters if the Character set is 8-bit. 
+
+    This field gives you the octet length of the implementation-defined
+    message string. This will be the same as the message length in
+    characters if the Character set is 8-bit.
 
 ``0025``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_CONDITION_NAME,&charstring,sizeof(charstring),
          &charstring_size);
-    
+
     This field gives you the name of an unhandled user-defined exception.
 
 ``0026``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_PARAMETER_NAME,charstring,sizeof(charstring),
          &charstring_size);
-    
-    This field gives you the name of a parameter -- presumably the parameter 
-    which contained bad (input) data. Since named parameters are not a 
-    universal feature, most DBMSs will not return anything here. 
+
+    This field gives you the name of a parameter -- presumably the parameter
+    which contained bad (input) data. Since named parameters are not a
+    universal feature, most DBMSs will not return anything here.
 
 ``0027``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_ROUTINE_CATALOG,charstring,sizeof(charstring),
          &charstring_size);
 
 ``0028``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_ROUTINE_SCHEMA,charstring,sizeof(charstring),
          &charstring_size);
 
 ``0029``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_ROUTINE_NAME,charstring,sizeof(charstring),
          &charstring_size);
 
 ``0030``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_SPECIFIC_NAME,charstring,sizeof(charstring),
          &charstring_size);
-    
-    If the ``SQLSTATE`` error class is '38' (external routine exception) or 
-    '39' (external routine invocation exception), fields ``0027``, ``0028`` 
-    and ``0029`` give you the full identifier of the routine that "caused" 
-    the error, while field ``0030`` gives you the routine's specific name. 
+
+    If the ``SQLSTATE`` error class is '38' (external routine exception) or
+    '39' (external routine invocation exception), fields ``0027``, ``0028``
+    and ``0029`` give you the full identifier of the routine that "caused"
+    the error, while field ``0030`` gives you the routine's specific name.
 
 ``0031``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_TRIGGER_CATALOG,charstring,sizeof(charstring),
          &charstring_size);
 
 ``0032``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_TRIGGER_SCHEMA,charstring,sizeof(charstring),
          &charstring_size);
 
 ``0033``
     ::
-    
+
       SQLGetDiagField(
          ...,...,n,SQL_DIAG_TRIGGER_NAME,charstring,sizeof(charstring),
          &charstring_size);
-    
-    If ``SQLSTATE='40004'`` or ``'09000'``, fields ``0031``, ``0032`` and 
-    ``0033`` give you the full identifier of the Trigger that "caused" the 
-    problem. 
+
+    If ``SQLSTATE='40004'`` or ``'09000'``, fields ``0031``, ``0032`` and
+    ``0033`` give you the full identifier of the Trigger that "caused" the
+    problem.
 
 **Algorithm:**
 
@@ -712,26 +714,26 @@ Character String Retrieval.
 **Notes:**
 
 * Status Records are sorted according to the severity of the error class:
-  
+
    * Highest: Errors that cause rollback (class '40').
-   
+
    * Lower: Ordinary errors (everything except '40' or '01' or '02').
-   
+
    * Lower: No-data warning (class '02').
-   
+
    * Lowest: Mere warning (class '01').
-  
+
   The first Status Record is thus the most important. If the return code is
   ``SQL_ERROR`` you can be sure that the first Status Record describes an error
   condition.
 
-* The ``SQLSTATE``\s associated with the possible ``SQLGetDiagField`` errors 
-  are only mentioned for documentary reasons. The ``SQLGetDiagField`` function 
-  does not itself post any diagnostics. The way you check for errors is: look 
-  at   the return code, then start guessing. These tips may be useful: 
-  
+* The ``SQLSTATE``\s associated with the possible ``SQLGetDiagField`` errors
+  are only mentioned for documentary reasons. The ``SQLGetDiagField`` function
+  does not itself post any diagnostics. The way you check for errors is: look
+  at   the return code, then start guessing. These tips may be useful:
+
   ::
-  
+
     If (SQLGetDiagField returns SQL_SUCCESS_WITH_INFO)
       Probably the DiagInfo buffer is too small.
       Compare BufferLength (the maximum size of the DiagInfo buffer)
@@ -757,18 +759,18 @@ Character String Retrieval.
       than the value in the diagnostics area's NUMBER field.
       For example: you passed 1 but there are zero status records.
 
-Some header fields always have valid information, even if the last call 
-didn't end with an error or warning. For example, you can find out what the 
-last executed SQL statement was, and how many rows it affected, even if the 
-number of Status Records is zero. 
+Some header fields always have valid information, even if the last call
+didn't end with an error or warning. For example, you can find out what the
+last executed SQL statement was, and how many rows it affected, even if the
+number of Status Records is zero.
 
-The great majority of diagnostics are only applicable to ``stmt``\s. You will 
-only need to get a ``dbc``\'s diagnostics area fields if the last call used a 
-``dbc`` handle, which usually means if the last call was ``connect``, 
-``disconnect``, ``endtran`` or some variants of ``allochandle`` and 
-``freehandle``. As for ``env``\s and ``desc``\s, they too have diagnostics 
-areas, but use of ``SQLGetDiagField`` with ``henv``\s and ``hdesc``\s is 
-esoteric. 
+The great majority of diagnostics are only applicable to ``stmt``\s. You will
+only need to get a ``dbc``\'s diagnostics area fields if the last call used a
+``dbc`` handle, which usually means if the last call was ``connect``,
+``disconnect``, ``endtran`` or some variants of ``allochandle`` and
+``freehandle``. As for ``env``\s and ``desc``\s, they too have diagnostics
+areas, but use of ``SQLGetDiagField`` with ``henv``\s and ``hdesc``\s is
+esoteric.
 
 **Example:**
 
@@ -814,12 +816,12 @@ esoteric.
              name,sizeof(name),&name_size);
     } }
 
-**ODBC:** The ``SQLGetDiagField`` function is new in ODBC 3.0 (older ODBC 
-versions had only ``SQLError`` for getting diagnostics fields). In addition to 
-all the standard options, ODBC has an additional useful-looking one: 
-``SQL_DIAG_CURSOR_ROW_COUNT``, for getting the number of rows in an open 
-Cursor. (ODBC also gives row and Column number within the result set.) ODBC, 
-unlike standard SQL, sorts status records by row number. 
+**ODBC:** The ``SQLGetDiagField`` function is new in ODBC 3.0 (older ODBC
+versions had only ``SQLError`` for getting diagnostics fields). In addition to
+all the standard options, ODBC has an additional useful-looking one:
+``SQL_DIAG_CURSOR_ROW_COUNT``, for getting the number of rows in an open
+Cursor. (ODBC also gives row and Column number within the result set.) ODBC,
+unlike standard SQL, sorts status records by row number.
 
 SQLGetDiagRec
 =============
@@ -838,7 +840,7 @@ SQLGetDiagRec
      SQLSMALLINT BufferLength,            /* 16-bit input */
      SQLSMALLINT *TextLength);            /* 16-bit output */
 
-**Job:** Get ``SQLSTATE``, ``sqlcode`` and error-message from one status 
+**Job:** Get ``SQLSTATE``, ``sqlcode`` and error-message from one status
 record.
 
 **Algorithm:**
@@ -869,28 +871,28 @@ For description of the ``SQL_DIAG_SQLSTATE``, ``SQL_DIAG_NATIVE_ERROR``, and
 
 **Notes:**
 
-* The assumption behind ``SQLGetDiagRec`` is that, when you want diagnostics 
-  information, you specifically want ``SQL_DIAG_SQLSTATE``, 
-  ``SQL_NATIVE_ERROR`` and ``SQL_DIAG_MESSAGE_TEXT`` (both contents and 
-  length). If the assumption is wrong and you want only some of these fields, 
-  or you want other fields, then you might find that ``SQLGetDiagField`` is all 
-  you need. We observed similar assumptions at work when we looked at the 
-  ``desc`` functions, ``SQLGetDescField`` and ``SQLGetDescRec``. 
+* The assumption behind ``SQLGetDiagRec`` is that, when you want diagnostics
+  information, you specifically want ``SQL_DIAG_SQLSTATE``,
+  ``SQL_NATIVE_ERROR`` and ``SQL_DIAG_MESSAGE_TEXT`` (both contents and
+  length). If the assumption is wrong and you want only some of these fields,
+  or you want other fields, then you might find that ``SQLGetDiagField`` is all
+  you need. We observed similar assumptions at work when we looked at the
+  ``desc`` functions, ``SQLGetDescField`` and ``SQLGetDescRec``.
 
-* Calls to ``SQLGetDiagRec`` are frequent after a CLI function returns an 
-  error. That is: 
+* Calls to ``SQLGetDiagRec`` are frequent after a CLI function returns an
+  error. That is:
 
-  
+
   ::
-  
+
      if (SQLfunction(...) < 0)  SQLGetDiagRec(...);
-  
+
   is the normal way of calling.
 
-**Example:** This example shows that ``SQLGetDiagRec`` and ``SQLGetDiagField`` 
-may be similar. The first call retrieves ``dbc``\'s ``SQLSTATE`` using 
-``SQLGetDiagField`` -- we pass ``NULL`` for the final 4 parameters because we 
-don't care about them. 
+**Example:** This example shows that ``SQLGetDiagRec`` and ``SQLGetDiagField``
+may be similar. The first call retrieves ``dbc``\'s ``SQLSTATE`` using
+``SQLGetDiagField`` -- we pass ``NULL`` for the final 4 parameters because we
+don't care about them.
 
 ::
 
@@ -900,13 +902,13 @@ don't care about them.
       SQLGetDiagField(SQL_HANDLE_DBC,hdbc,1,sqlstate,sizeof(sqlstate),NULL);
       SQLGetDiagRec(SQL_HANDLE_DBC,hdbc,1,sqlstate,NULL,NULL,NULL,NULL);
 
-This example shows the minimalist error-handling procedure for applications 
-that are written in a hurry: if anything goes wrong, print a message and stop 
-the program. The symbol ``SQL...`` means "any CLI function". The ``"if 
-(sqlreturn < 0)"`` test uses an assumption (true at the moment) that 
-``SQL_SUCCESS`` and ``SQL_SUCCESS_WITH_INFO`` and ``SQL_NO_DATA`` -- the 
-non-problems -- are all greater than or equal to zero; ``SQL_INVALID_HANDLE`` 
-and ``SQL_NEED_DATA`` and ``SQL_ERROR`` -- the problems -- are less than zero. 
+This example shows the minimalist error-handling procedure for applications
+that are written in a hurry: if anything goes wrong, print a message and stop
+the program. The symbol ``SQL...`` means "any CLI function". The ``"if
+(sqlreturn < 0)"`` test uses an assumption (true at the moment) that
+``SQL_SUCCESS`` and ``SQL_SUCCESS_WITH_INFO`` and ``SQL_NO_DATA`` -- the
+non-problems -- are all greater than or equal to zero; ``SQL_INVALID_HANDLE``
+and ``SQL_NEED_DATA`` and ``SQL_ERROR`` -- the problems -- are less than zero.
 
 ::
 
@@ -964,10 +966,10 @@ This example displays warning or error messages after an execution.
   if (sqlmore) {
     printf("Not all Error/Warning conditions have been displayed!\n"); }
 
-**ODBC:** The ``SQLGetDiagRec`` function is new in ODBC 3.0; applications for 
-earlier ODBC versions use ``SQLError``, which is similar. ODBC example programs 
-often use the names ``SqlState``, ``Msg`` and ``rc`` where we have tended to 
-use ``SQLSTATE``, ``sqlmessage`` and ``sqlreturn``. 
+**ODBC:** The ``SQLGetDiagRec`` function is new in ODBC 3.0; applications for
+earlier ODBC versions use ``SQLError``, which is similar. ODBC example programs
+often use the names ``SqlState``, ``Msg`` and ``rc`` where we have tended to
+use ``SQLSTATE``, ``sqlmessage`` and ``sqlreturn``.
 
 SQLError
 ========
@@ -987,13 +989,13 @@ SQLError
     SQLSMALLINT *TextLength         /* pointer to 16-bit output */
     );
 
-**Job:** Return "diagnostics" -- that is, the completion conditions (warnings) 
-and exception conditions (errors) that are associated with the ``env`` or 
-``dbc`` or ``stmt``. 
+**Job:** Return "diagnostics" -- that is, the completion conditions (warnings)
+and exception conditions (errors) that are associated with the ``env`` or
+``dbc`` or ``stmt``.
 
-Although all standard DBMSs will support it, and although it is an official 
-SQL3 function, ``SQLError`` is obsolete. The modern way to get diagnostics is 
-with ``SQLGetDiagRec`` or ``SQLGetDiagField``. 
+Although all standard DBMSs will support it, and although it is an official
+SQL3 function, ``SQLError`` is obsolete. The modern way to get diagnostics is
+with ``SQLGetDiagRec`` or ``SQLGetDiagField``.
 
 **Algorithm:**
 
@@ -1041,11 +1043,11 @@ with ``SQLGetDiagRec`` or ``SQLGetDiagField``.
       Return status record's SQL_DIAG_NATIVE value, presumably SQLCODE, to
       NativeError.
 
-**Notes:** The last five parameters of ``SQLError`` are the same as the last 
-five parameters of ``SQLGetDiagRec``. The effective difference is that, with 
-``SQLGetDiagRec``, you pass a ``RecordNumber`` parameter, while with 
-``SQLError`` you depend on the DBMS to keep an internal counter -- ``SQLError`` 
-will always retrieve the next status record. 
+**Notes:** The last five parameters of ``SQLError`` are the same as the last
+five parameters of ``SQLGetDiagRec``. The effective difference is that, with
+``SQLGetDiagRec``, you pass a ``RecordNumber`` parameter, while with
+``SQLError`` you depend on the DBMS to keep an internal counter -- ``SQLError``
+will always retrieve the next status record.
 
 **Example:**
 
@@ -1069,8 +1071,8 @@ will always retrieve the next status record.
     /* sqlnative is probably less than zero */
     ...
 
-**ODBC:** The ``SQLError`` function has been around since ODBC 1.0. In ODBC 
-3.0, it is labelled "deprecated" and ODBC's driver manager will map it to 
+**ODBC:** The ``SQLError`` function has been around since ODBC 1.0. In ODBC
+3.0, it is labelled "deprecated" and ODBC's driver manager will map it to
 ``SQLGetDiagRec``.
 
 SQLRowCount
@@ -1098,44 +1100,44 @@ execution of the last ``SQLExecute`` or ``SQLExecDirect`` call.
 
 **Notes:**
 
-* The row count is the number of rows affected when you call ``SQLExecute`` or 
-  ``SQLExecDirect``, and the SQL statement you're executing begins with 
-  ``INSERT`` or ``UPDATE`` or ``DELETE`` (the SQL-data change statements). 
+* The row count is the number of rows affected when you call ``SQLExecute`` or
+  ``SQLExecDirect``, and the SQL statement you're executing begins with
+  ``INSERT`` or ``UPDATE`` or ``DELETE`` (the SQL-data change statements).
 
-* Only directly affected rows matter. If you delete one primary key row, and 
-  there are 10 foreign key rows that are also deleted because the ``FOREIGN 
-  KEY`` Constraint definition includes ``ON DELETE CASCADE``, then a total of 
-  11 rows are deleted: 1 directly, 10 indirectly -- so the ``SQLRowCount`` 
-  function returns 1. 
+* Only directly affected rows matter. If you delete one primary key row, and
+  there are 10 foreign key rows that are also deleted because the ``FOREIGN
+  KEY`` Constraint definition includes ``ON DELETE CASCADE``, then a total of
+  11 rows are deleted: 1 directly, 10 indirectly -- so the ``SQLRowCount``
+  function returns 1.
 
-* Only "searched ``UPDATE``" and "searched ``DELETE``" statements matter. The 
-  ``UPDATE ... WHERE CURRENT OF`` <Cursor> and ``DELETE ... WHERE CURRENT OF`` 
-  <Cursor> statements have no effect on row count. 
+* Only "searched ``UPDATE``" and "searched ``DELETE``" statements matter. The
+  ``UPDATE ... WHERE CURRENT OF`` <Cursor> and ``DELETE ... WHERE CURRENT OF``
+  <Cursor> statements have no effect on row count.
 
-* With some DBMSs, ``SQLRowCount`` will contain the number of rows returned by 
-  the last ``SELECT`` statement. That's very useful if you want to display the 
-  results on the screen along with a Windows scrollbar. If your DBMS won't give 
-  you that, there are other options: *(a)* use a ``SELECT COUNT(*)`` statement 
-  (may be unreliable in a multi-user environment, may fail if selection is of a 
-  grouped View), *(b)* call ``SQLGetDiagField`` with the 
-  ``SQL_DIAG_CURSOR_ROW_COUNT`` option (non-standard, works only with ODBC) or 
-  *(c)* call ``SQLFetchScroll`` until the return is ``SQL_NO_DATA``. 
+* With some DBMSs, ``SQLRowCount`` will contain the number of rows returned by
+  the last ``SELECT`` statement. That's very useful if you want to display the
+  results on the screen along with a Windows scrollbar. If your DBMS won't give
+  you that, there are other options: *(a)* use a ``SELECT COUNT(*)`` statement
+  (may be unreliable in a multi-user environment, may fail if selection is of a
+  grouped View), *(b)* call ``SQLGetDiagField`` with the
+  ``SQL_DIAG_CURSOR_ROW_COUNT`` option (non-standard, works only with ODBC) or
+  *(c)* call ``SQLFetchScroll`` until the return is ``SQL_NO_DATA``.
 
 * You can get the same result by calling:
-  
-  ::
-  
-      SQLGetDiagField(SQL_HANDLE_STMT,hstmt,SQL_DIAG_ROW_COUNT,&RowCount,NULL,NULL);
-  
-  but ``SQLGetDiagField`` only returns results for "the last function", which 
-  means (for instance) that if you've fetched since you executed the ``UPDATE`` 
-  statement, ``SQLGetDiagField`` can't tell you anything. ``SQLRowCount``, 
-  which returns results for "the last ``SQLExecute`` or ``SQLExecDirect`` 
-  function", is better. 
 
-* If the number of changed rows is zero, then ``SQLExecute`` and 
-  ``SQLExecDirect`` both return ``SQL_NO_DATA`` (not ``SQL_SUCCESS`` or 
-  ``SQL_SUCCESS_WITH_INFO``). 
+  ::
+
+      SQLGetDiagField(SQL_HANDLE_STMT,hstmt,SQL_DIAG_ROW_COUNT,&RowCount,NULL,NULL);
+
+  but ``SQLGetDiagField`` only returns results for "the last function", which
+  means (for instance) that if you've fetched since you executed the ``UPDATE``
+  statement, ``SQLGetDiagField`` can't tell you anything. ``SQLRowCount``,
+  which returns results for "the last ``SQLExecute`` or ``SQLExecDirect``
+  function", is better.
+
+* If the number of changed rows is zero, then ``SQLExecute`` and
+  ``SQLExecDirect`` both return ``SQL_NO_DATA`` (not ``SQL_SUCCESS`` or
+  ``SQL_SUCCESS_WITH_INFO``).
 
 **Example:**
 
@@ -1156,65 +1158,65 @@ Standard's ``SQLSTATE`` codes.
 SQLSTATE Codes
 ==============
 
-The SQL status parameter ``SQLSTATE`` is a 5-character string value, with 2 
-parts: the first 2 characters represent a class value, the following 3 
-characters represent a subclass value. ``SQLSTATE`` codes are limited to digits 
-and simple Latin upper-case letters. 
+The SQL status parameter ``SQLSTATE`` is a 5-character string value, with 2
+parts: the first 2 characters represent a class value, the following 3
+characters represent a subclass value. ``SQLSTATE`` codes are limited to digits
+and simple Latin upper-case letters.
 
-Class values that begin with 0, 1, 2, 3, 4, A, B, C, D, E, F, G or H are called 
-*standard-defined classes* and identify status conditions defined in either the 
-SQL Standard or some other international standard. Subclass values associated 
-with standard-defined classes that also begin with one of those 13 characters 
-are called *standard-defined subclasses* and also identify status conditions 
-defined in either the SQL Standard or some other international standard, while 
-subclass values associated with standard-defined classes that begin with 5, 6, 
-7, 8, 9, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y or Z are called 
-*implementation-defined subclasses* and identify status conditions defined by 
-DBMS vendors. 
+Class values that begin with 0, 1, 2, 3, 4, A, B, C, D, E, F, G or H are called
+*standard-defined classes* and identify status conditions defined in either the
+SQL Standard or some other international standard. Subclass values associated
+with standard-defined classes that also begin with one of those 13 characters
+are called *standard-defined subclasses* and also identify status conditions
+defined in either the SQL Standard or some other international standard, while
+subclass values associated with standard-defined classes that begin with 5, 6,
+7, 8, 9, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y or Z are called
+*implementation-defined subclasses* and identify status conditions defined by
+DBMS vendors.
 
-Class values that begin with 5, 6, 7, 8, 9, I, J, K, L, M, N, O, P, Q, R, S, T, 
-U, V, W, X, Y or Z are called *implementation-defined classes* and identify 
-exception conditions defined by DBMS vendors. All subclass values except '000' 
-(no subclass) associated with implementation-defined classes are 
-implementation-defined subclasses. An implementation-defined completion 
-condition is identified by returning an implementation-defined subclass 
-together with one of the ``SUCCESSFUL COMPLETION``, ``WARNING`` or ``NO DATA`` 
-classes. 
+Class values that begin with 5, 6, 7, 8, 9, I, J, K, L, M, N, O, P, Q, R, S, T,
+U, V, W, X, Y or Z are called *implementation-defined classes* and identify
+exception conditions defined by DBMS vendors. All subclass values except '000'
+(no subclass) associated with implementation-defined classes are
+implementation-defined subclasses. An implementation-defined completion
+condition is identified by returning an implementation-defined subclass
+together with one of the ``SUCCESSFUL COMPLETION``, ``WARNING`` or ``NO DATA``
+classes.
 
-If a subclass value is not specified for a condition, then either subclass 
-'000' or an implementation-defined subclass is returned. 
+If a subclass value is not specified for a condition, then either subclass
+'000' or an implementation-defined subclass is returned.
 
-If multiple conditions are returned, then your DBMS decides which condition is 
-the one that will be returned in the ``SQLSTATE`` parameter. (Any number of 
-condition values, in addition to ``SQLSTATE``, may be returned in the 
-diagnostics area.) 
+If multiple conditions are returned, then your DBMS decides which condition is
+the one that will be returned in the ``SQLSTATE`` parameter. (Any number of
+condition values, in addition to ``SQLSTATE``, may be returned in the
+diagnostics area.)
 
-Using the CLI, you can retrieve ``SQLSTATE`` with one of the diagnostics 
-functions (``SQLGetDiagField``, ``SQLGetDiagRec`` or ``SQLError``). Using 
-embedded SQL, you can retrieve ``SQLSTATE`` with ``GET DIAGNOSTICS``, or you 
-can let the DBMS fill it in automatically. Since the status codes are 
-reasonably standard, application programmers can anticipate what ``SQLSTATE`` 
-values may crop up, and they can write appropriate error-testing or descriptive 
-routines. The rest of this chapter contains detailed descriptions for all 
-``SQLSTATE``\s which are defined in the SQL Standard, as well as summary 
-information about some ``SQLSTATE``\s which are used in common application 
-environments, such as ODBC. 
+Using the CLI, you can retrieve ``SQLSTATE`` with one of the diagnostics
+functions (``SQLGetDiagField``, ``SQLGetDiagRec`` or ``SQLError``). Using
+embedded SQL, you can retrieve ``SQLSTATE`` with ``GET DIAGNOSTICS``, or you
+can let the DBMS fill it in automatically. Since the status codes are
+reasonably standard, application programmers can anticipate what ``SQLSTATE``
+values may crop up, and they can write appropriate error-testing or descriptive
+routines. The rest of this chapter contains detailed descriptions for all
+``SQLSTATE``\s which are defined in the SQL Standard, as well as summary
+information about some ``SQLSTATE``\s which are used in common application
+environments, such as ODBC.
 
-We suggest you examine the list of ``SQLSTATE`` codes and decide which warnings 
-and errors you must take specific action for. Make a case statement which will 
-be executed after each SQL operation. If you are programming for ODBC 3.x, 
-don't worry about the obsolete ODBC 2.0 entries in the list -- Microsoft's 
-driver manager will translate them to the current standardized value. If you 
-use the list in conjunction with some vendor manual, you will probably notice 
-that our descriptions are more specific and detailed; however, you should 
-prefer the vendor's description in case of outright contradiction. For casual 
-users, the DBMS's in-context error-message displays, accompanied by a pointer 
-to the offending SQL statement, will suffice. But that is an "after-the-fact" 
-proposition. If your job is to program for errors that haven't happened yet, 
-you need a complete list with some examples and explanations for every entry. 
+We suggest you examine the list of ``SQLSTATE`` codes and decide which warnings
+and errors you must take specific action for. Make a case statement which will
+be executed after each SQL operation. If you are programming for ODBC 3.x,
+don't worry about the obsolete ODBC 2.0 entries in the list -- Microsoft's
+driver manager will translate them to the current standardized value. If you
+use the list in conjunction with some vendor manual, you will probably notice
+that our descriptions are more specific and detailed; however, you should
+prefer the vendor's description in case of outright contradiction. For casual
+users, the DBMS's in-context error-message displays, accompanied by a pointer
+to the offending SQL statement, will suffice. But that is an "after-the-fact"
+proposition. If your job is to program for errors that haven't happened yet,
+you need a complete list with some examples and explanations for every entry.
 
-Here is an example of a tiny C program (runnable in a DOS box) with one 
-embedded SQL statement, followed by a case statement that checks for an error: 
+Here is an example of a tiny C program (runnable in a DOS box) with one
+embedded SQL statement, followed by a case statement that checks for an error:
 
 ::
 
@@ -1248,108 +1250,108 @@ embedded SQL statement, followed by a case statement that checks for an error:
 The following ``SQLSTATE`` codes identify a successful completion condition.
 
 ``00000  successful completion``
-    The "successful completion" class identifies "completion conditions" (as 
-    opposed to "exception conditions", which are errors). In the case of 
-    ``SQLSTATE 00000``, the last SQL operation sailed through without a 
-    problem. The ``00000`` status code is invisible to CLI programs because 
-    the Standard says: if the return code ``= SQL_SUCCESS``, then no status 
-    records are generated. 
+    The "successful completion" class identifies "completion conditions" (as
+    opposed to "exception conditions", which are errors). In the case of
+    ``SQLSTATE 00000``, the last SQL operation sailed through without a
+    problem. The ``00000`` status code is invisible to CLI programs because
+    the Standard says: if the return code ``= SQL_SUCCESS``, then no status
+    records are generated.
 
 *WARNING SQLSTATEs*
 -------------------
 
-The following ``SQLSTATE`` codes identify a successful completion condition 
-with a warning. 
+The following ``SQLSTATE`` codes identify a successful completion condition
+with a warning.
 
-``01000 warning`` 
-    The "warning" class identifies completion conditions that were processed 
-    with some type of warning. They are usually associated with some 
-    DBMS-specific informational message, which you can retrieve with 
-    ``SQLGetDiagRec`` or ``GET DIAGNOSTICS``. In the CLI, the existence of a 
-    warning diagnostic is signalled by the ``SQLRETURN`` value 
-    ``SQL_SUCCESS_WITH_INFO (1)``. ``SQLSTATE 01000`` is the 
-    miscellaneous-warning category. For completion conditions that fit in 
-    the warning class, but don't fit in one of the subclasses listed below 
-    (such as ``01001``), this is what you'll get. Suggestion for this 
-    ``SQLSTATE``: get the message with ``SQLGetDiagRec``, display the 
-    message and continue. 
+``01000 warning``
+    The "warning" class identifies completion conditions that were processed
+    with some type of warning. They are usually associated with some
+    DBMS-specific informational message, which you can retrieve with
+    ``SQLGetDiagRec`` or ``GET DIAGNOSTICS``. In the CLI, the existence of a
+    warning diagnostic is signalled by the ``SQLRETURN`` value
+    ``SQL_SUCCESS_WITH_INFO (1)``. ``SQLSTATE 01000`` is the
+    miscellaneous-warning category. For completion conditions that fit in
+    the warning class, but don't fit in one of the subclasses listed below
+    (such as ``01001``), this is what you'll get. Suggestion for this
+    ``SQLSTATE``: get the message with ``SQLGetDiagRec``, display the
+    message and continue.
 
-``01001 warning-cursor operation conflict`` 
-    This ``SQLSTATE`` was included in the SQL-92 Standard by mistake; the 
-    corrigendum bulletin #3 says it should only be an SQL3 ``SQLSTATE``. The 
-    NIST tests expect DBMSs to return ``SQLSTATE=01001`` if you ``DELETE`` 
-    with and without a Cursor in the same transaction. 
+``01001 warning-cursor operation conflict``
+    This ``SQLSTATE`` was included in the SQL-92 Standard by mistake; the
+    corrigendum bulletin #3 says it should only be an SQL3 ``SQLSTATE``. The
+    NIST tests expect DBMSs to return ``SQLSTATE=01001`` if you ``DELETE``
+    with and without a Cursor in the same transaction.
 
-``01002 warning-disconnect error`` 
-    There was an error during execution of the CLI function 
-    ``SQLDisconnect``, but you won't be able to see the details because the 
-    ``SQLDisconnect`` succeeded. 
+``01002 warning-disconnect error``
+    There was an error during execution of the CLI function
+    ``SQLDisconnect``, but you won't be able to see the details because the
+    ``SQLDisconnect`` succeeded.
 
-``01003 warning-null value eliminated in set function`` 
-    The set function had to ignore a ``NULL`` when working on its argument. 
-    For example, the ``SUM`` of 5 and ``NULL`` is 5 (not ``NULL``), but 
-    ``01003`` warns you that the result may be inaccurate because ``NULL`` 
-    usually means "unknown". 
+``01003 warning-null value eliminated in set function``
+    The set function had to ignore a ``NULL`` when working on its argument.
+    For example, the ``SUM`` of 5 and ``NULL`` is 5 (not ``NULL``), but
+    ``01003`` warns you that the result may be inaccurate because ``NULL``
+    usually means "unknown".
 
-``01004 warning-string data, right truncation`` 
-    Happens when you try to squeeze a 5-character (or bit) value into a 
-    4-character (or bit) space (remember that "string" can be either 
-    character or bit string). The truncation should happen for data outbound 
-    from the database to a host variable, for example in the statement 
-    ``"SELECT ... INTO :x"``. It should not happen for data inbound to the 
-    database -- that would be not a warning but an error (``22001``). 
+``01004 warning-string data, right truncation``
+    Happens when you try to squeeze a 5-character (or bit) value into a
+    4-character (or bit) space (remember that "string" can be either
+    character or bit string). The truncation should happen for data outbound
+    from the database to a host variable, for example in the statement
+    ``"SELECT ... INTO :x"``. It should not happen for data inbound to the
+    database -- that would be not a warning but an error (``22001``).
 
-``01005 warning-insufficient data item descriptor areas`` 
-    Every descriptor area has multiple IDAs. You need one IDA per Column of 
-    a result set, or one per parameter. Either reduce the number of Columns 
-    in the select list or reduce the number of ?s in the SQL statement as a 
-    whole. 
+``01005 warning-insufficient data item descriptor areas``
+    Every descriptor area has multiple IDAs. You need one IDA per Column of
+    a result set, or one per parameter. Either reduce the number of Columns
+    in the select list or reduce the number of ?s in the SQL statement as a
+    whole.
 
-``01006 warning-privilege not revoked`` 
-    There is no Privilege descriptor for a combination of: this grantor, 
-    this grantee, this action. The DBMS does not return an error if a 
-    Privilege revocation fails -- instead, it revokes whatever Privileges it 
-    can and returns this warning. If an equivalent Privilege was granted by 
-    a different grantor, it continues to exist, but warning ``01006`` does 
-    not appear. 
+``01006 warning-privilege not revoked``
+    There is no Privilege descriptor for a combination of: this grantor,
+    this grantee, this action. The DBMS does not return an error if a
+    Privilege revocation fails -- instead, it revokes whatever Privileges it
+    can and returns this warning. If an equivalent Privilege was granted by
+    a different grantor, it continues to exist, but warning ``01006`` does
+    not appear.
 
-``01007 warning-privilege not granted`` 
-    Probably the grantor doesn't hold a Privilege ``WITH GRANT OPTION``. For 
-    example: Susan has the ``UPDATE`` Privilege on ``TABLE_1`` (without 
-    grant option) and the ``INSERT`` Privilege on ``TABLE_1`` (``WITH GRANT 
-    OPTION``). She says: ``"GRANT SELECT, INSERT, UPDATE ON Table_1 TO 
-    Joe;"``. Result: Joe gets the ``INSERT`` Privilege, but not the 
-    ``SELECT`` or ``UPDATE`` Privileges, hence this warning (some DBMSs will 
-    generate the warning twice because two Privileges are ungranted). 
-    Warning ``01007`` also appears if the grantor has zero Privileges ``WITH 
-    GRANT OPTION``, and says ``"GRANT ALL PRIVILEGES ..."``. On the other 
-    hand, if the grantor holds zero Privileges period, the result is error 
-    ``42000`` instead of warning ``01007``. 
+``01007 warning-privilege not granted``
+    Probably the grantor doesn't hold a Privilege ``WITH GRANT OPTION``. For
+    example: Susan has the ``UPDATE`` Privilege on ``TABLE_1`` (without
+    grant option) and the ``INSERT`` Privilege on ``TABLE_1`` (``WITH GRANT
+    OPTION``). She says: ``"GRANT SELECT, INSERT, UPDATE ON Table_1 TO
+    Joe;"``. Result: Joe gets the ``INSERT`` Privilege, but not the
+    ``SELECT`` or ``UPDATE`` Privileges, hence this warning (some DBMSs will
+    generate the warning twice because two Privileges are ungranted).
+    Warning ``01007`` also appears if the grantor has zero Privileges ``WITH
+    GRANT OPTION``, and says ``"GRANT ALL PRIVILEGES ..."``. On the other
+    hand, if the grantor holds zero Privileges period, the result is error
+    ``42000`` instead of warning ``01007``.
 
 ``01008  warning-implicit zero-bit padding``
-    Suppose you insert ``B'1'`` -- a one-bit binary <literal> -- into a 
-    two-bit Column. The second bit will be a 0, and the DBMS will return 
-    this warning. 
+    Suppose you insert ``B'1'`` -- a one-bit binary <literal> -- into a
+    two-bit Column. The second bit will be a 0, and the DBMS will return
+    this warning.
 
 ``01009  warning-search condition too long for information schema``
-    Suppose you say "``CREATE TABLE ... CHECK`` (<condition>)", and the 
-    length of <condition> is larger than what can be stored in the 
-    ``INFORMATION_SCHEMA`` View, ``CHECK_CONSTRAINTS``, in its 
-    ``CHECK_CLAUSE`` Column. The Table will still be created -- this warning 
-    only means you won't be able to see the entire information about the 
-    Table when you look at ``INFORMATION_SCHEMA``. See also: ``0100A`` and 
-    ``0100B``. 
+    Suppose you say "``CREATE TABLE ... CHECK`` (<condition>)", and the
+    length of <condition> is larger than what can be stored in the
+    ``INFORMATION_SCHEMA`` View, ``CHECK_CONSTRAINTS``, in its
+    ``CHECK_CLAUSE`` Column. The Table will still be created -- this warning
+    only means you won't be able to see the entire information about the
+    Table when you look at ``INFORMATION_SCHEMA``. See also: ``0100A`` and
+    ``0100B``.
 
-``0100A warning-query expression too long for information schema`` 
-    This is the same as warning ``01009`` except that instead of a search 
-    condition (as in a ``CHECK`` clause), you're using a query condition 
-    (usually ``SELECT``). Thus, if you say ``"CREATE VIEW ..."`` with a very 
-    long query, the size of Column ``VIEW_DEFINITION`` in View ``VIEWS`` in 
-    ``INFORMATION_SCHEMA`` is a limiting factor. 
+``0100A warning-query expression too long for information schema``
+    This is the same as warning ``01009`` except that instead of a search
+    condition (as in a ``CHECK`` clause), you're using a query condition
+    (usually ``SELECT``). Thus, if you say ``"CREATE VIEW ..."`` with a very
+    long query, the size of Column ``VIEW_DEFINITION`` in View ``VIEWS`` in
+    ``INFORMATION_SCHEMA`` is a limiting factor.
 
 ``0100B  warning-default value too long for information schema``
-    This is the same as warning ``01009`` except that instead of a search 
-    condition (as in a ``CHECK`` clause), you're using a default value. 
+    This is the same as warning ``01009`` except that instead of a search
+    condition (as in a ``CHECK`` clause), you're using a default value.
 
 ``0100C  warning-dynamic result sets returned``
 
@@ -1365,81 +1367,81 @@ with a warning.
     The author of the external routine chooses the subclass value of ``xx``.
 
 ``01S00  warning-invalid connection string attribute`` (ODBC 2+3)
-    The ODBC function ``SQLBrowseConnect`` or ``SQLDriverConnect`` requires a 
+    The ODBC function ``SQLBrowseConnect`` or ``SQLDriverConnect`` requires a
     parameter string with a certain format. Connection happens anyway.
 
 ``01S01  warning-error in row`` (ODBC 3)
-    With ODBC 3.x, this warning happens only for ``SQLExtendedFetch`` or for 
-    ``SQLFetchScroll``. Although an "error" has happened, this is only a 
-    warning because other rows might have been returned without error. 
+    With ODBC 3.x, this warning happens only for ``SQLExtendedFetch`` or for
+    ``SQLFetchScroll``. Although an "error" has happened, this is only a
+    warning because other rows might have been returned without error.
 
 ``01S02  warning-option value changed`` (ODBC 3)
-    You used an ODBC function to change an option (e.g.: ``SQLSetEnvAttr``). 
-    This warns you that the change occurred. 
+    You used an ODBC function to change an option (e.g.: ``SQLSetEnvAttr``).
+    This warns you that the change occurred.
 
 ``01S06  warning-attempt to fetch before the result set returned the first rowset`` (ODBC 3)
-    It would be clearer to use this wording: "attempt to fetch before the 
-    first row in the result set". This error would be returned if your last 
-    fetch was of the first row in the result set and now you attempt to 
-    fetch ``PRIOR``. 
+    It would be clearer to use this wording: "attempt to fetch before the
+    first row in the result set". This error would be returned if your last
+    fetch was of the first row in the result set and now you attempt to
+    fetch ``PRIOR``.
 
 ``01S07  warning-fractional truncation`` (ODBC 3)
-    You'll get this error if, for example, you assigned the value 5.432 to a 
-    Column whose definition is ``DECIMAL(3,2)`` -- that is, the scale of the 
-    target is 2 and the scale of the source is 3, so only 5.4 is stored. A 
-    problem with the non-fractional part would result in another SQLSTATE: 
-    ``22003``. 
+    You'll get this error if, for example, you assigned the value 5.432 to a
+    Column whose definition is ``DECIMAL(3,2)`` -- that is, the scale of the
+    target is 2 and the scale of the source is 3, so only 5.4 is stored. A
+    problem with the non-fractional part would result in another SQLSTATE:
+    ``22003``.
 
 ``01S08  warning-error saving file DSN`` (ODBC 3)
     A warning from ``SQLDriverConnect``. The Connection succeeds, but the file
     indicated by the FILEDSN keyword was not saved.
 
 ``01S09  warning-invalid keyword`` (ODBC 3)
-    A warning from ``SQLDriverConnect``. The Connection succeeds, but the 
+    A warning from ``SQLDriverConnect``. The Connection succeeds, but the
     ``SAVEFILE`` keyword was ignored.
 
 *NO DATA SQLSTATEs*
 -------------------
 
-The following ``SQLSTATE`` codes identify a successful completion condition 
+The following ``SQLSTATE`` codes identify a successful completion condition
 where no data has been found that matches the given criteria.
 
 ``02000 no data``
-    The "data not found" class identifies completion conditions that were 
-    processed without any data that matched the given criteria being found. 
-    If the status code is class 02, then the return code will be 
-    ``SQL_NO_DATA``. Most programs do not look for status records if the 
-    return code is ``SQL_NO_DATA``, but there is a slight chance that a 
-    warning exists. The DBMS does not make a status record for ``SQLSTATE 
-    02000``, but it might make status records for implementation-defined 
-    subclasses within class 02. ``SQLSTATE 02000`` goes together with 
-    ``sqlcode = +100`` and return code ``= SQL_NO_DATA``. There are several 
-    scenarios which lead to ``SQLSTATE 02000``: 
-    
-    * fetches -- If the Cursor position is now past the last row, or before the 
-      first row in the result set -- e.g.: due to a 
-      ``SQLFetchScroll(...,SQL_PRIOR,...)`` call when Cursor was on first row 
-      of the result set. 
-    
-    * updates -- Zero rows were affected by an ``INSERT``, ``UPDATE`` or 
-      ``DELETE`` statement. 
-    
-    * diagnostics -- No status record corresponds to the ``RecordNumber`` 
-      parameter. 
-    
-    * ``desc`` functions -- No item descriptor area corresponds to the 
-      ``RecordNumber`` parameter 
-    
-    * in general -- Whenever you ask for data, and there is no data. 
-    
-    In the CLI, the DBMS does not generate status records for 
-    ``SQLSTATE=02000``. The only way to check for "no data" is to look at the 
+    The "data not found" class identifies completion conditions that were
+    processed without any data that matched the given criteria being found.
+    If the status code is class 02, then the return code will be
+    ``SQL_NO_DATA``. Most programs do not look for status records if the
+    return code is ``SQL_NO_DATA``, but there is a slight chance that a
+    warning exists. The DBMS does not make a status record for ``SQLSTATE
+    02000``, but it might make status records for implementation-defined
+    subclasses within class 02. ``SQLSTATE 02000`` goes together with
+    ``sqlcode = +100`` and return code ``= SQL_NO_DATA``. There are several
+    scenarios which lead to ``SQLSTATE 02000``:
+
+    * fetches -- If the Cursor position is now past the last row, or before the
+      first row in the result set -- e.g.: due to a
+      ``SQLFetchScroll(...,SQL_PRIOR,...)`` call when Cursor was on first row
+      of the result set.
+
+    * updates -- Zero rows were affected by an ``INSERT``, ``UPDATE`` or
+      ``DELETE`` statement.
+
+    * diagnostics -- No status record corresponds to the ``RecordNumber``
+      parameter.
+
+    * ``desc`` functions -- No item descriptor area corresponds to the
+      ``RecordNumber`` parameter
+
+    * in general -- Whenever you ask for data, and there is no data.
+
+    In the CLI, the DBMS does not generate status records for
+    ``SQLSTATE=02000``. The only way to check for "no data" is to look at the
     return code.
 
 ``02001  no data-no additional result sets returned``
-    It is possible for a ``CALL`` statement to produce multiple result sets, 
-    but in this case there are no more. ``02001`` is possible if the 
-    function is ``SQLMoreResults``. 
+    It is possible for a ``CALL`` statement to produce multiple result sets,
+    but in this case there are no more. ``02001`` is possible if the
+    function is ``SQLMoreResults``.
 
 *ERROR SQLSTATEs*
 -----------------
@@ -1448,151 +1450,151 @@ The following ``SQLSTATE`` codes identify an exception condition: something is
 preventing an SQL statement from being successfully completed.
 
 ``03000  SQL statement not yet complete``
-    The "SQL statement not yet complete" class identifies exception 
-    conditions that relate to incomplete processing of SQL statements. 
+    The "SQL statement not yet complete" class identifies exception
+    conditions that relate to incomplete processing of SQL statements.
 
 ``07000  dynamic SQL error``
-    The "dynamic SQL error" class identifies exception conditions that 
-    relate to dynamic SQL processing errors. 
+    The "dynamic SQL error" class identifies exception conditions that
+    relate to dynamic SQL processing errors.
 
 ``07001  dynamic SQL error-using clause does not match dynamic parameters``
-    You might encounter this error if you set the length of a descriptor, 
-    then ``EXECUTE ... USING`` <descriptor>. Often this exception results 
-    from consistency-check failure during ``SQLExecute``: see ``SQLSTATE 
-    HY021``. In ODBC, the name for this subclass is "wrong number of 
-    parameters". 
+    You might encounter this error if you set the length of a descriptor,
+    then ``EXECUTE ... USING`` <descriptor>. Often this exception results
+    from consistency-check failure during ``SQLExecute``: see ``SQLSTATE
+    HY021``. In ODBC, the name for this subclass is "wrong number of
+    parameters".
 
 ``07002  dynamic SQL error-using clause does not match target specifications``
-    Often this exception results from consistency-check failure during 
-    ``SQLExecute``: see ``SQLSTATE HY021``. Sometimes this exception results 
-    from an incorrect number of parameters -- but see also: ``SQLSTATE 
-    07008``. In ODBC, the name for this subclass is "``COUNT`` field 
-    incorrect". 
+    Often this exception results from consistency-check failure during
+    ``SQLExecute``: see ``SQLSTATE HY021``. Sometimes this exception results
+    from an incorrect number of parameters -- but see also: ``SQLSTATE
+    07008``. In ODBC, the name for this subclass is "``COUNT`` field
+    incorrect".
 
 ``07003  dynamic SQL error-cursor specification cannot be executed``
 
 ``07004  dynamic SQL error-using clause required for dynamic parameters``
-    You cannot simply ``EXECUTE`` an SQL statement which has dynamic 
-    parameters -- you also need to use a ``USING`` clause. See also: 
-    ``SQLSTATE 07007``. 
+    You cannot simply ``EXECUTE`` an SQL statement which has dynamic
+    parameters -- you also need to use a ``USING`` clause. See also:
+    ``SQLSTATE 07007``.
 
 ``07005  dynamic SQL error-prepared statement not a cursor-specification``
-    This results from an attempt to use ODBC function ``SQLColAttribute`` or 
-    ``SQLDescribeCol`` for an SQL statement that returned no result set, or 
-    from using "``DECLARE CURSOR``" followed by a prepare or execute of an 
-    SQL statement that does not return a result set. 
+    This results from an attempt to use ODBC function ``SQLColAttribute`` or
+    ``SQLDescribeCol`` for an SQL statement that returned no result set, or
+    from using "``DECLARE CURSOR``" followed by a prepare or execute of an
+    SQL statement that does not return a result set.
 
 ``07006  dynamic SQL error-restricted data type attribute violation``
-    You are using a parameter whose value does not match the <data type>; 
-    the DBMS cannot even try to ``CAST`` to the correct <data type> because 
-    the source and target are too different. For example, you have a host 
-    variable defined as ``SQLINTEGER``, you have a Column containing a 
-    ``TIMESTAMP`` and you try to fetch that Column into the host variable. 
-    With CLI, this might mean that you forgot to re-bind the parameters when 
-    you prepared a new SQL statement. 
+    You are using a parameter whose value does not match the <data type>;
+    the DBMS cannot even try to ``CAST`` to the correct <data type> because
+    the source and target are too different. For example, you have a host
+    variable defined as ``SQLINTEGER``, you have a Column containing a
+    ``TIMESTAMP`` and you try to fetch that Column into the host variable.
+    With CLI, this might mean that you forgot to re-bind the parameters when
+    you prepared a new SQL statement.
 
 ``07007  dynamic SQL error-using clause required for result fields``
-    You cannot simply ``EXECUTE`` an SQL statement which has result fields 
-    -- you also need to use a ``USING`` clause. See also: ``SQLSTATE 
-    07004``. 
+    You cannot simply ``EXECUTE`` an SQL statement which has result fields
+    -- you also need to use a ``USING`` clause. See also: ``SQLSTATE
+    07004``.
 
 ``07008  dynamic SQL error-invalid descriptor count``
-    Using the embedded ``SQL ALLOCATE DESCRIPTOR`` statement, you allocated 
-    a 5-item descriptor. Now you are trying to use the sixth item in that 
-    descriptor. See also: ``SQLSTATE 07009``. 
+    Using the embedded ``SQL ALLOCATE DESCRIPTOR`` statement, you allocated
+    a 5-item descriptor. Now you are trying to use the sixth item in that
+    descriptor. See also: ``SQLSTATE 07009``.
 
 ``07009  dynamic SQL error-invalid descriptor index``
-    You are using a CLI descriptor function (such as ``SQLBindCol`` or 
-    ``SQLBindParameter``) and the Column number is less than 1 or greater 
-    than the maximum number of Columns. Or, you are using the embedded SQL 
-    ``ALLOCATE DESCRIPTOR`` statement with a size which is less than 1 or 
-    greater than an implementation-defined maximum. See also: ``SQLSTATE 
-    07008``. 
+    You are using a CLI descriptor function (such as ``SQLBindCol`` or
+    ``SQLBindParameter``) and the Column number is less than 1 or greater
+    than the maximum number of Columns. Or, you are using the embedded SQL
+    ``ALLOCATE DESCRIPTOR`` statement with a size which is less than 1 or
+    greater than an implementation-defined maximum. See also: ``SQLSTATE
+    07008``.
 
 ``07S01  dynamic SQL error-invalid use of default parameter``
-    You used ``SQLBindParameter`` with ``SQL_DEFAULT_PARAMETER``, but now it 
-    turns out that the parameter does not have a default value. 
+    You used ``SQLBindParameter`` with ``SQL_DEFAULT_PARAMETER``, but now it
+    turns out that the parameter does not have a default value.
 
 ``08000  connection exception``
-    The "connection exception" class identifies exception conditions that 
-    relate to SQL-Connections. 
+    The "connection exception" class identifies exception conditions that
+    relate to SQL-Connections.
 
 ``08001  connection exception-SQL-client unable to establish SQL-connection``
-    The client could not get in touch with the server -- perhaps there is no 
-    such server or perhaps the network is busy. 
+    The client could not get in touch with the server -- perhaps there is no
+    such server or perhaps the network is busy.
 
 ``08002  connection exception-connection name in use``
-    The name of an SQL-Connection must be unique. With standard SQL, this 
-    would happen if you said "``CONNECT ... AS 'X' ...``" twice (only one 
-    ``X`` at a time, please). 
+    The name of an SQL-Connection must be unique. With standard SQL, this
+    would happen if you said "``CONNECT ... AS 'X' ...``" twice (only one
+    ``X`` at a time, please).
 
 ``08003  connection exception-connection does not exist``
-    You are trying to use a connection-related function (such as 
-    ``SQLGetConnectAttr``) but the SQL-Connection is not open. Or, you said 
-    "``DISCONNECT 'X'``" and either ``X`` was never connected, or has 
-    already been disconnected. If the call is 
-    ``SQLAllocHandle(SQL_HANDLE_STMT,...)``, ``&hstmt`` is set to zero. You 
-    can get diagnostics from the ``hdbc``. 
+    You are trying to use a connection-related function (such as
+    ``SQLGetConnectAttr``) but the SQL-Connection is not open. Or, you said
+    "``DISCONNECT 'X'``" and either ``X`` was never connected, or has
+    already been disconnected. If the call is
+    ``SQLAllocHandle(SQL_HANDLE_STMT,...)``, ``&hstmt`` is set to zero. You
+    can get diagnostics from the ``hdbc``.
 
 ``08004  connection exception-SQL-server rejected establishment of SQL-connection``
-    You'll get this error if, for example, the ``SQLConnect`` function was 
-    unsuccessful. The server might not like the password, or it might 
-    already be handling the maximum number of clients. 
+    You'll get this error if, for example, the ``SQLConnect`` function was
+    unsuccessful. The server might not like the password, or it might
+    already be handling the maximum number of clients.
 
 ``08006  connection exception-connection failure``
-    This occurs for a ``SET CONNECTION`` statement, where the argument is 
-    presumably a dormant Connection. The failure might be due to a server 
-    failure that occurred while the Connection was dormant. The ``SET 
-    CONNECTION`` might be implicit -- for example, a ``DISCONNECT`` 
-    statement might result in an attempt to re-establish the last dormant 
-    Connection. 
+    This occurs for a ``SET CONNECTION`` statement, where the argument is
+    presumably a dormant Connection. The failure might be due to a server
+    failure that occurred while the Connection was dormant. The ``SET
+    CONNECTION`` might be implicit -- for example, a ``DISCONNECT``
+    statement might result in an attempt to re-establish the last dormant
+    Connection.
 
 ``08007  connection exception-transaction resolution unknown``
-    While you were trying to ``COMMIT``, you were cut off. This is a bad 
-    one, because you are not told whether the transaction finished 
-    successfully or not. The ODBC manual calls this error "Connection 
-    failure during transaction" and implies that it can happen for 
-    ``ROLLBACK`` too. 
+    While you were trying to ``COMMIT``, you were cut off. This is a bad
+    one, because you are not told whether the transaction finished
+    successfully or not. The ODBC manual calls this error "Connection
+    failure during transaction" and implies that it can happen for
+    ``ROLLBACK`` too.
 
 ``08S01  connection exception-communication link failure`` (ODBC 2+3)
-    This can happen during execution of pretty well any ODBC function. 
-    Perhaps there was a hiccup on a phone line. 
+    This can happen during execution of pretty well any ODBC function.
+    Perhaps there was a hiccup on a phone line.
 
 ``09000   triggered action exception``
-    The "triggered action exception" class identifies exception conditions 
-    that relate to Triggers. 
+    The "triggered action exception" class identifies exception conditions
+    that relate to Triggers.
 
 ``0A000  feature not supported``
-    The "feature not supported" class identifies exception conditions that 
-    relate to features you're trying to use, but that your DBMS hasn't 
-    implemented. The Standard does not specify what will cause this 
-    ``SQLSTATE``, possibly because the expectation is that all features will 
-    be supported. If the feature is ODBC-related, see also: ``SQLSTATE 
-    IM001``, ``HYC00``. 
+    The "feature not supported" class identifies exception conditions that
+    relate to features you're trying to use, but that your DBMS hasn't
+    implemented. The Standard does not specify what will cause this
+    ``SQLSTATE``, possibly because the expectation is that all features will
+    be supported. If the feature is ODBC-related, see also: ``SQLSTATE
+    IM001``, ``HYC00``.
 
 ``0A001  feature not supported-multiple server transactions``
-    The meaning is "a single transaction cannot be performed on multiple 
-    servers". Such a feature is sophisticated and rare. 
+    The meaning is "a single transaction cannot be performed on multiple
+    servers". Such a feature is sophisticated and rare.
 
 ``0B000  invalid transaction initiation``
     The "invalid transaction initiation" class identifies exception conditions
     that relate to beginning a transaction.
 
 ``0D000  invalid target type specification``
-    The "invalid target type specification" class identifies exception 
-    conditions that relate to specifying a target for data. 
+    The "invalid target type specification" class identifies exception
+    conditions that relate to specifying a target for data.
 
 ``0E000  invalid schema name list specification``
     The "invalid schema name list specification" class identifies exception
     conditions that relate to specifying Schema paths.
 
 ``0F000  locator exception``
-    The "locator exception" class identifies exception conditions that 
-    relate to locators: ``BLOB`` and ``CLOB`` <data type>s, and their 
-    values. 
+    The "locator exception" class identifies exception conditions that
+    relate to locators: ``BLOB`` and ``CLOB`` <data type>s, and their
+    values.
 
 ``0F001  locator exception-invalid specification``
-    This will be returned if a value passed for a ``BLOB`` or ``CLOB`` is 
+    This will be returned if a value passed for a ``BLOB`` or ``CLOB`` is
     invalid.
 
 ``0F002  locator exception-update attempted with non-updatable locator``
@@ -1626,77 +1628,77 @@ preventing an SQL statement from being successfully completed.
 ``20000  case not found for case statement``
 
 ``21000  cardinality violation``
-    Suggested error message: "subquery contained more than one row". For 
-    example, suppose you have a Table T, with a Column S1 and two rows. In 
-    both rows, Column S1 has the value 5. Then either "``SELECT (SELECT s1 
-    FROM T) FROM ...``" (scalar subquery) or "``... WHERE 5 = (SELECT s1 
-    FROM T)``" (row subquery) violate cardinality. Another possibility, 
-    applicable to embedded SQL only, is that you are using a 
-    singleton-``SELECT`` statement format but there are two rows returned. 
-    Some cardinality violations, e.g.: ``OVERLAPS`` operand with degree 
-    greater than 2, cause ``SQLSTATE=42000`` instead of ``SQLSTATE=21000``. 
+    Suggested error message: "subquery contained more than one row". For
+    example, suppose you have a Table T, with a Column S1 and two rows. In
+    both rows, Column S1 has the value 5. Then either "``SELECT (SELECT s1
+    FROM T) FROM ...``" (scalar subquery) or "``... WHERE 5 = (SELECT s1
+    FROM T)``" (row subquery) violate cardinality. Another possibility,
+    applicable to embedded SQL only, is that you are using a
+    singleton-``SELECT`` statement format but there are two rows returned.
+    Some cardinality violations, e.g.: ``OVERLAPS`` operand with degree
+    greater than 2, cause ``SQLSTATE=42000`` instead of ``SQLSTATE=21000``.
 
 ``21S01  cardinality violation-insert value list does not match column list`` (ODBC 2+3)
-    For example: the statement "``INSERT INTO T (a,b) VALUES (1,2,3)``" is 
-    trying to insert three values into two Columns. 
+    For example: the statement "``INSERT INTO T (a,b) VALUES (1,2,3)``" is
+    trying to insert three values into two Columns.
 
 ``21S02  cardinality violation-degree of derived table does not match column list`` (ODBC 2+3)
-    For example: the SQL statement "``CREATE VIEW (a,b) AS SELECT a,b,c FROM 
-    T;``" is creating a 2-Column View for a 3-Column select. 
+    For example: the SQL statement "``CREATE VIEW (a,b) AS SELECT a,b,c FROM
+    T;``" is creating a 2-Column View for a 3-Column select.
 
 ``22000  data exception``
-    The "data exception" class identifies exception conditions that relate 
-    to data errors. 
+    The "data exception" class identifies exception conditions that relate
+    to data errors.
 
 ``22001  data exception-string data, right truncation``
-    Suppose you try to insert a 5-character string into a Column defined as 
-    ``CHAR(4)``, or suppose you use the expression "``CAST (12345 AS 
-    CHAR(4))``". No truncation actually occurs since the SQL statement 
-    fails. See also: ``SQLSTATE 01004``. 
+    Suppose you try to insert a 5-character string into a Column defined as
+    ``CHAR(4)``, or suppose you use the expression "``CAST (12345 AS
+    CHAR(4))``". No truncation actually occurs since the SQL statement
+    fails. See also: ``SQLSTATE 01004``.
 
 ``22002  data exception-null value, no indicator parameter``
-    Suggested error message: "``NULL`` seen, host program passed no 
-    indicator". For example, you used ``SQLBindCol``, but passed no 
-    parameter for an indicator value to be returned to. This is not an error 
-    unless you fetch a ``NULL``. 
+    Suggested error message: "``NULL`` seen, host program passed no
+    indicator". For example, you used ``SQLBindCol``, but passed no
+    parameter for an indicator value to be returned to. This is not an error
+    unless you fetch a ``NULL``.
 
 ``22003  data exception-numeric value out of range``
-    Suggested error message: "the numeric value <> is too big to fit in the 
-    target <>". Often this is the result of an arithmetic overflow -- for 
-    example, "``UPDATE ... SET SMALLINT_COLUMN = 9999999999``", or you're 
-    trying to retrieve a value of 5 billion into a host variable defined in 
-    Pascal as "Word". Fractional truncation won't cause this error, see 
-    ``SQLSTATE 01S07``. 
+    Suggested error message: "the numeric value <> is too big to fit in the
+    target <>". Often this is the result of an arithmetic overflow -- for
+    example, "``UPDATE ... SET SMALLINT_COLUMN = 9999999999``", or you're
+    trying to retrieve a value of 5 billion into a host variable defined in
+    Pascal as "Word". Fractional truncation won't cause this error, see
+    ``SQLSTATE 01S07``.
 
 ``22004  data exception-null value not allowed``
 
 ``22005  data exception-error in assignment``
-    For ``GET DESCRIPTOR`` and ``SET DESCRIPTOR`` statements, where the 
-    <data type> and size indicated in the descriptor does not match the 
-    value, this error appears. 
+    For ``GET DESCRIPTOR`` and ``SET DESCRIPTOR`` statements, where the
+    <data type> and size indicated in the descriptor does not match the
+    value, this error appears.
 
 ``22006  data exception-invalid interval format``
-    For example, a year-month interval should contain only a year integer, a 
-    '-' separator, and a month integer. See also: ``SQLSTATE 22015``. 
+    For example, a year-month interval should contain only a year integer, a
+    '-' separator, and a month integer. See also: ``SQLSTATE 22015``.
 
 ``22007  data exception-invalid datetime format``
-    Suggested message: "For the <data type> <>, <> is not a valid value". 
-    This error only occurs if there is an explicit or implicit ``CAST`` to a 
-    datetime (date or time or timestamp). See also: ``SQLSTATE 22008``, 
-    ``22018``. 
+    Suggested message: "For the <data type> <>, <> is not a valid value".
+    This error only occurs if there is an explicit or implicit ``CAST`` to a
+    datetime (date or time or timestamp). See also: ``SQLSTATE 22008``,
+    ``22018``.
 
 ``22008  data exception-datetime field overflow``
-    Suggested message: "For the data type <>, <> is not a valid value". One 
-    thing to look for: arithmetic which causes the ``DAY`` field of a date 
-    to be greater than the last day of the month -- for example ``DATE 
-    '1994-03-31' + INTERVAL '01' MONTH``. See also: ``SQLSTATE 22007``. 
+    Suggested message: "For the data type <>, <> is not a valid value". One
+    thing to look for: arithmetic which causes the ``DAY`` field of a date
+    to be greater than the last day of the month -- for example ``DATE
+    '1994-03-31' + INTERVAL '01' MONTH``. See also: ``SQLSTATE 22007``.
 
 ``22009  data exception-invalid time zone displacement value``
-    Suggested message: "The time zone displacement value <> is outside the 
-    range -12:59 to 13:00". This could happen for ``SET LOCAL TIME ZONE 
-    INTERVAL '22:00' HOUR TO MINUTE;``, or for ``TIMESTAMP '1994-01-01 
-    02:00:00+10:00'``. (In the latter case, it is the result of the 
-    calculation that is a problem.) 
+    Suggested message: "The time zone displacement value <> is outside the
+    range -12:59 to 13:00". This could happen for ``SET LOCAL TIME ZONE
+    INTERVAL '22:00' HOUR TO MINUTE;``, or for ``TIMESTAMP '1994-01-01
+    02:00:00+10:00'``. (In the latter case, it is the result of the
+    calculation that is a problem.)
 
 ``2200A  data exception-null value in reference target``
 
@@ -1707,38 +1709,38 @@ preventing an SQL statement from being successfully completed.
 ``2200D  data exception-invalid escape octet``
 
 ``22010  data exception-invalid indicator parameter value``
-    The value of the indicator variable is less than zero but is not equal 
-    to -1 (``SQL_NULL_DATA``). 
+    The value of the indicator variable is less than zero but is not equal
+    to -1 (``SQL_NULL_DATA``).
 
 ``22011  data exception-substring error``
-    Suggested message: "The maximum length of ``SUBSTRING`` parameter is 
-    <>". For example, "``... SUBSTRING (string_column FROM 5 FOR 100) ...``" 
-    when the length of ``STRING_COLUMN`` is only 1. 
+    Suggested message: "The maximum length of ``SUBSTRING`` parameter is
+    <>". For example, "``... SUBSTRING (string_column FROM 5 FOR 100) ...``"
+    when the length of ``STRING_COLUMN`` is only 1.
 
 ``22012  data exception-division by zero``
-    For example: "``... column_name / ? ...``", where ``?`` is a parameter 
-    marker, and the value of the parameter at run time is 0. If the Column 
-    contains ``NULL``, then the result is ``NULL`` -- the Standard makes it 
-    clear that dividing ``NULL`` by zero is not an error. 
+    For example: "``... column_name / ? ...``", where ``?`` is a parameter
+    marker, and the value of the parameter at run time is 0. If the Column
+    contains ``NULL``, then the result is ``NULL`` -- the Standard makes it
+    clear that dividing ``NULL`` by zero is not an error.
 
 ``22014  data exception-invalid update value``
 
 ``22015  data exception-interval field overflow``
-    Suggested message: "The <> field contains <>, the maximum is <>". For 
-    example, "``... DATE '1993-01-01' + INTERVAL '1000' YEAR ...``" (this is 
-    a tricky one -- the default size of all interval fields including year 
-    fields is only 2 digits). See also: ``SQLSTATE 22006``. 
+    Suggested message: "The <> field contains <>, the maximum is <>". For
+    example, "``... DATE '1993-01-01' + INTERVAL '1000' YEAR ...``" (this is
+    a tricky one -- the default size of all interval fields including year
+    fields is only 2 digits). See also: ``SQLSTATE 22006``.
 
 ``22018  data exception-invalid character value for cast``
-    Suggested message: "The character <> cannot be used when ``CAST``ing to 
-    data type <>". For example, if you try to cast ``'1994/10/10'`` to a 
-    date, it won't work because the separator is '/' (the correct separator 
-    is '-'). 
+    Suggested message: "The character <> cannot be used when ``CAST``ing to
+    data type <>". For example, if you try to cast ``'1994/10/10'`` to a
+    date, it won't work because the separator is '/' (the correct separator
+    is '-').
 
-``22019 data exception-invalid escape character`` 
-    Suggested message: "The ``LIKE`` escape value <> is longer than 1 
-    character". The expression "``... LIKE '...' ESCAPE 'AB' ...``" would 
-    return this error. 
+``22019 data exception-invalid escape character``
+    Suggested message: "The ``LIKE`` escape value <> is longer than 1
+    character". The expression "``... LIKE '...' ESCAPE 'AB' ...``" would
+    return this error.
 
 ``2201B  data exception-invalid regular expression``
 
@@ -1747,43 +1749,43 @@ preventing an SQL statement from being successfully completed.
 ``22020  data exception-invalid limit value``
 
 ``22021  data exception-character not in repertoire``
-    Suggested message: "The character <> is not in the repertoire of 
-    Character set <>". For example, the Character set ``SQL_CHARACTER`` does 
-    not contain the tilde (~), so this <literal> is not allowed: "``... 
-    _SQL_CHARACTER '~' ...``". 
+    Suggested message: "The character <> is not in the repertoire of
+    Character set <>". For example, the Character set ``SQL_CHARACTER`` does
+    not contain the tilde (~), so this <literal> is not allowed: "``...
+    _SQL_CHARACTER '~' ...``".
 
 ``22022  data exception-indicator overflow``
-    Suggested message: "indicator is too small for size value <>". This 
-    could happen if you use embedded SQL and you define the indicator as a C 
-    "short int" or Pascal "Word". If you use ODBC, then the message won't 
-    happen because all indicators must be 32-bit. 
+    Suggested message: "indicator is too small for size value <>". This
+    could happen if you use embedded SQL and you define the indicator as a C
+    "short int" or Pascal "Word". If you use ODBC, then the message won't
+    happen because all indicators must be 32-bit.
 
 ``22023  data exception-invalid parameter value``
 
 ``22024  data exception-unterminated C string``
-    Suggested message: "the C parameter string starting with <> is too 
-    long". For example, an SQL statement uses a ``?`` parameter, for a 
-    string, but at runtime it is seen that the C char-string does not have a 
-    terminating ``'\0'``. The DBMS can only detect this error if it knows 
-    what the maximum string size is, i.e.: only in embedded SQL. Usually 
-    this problem will appear as a too-long or improperly-formatted string, 
-    so several other ``SQLSTATE`` error returns are possible -- for example. 
-    ``SQLSTATE 22019``. 
+    Suggested message: "the C parameter string starting with <> is too
+    long". For example, an SQL statement uses a ``?`` parameter, for a
+    string, but at runtime it is seen that the C char-string does not have a
+    terminating ``'\0'``. The DBMS can only detect this error if it knows
+    what the maximum string size is, i.e.: only in embedded SQL. Usually
+    this problem will appear as a too-long or improperly-formatted string,
+    so several other ``SQLSTATE`` error returns are possible -- for example.
+    ``SQLSTATE 22019``.
 
 ``22025  data exception-invalid escape sequence``
-    Suggested message: "``LIKE`` pattern <> has invalid escape sequence <>". 
-    If you use an escape character, it must be followed in the pattern by _ 
-    or % or another escape character. If you use "``... LIKE 'X%@' ESCAPE 
-    '@' ...``", you'll get this error. 
+    Suggested message: "``LIKE`` pattern <> has invalid escape sequence <>".
+    If you use an escape character, it must be followed in the pattern by _
+    or % or another escape character. If you use "``... LIKE 'X%@' ESCAPE
+    '@' ...``", you'll get this error.
 
 ``22026  data exception-string data, length mismatch``
-    With ODBC this error should only occur for ``SQL_LONGVARCHAR`` or 
-    ``SQL_LONGVARBINARY`` strings. For standard SQL, this error should only 
-    occur for bit strings. 
+    With ODBC this error should only occur for ``SQL_LONGVARCHAR`` or
+    ``SQL_LONGVARBINARY`` strings. For standard SQL, this error should only
+    occur for bit strings.
 
 ``22027  data exception-trim error``
-    Suggested message: "the ``TRIM`` string <> is longer than 1 character". 
-    For example, "``... TRIM('AB' FROM '...') ...``" results in this error. 
+    Suggested message: "the ``TRIM`` string <> is longer than 1 character".
+    For example, "``... TRIM('AB' FROM '...') ...``" results in this error.
 
 ``22028  data exception-row already exists``
 
@@ -1796,57 +1798,57 @@ preventing an SQL statement from being successfully completed.
 ``2202F  data exception-array data, right truncation``
 
 ``23000  integrity constraint violation``
-    The "integrity constraint violation" class identifies exception 
-    conditions that relate to Constraint violations. Suggested message for 
-    ``SQLSTATE 23000``: "Attempted violation of constraint <>". For example, 
-    Table T has a ``PRIMARY KEY`` Constraint and you attempt to insert two 
-    rows into T, both with precisely the same values in all Columns. For 
-    SQL-92, this ``SQLSTATE`` applies to attempted violations of any kind of 
-    Constraint, including ``NOT NULL``\s and ``FOREIGN KEY`` Constraints. 
-    The message can also occur if the total length of a foreign key Column 
-    list is exceeded. See also: ``SQLSTATE 40002``. 
+    The "integrity constraint violation" class identifies exception
+    conditions that relate to Constraint violations. Suggested message for
+    ``SQLSTATE 23000``: "Attempted violation of constraint <>". For example,
+    Table T has a ``PRIMARY KEY`` Constraint and you attempt to insert two
+    rows into T, both with precisely the same values in all Columns. For
+    SQL-92, this ``SQLSTATE`` applies to attempted violations of any kind of
+    Constraint, including ``NOT NULL``\s and ``FOREIGN KEY`` Constraints.
+    The message can also occur if the total length of a foreign key Column
+    list is exceeded. See also: ``SQLSTATE 40002``.
 
 ``23001  integrity constraint violation-restrict violation``
 
 ``24000  invalid cursor state``
-    The "invalid cursor state" class identifies exception conditions that 
-    relate to Cursors. For ``SQLSTATE 24000``, the Cursor-related operation 
-    can't happen because some preliminary function hasn't been called or 
-    hasn't been completed -- for example: 
+    The "invalid cursor state" class identifies exception conditions that
+    relate to Cursors. For ``SQLSTATE 24000``, the Cursor-related operation
+    can't happen because some preliminary function hasn't been called or
+    hasn't been completed -- for example:
 
     * ``OPEN`` <Cursor>, then immediately try to ``OPEN`` <Cursor> again.
-    
+
     * ``FETCH`` without opening the Cursor.
-    
-    * ``OPEN`` <Cursor>, forget to ``FETCH``, then ``DELETE ... WHERE CURRENT 
+
+    * ``OPEN`` <Cursor>, forget to ``FETCH``, then ``DELETE ... WHERE CURRENT
       OF`` <Cursor>.
-    
-    For CLI programs, the DBMS returns ``SQLSTATE=24000`` if you try to 
-    ``FETCH`` and there is no result set (for example, because the previous 
-    SQL statement was ``INSERT``). However, if there was no previous SQL 
-    statement at all, then the return is not ``24000`` but ``HY010`` 
-    (CLI-specific error-function sequence error). 
+
+    For CLI programs, the DBMS returns ``SQLSTATE=24000`` if you try to
+    ``FETCH`` and there is no result set (for example, because the previous
+    SQL statement was ``INSERT``). However, if there was no previous SQL
+    statement at all, then the return is not ``24000`` but ``HY010``
+    (CLI-specific error-function sequence error).
 
 ``25000  invalid transaction state``
-    The "invalid transaction state" class identifies exception conditions 
-    that relate to transactions. For ``SQLSTATE 25000``, you are most likely 
-    trying to execute an SQL statement that can only be executed at 
-    transaction start -- for example you are issuing a ``SET SESSION 
-    AUTHORIZATION`` statement after selecting something. Alternatively, you 
-    specified ``SET TRANSACTION READ ONLY`` and now you are saying 
-    ``UPDATE``, ``DROP``, etc. Finally, it is possible you are saying 
-    ``INSERT`` after a ``FETCH``. 
+    The "invalid transaction state" class identifies exception conditions
+    that relate to transactions. For ``SQLSTATE 25000``, you are most likely
+    trying to execute an SQL statement that can only be executed at
+    transaction start -- for example you are issuing a ``SET SESSION
+    AUTHORIZATION`` statement after selecting something. Alternatively, you
+    specified ``SET TRANSACTION READ ONLY`` and now you are saying
+    ``UPDATE``, ``DROP``, etc. Finally, it is possible you are saying
+    ``INSERT`` after a ``FETCH``.
 
 ``25001  invalid transaction state-active SQL-transaction``
-    ``START TRANSACTION`` or ``DISCONNECT`` or ``SET SESSION AUTHORIZATION`` 
-    or ``SET ROLE`` statements cannot be issued if a transaction has already 
-    been started. 
+    ``START TRANSACTION`` or ``DISCONNECT`` or ``SET SESSION AUTHORIZATION``
+    or ``SET ROLE`` statements cannot be issued if a transaction has already
+    been started.
 
 ``25002  invalid transaction state-branch transaction already active``
-    ``SET TRANSACTION LOCAL ...``, which applies only in multiple-server 
-    contexts, is illegal if a local transaction is already happening. 
+    ``SET TRANSACTION LOCAL ...``, which applies only in multiple-server
+    contexts, is illegal if a local transaction is already happening.
 
-``25003  invalid transaction state-inappropriate access mode for branch 
+``25003  invalid transaction state-inappropriate access mode for branch
 transaction``
 
 ``25004  invalid transaction state-inappropriate isolation level for branch
@@ -1858,45 +1860,45 @@ transaction``
 ``25006  invalid transaction state-read-only SQL-transaction``
 
 ``25007  invalid transaction state-schema and data statement mixing not supported``
-    Some DBMSs do not allow SQL-Schema statements (such as ``CREATE``) to be 
-    mixed with SQL-data statements (such as ``INSERT``) in the same 
-    transaction. 
+    Some DBMSs do not allow SQL-Schema statements (such as ``CREATE``) to be
+    mixed with SQL-data statements (such as ``INSERT``) in the same
+    transaction.
 
 ``25008  invalid transaction state-held cursor requires same isolation level``
-    The ``SET TRANSACTION`` statement cannot be used to change isolation 
-    level if there is a held Cursor made with a different isolation level 
-    left over from the last transaction. 
+    The ``SET TRANSACTION`` statement cannot be used to change isolation
+    level if there is a held Cursor made with a different isolation level
+    left over from the last transaction.
 
 ``25S01  invalid transaction state-transaction state unknown`` (ODBC 3)
-    The attempt to end the transaction (with ``SQLEndTran``) failed for at 
-    least one of the environment's Connections. 
+    The attempt to end the transaction (with ``SQLEndTran``) failed for at
+    least one of the environment's Connections.
 
 ``25S02  invalid transaction state-transaction is still active`` (ODBC 3)
-    The attempt to end the transaction (with ``SQLEndTran``) failed; the 
-    transaction did not end (that is, the transaction is not rolled back). 
+    The attempt to end the transaction (with ``SQLEndTran``) failed; the
+    transaction did not end (that is, the transaction is not rolled back).
 
 ``25S03  invalid transaction state-transaction is rolled back`` (ODBC 3)
-    The attempt to end the transaction (with ``SQLEndTran``) failed; the 
-    transaction is rolled back (that is, the transaction ended). 
+    The attempt to end the transaction (with ``SQLEndTran``) failed; the
+    transaction is rolled back (that is, the transaction ended).
 
 ``26000  invalid SQL statement name``
-    Probable cause: you failed to ``PREPARE`` an SQL statement and now you 
-    are trying to ``EXECUTE`` it. 
+    Probable cause: you failed to ``PREPARE`` an SQL statement and now you
+    are trying to ``EXECUTE`` it.
 
 ``27000   triggered data change violation``
-    With SQL-92, you can cause this error with interlocked ``FOREIGN KEY`` 
-    Constraints that ``CASCADE ON UPDATE``, so that when you ``UPDATE`` 
-    row#1 in ``TABLE#1``, it causes an ``UPDATE`` to row#2 in ``TABLE#2``, 
-    which in turn causes an ``UPDATE`` to row#1 in ``TABLE#1`` -- and that's 
-    an error because the Standard doesn't allow this kind of looping. With 
-    SQL3, this error can also happen for Triggers. See also: ``SQLSTATE 
-    09000``, ``40004``. 
+    With SQL-92, you can cause this error with interlocked ``FOREIGN KEY``
+    Constraints that ``CASCADE ON UPDATE``, so that when you ``UPDATE``
+    row#1 in ``TABLE#1``, it causes an ``UPDATE`` to row#2 in ``TABLE#2``,
+    which in turn causes an ``UPDATE`` to row#1 in ``TABLE#1`` -- and that's
+    an error because the Standard doesn't allow this kind of looping. With
+    SQL3, this error can also happen for Triggers. See also: ``SQLSTATE
+    09000``, ``40004``.
 
 ``28000  invalid authorization specification``
-    This error is caused by an invalid <AuthorizationID>. For example, 
-    "``SET SESSION AUTHORIZATION 'PUBLIC'``" is illegal because ``'PUBLIC'`` 
-    has a special significance in SQL. It's implementation-defined whether 
-    this can happen due to an entry of the wrong password. 
+    This error is caused by an invalid <AuthorizationID>. For example,
+    "``SET SESSION AUTHORIZATION 'PUBLIC'``" is illegal because ``'PUBLIC'``
+    has a special significance in SQL. It's implementation-defined whether
+    this can happen due to an entry of the wrong password.
 
 ``2A000  direct SQL syntax error access or rule violation``
     This error does not appear in ordinary programs.
@@ -1905,8 +1907,8 @@ transaction``
     You used "``REVOKE GRANT OPTION FOR``", but not ``CASCADE``.
 
 ``2C000  invalid character set name``
-    Presumably an invalid <Character set name> would be one that begins with 
-    a digit, contains a non-Latin letter, etc. 
+    Presumably an invalid <Character set name> would be one that begins with
+    a digit, contains a non-Latin letter, etc.
 
 ``2D000  invalid transaction termination``
     Has to do with savepoints and atomicity of transactions. Should not be a
@@ -1916,32 +1918,32 @@ transaction``
     For a ``CONNECT`` statement, the argument must be a valid <identifier>.
 
 ``2F000  SQL routine exception``
-    An SQL routine is a procedure or function which is written in SQL. 
-    ``SQLSTATE`` class ``2F`` identifies exception conditions that relate to 
-    SQL routines. (Exceptions for non-SQL routines are class ``38``.) 
+    An SQL routine is a procedure or function which is written in SQL.
+    ``SQLSTATE`` class ``2F`` identifies exception conditions that relate to
+    SQL routines. (Exceptions for non-SQL routines are class ``38``.)
 
 ``2F002  SQL routine exception-modifying SQL-data not permitted``
-    The probable cause of this error is that the ``CREATE PROCEDURE`` or 
-    ``CREATE FUNCTION`` statement contained the clause: ``CONTAINS SQL`` or 
-    ``READS SQL``, but the function contains an SQL statement which can 
-    modify the database (for example, an ``UPDATE`` statement). The 
-    corresponding external-routine exception is ``38002``. 
+    The probable cause of this error is that the ``CREATE PROCEDURE`` or
+    ``CREATE FUNCTION`` statement contained the clause: ``CONTAINS SQL`` or
+    ``READS SQL``, but the function contains an SQL statement which can
+    modify the database (for example, an ``UPDATE`` statement). The
+    corresponding external-routine exception is ``38002``.
 
 ``2F003  SQL routine exception-prohibited SQL-statement attempted``
-    The prohibited procedural SQL statements are the SQL-transaction 
-    statements (``START TRANSACTION``, ``SET TRANSACTION``, ``SET 
-    CONSTRAINTS``, ``CREATE SAVEPOINT``, ``RELEASE SAVEPOINT``, ``COMMIT``, 
-    ``ROLLBACK``) or the SQL-Connection statements (``CONNECT``, ``SET 
-    CONNECTION``, ``DISCONNECT``) or the SQL-Schema statements (``CREATE``, 
-    ``DROP``, ``ALTER``, ``GRANT``, ``REVOKE``). The corresponding 
-    external-routine exception is ``38003``. 
+    The prohibited procedural SQL statements are the SQL-transaction
+    statements (``START TRANSACTION``, ``SET TRANSACTION``, ``SET
+    CONSTRAINTS``, ``CREATE SAVEPOINT``, ``RELEASE SAVEPOINT``, ``COMMIT``,
+    ``ROLLBACK``) or the SQL-Connection statements (``CONNECT``, ``SET
+    CONNECTION``, ``DISCONNECT``) or the SQL-Schema statements (``CREATE``,
+    ``DROP``, ``ALTER``, ``GRANT``, ``REVOKE``). The corresponding
+    external-routine exception is ``38003``.
 
 ``2F004  SQL routine exception-reading SQL-data not permitted``
-    The probable cause of this error is that the ``CREATE PROCEDURE`` or 
-    ``CREATE FUNCTION`` statement contains the clause: ``CONTAINS SQL``, but 
-    the function contains an SQL statement which reads the database (for 
-    example, a ``SELECT`` statement). The corresponding SQL-routine 
-    exception is ``38004``. 
+    The probable cause of this error is that the ``CREATE PROCEDURE`` or
+    ``CREATE FUNCTION`` statement contains the clause: ``CONTAINS SQL``, but
+    the function contains an SQL statement which reads the database (for
+    example, a ``SELECT`` statement). The corresponding SQL-routine
+    exception is ``38004``.
 
 ``2F005  SQL routine exception-function executed no return statement``
 
@@ -1950,72 +1952,72 @@ transaction``
 ``31000  invalid target specification value``
 
 ``33000  invalid SQL descriptor name``
-    If, in embedded SQL, you use "``EXECUTE ... USING DESCRIPTOR 'X';``", a 
-    descriptor named ``X`` must exist. 
+    If, in embedded SQL, you use "``EXECUTE ... USING DESCRIPTOR 'X';``", a
+    descriptor named ``X`` must exist.
 
 ``34000  invalid cursor name``
-    If the function is ``SQLSetCursorName``, then the problem is that a 
-    <Cursor name> must be a unique, valid <identifier>. If the function is 
-    ``SQLPrepare`` or ``SQLExecDirect``, the SQL statement is "``UPDATE ... 
-    WHERE CURRENT OF`` <Cursor>" or "``DELETE ... WHERE CURRENT OF`` 
-    <Cursor>" and <Cursor> is not the name of an open Cursor. 
+    If the function is ``SQLSetCursorName``, then the problem is that a
+    <Cursor name> must be a unique, valid <identifier>. If the function is
+    ``SQLPrepare`` or ``SQLExecDirect``, the SQL statement is "``UPDATE ...
+    WHERE CURRENT OF`` <Cursor>" or "``DELETE ... WHERE CURRENT OF``
+    <Cursor>" and <Cursor> is not the name of an open Cursor.
 
 ``35000  invalid condition number``
-    With embedded SQL, you get this by saying "``GET DIAGNOSTICS EXCEPTION 
-    0``". With the CLI, you get this by calling ``SQLGetDiagRec`` or 
-    ``SQLGetDiagField`` with a ``RecordNumber`` parameter less than 1. If 
-    ``RecordNumber`` is greater than the number of status records, you don't 
-    get this error. Instead, you get an ``SQL_NO_DATA`` return code. 
+    With embedded SQL, you get this by saying "``GET DIAGNOSTICS EXCEPTION
+    0``". With the CLI, you get this by calling ``SQLGetDiagRec`` or
+    ``SQLGetDiagField`` with a ``RecordNumber`` parameter less than 1. If
+    ``RecordNumber`` is greater than the number of status records, you don't
+    get this error. Instead, you get an ``SQL_NO_DATA`` return code.
 
 ``36000  cursor sensitivity exception``
-    The "cursor sensitivity exception" class identifies exception conditions 
-    that relate to Cursors and their sensitivity attribute. 
+    The "cursor sensitivity exception" class identifies exception conditions
+    that relate to Cursors and their sensitivity attribute.
 
 ``36001  cursor sensitivity exception-request rejected``
-    An attempt was made to open a sensitive Cursor, but the DBMS cannot 
-    guarantee that data changes will be visible throughout the transaction. 
+    An attempt was made to open a sensitive Cursor, but the DBMS cannot
+    guarantee that data changes will be visible throughout the transaction.
 
 ``36002  cursor sensitivity exception-request failed``
-    For example, an attempt was made to execute a positioned ``DELETE`` 
-    statement, but there is a sensitive Cursor open, and (for some 
-    implementation-dependent reason) the effects of the ``DELETE`` cannot be 
-    made visible via that Cursor. 
+    For example, an attempt was made to execute a positioned ``DELETE``
+    statement, but there is a sensitive Cursor open, and (for some
+    implementation-dependent reason) the effects of the ``DELETE`` cannot be
+    made visible via that Cursor.
 
 ``37000  dynamic SQL syntax error or access rule violation``
-    The SQL-92 Standard originally mentioned this ``SQLSTATE``, but 
-    according to a later correction (corrigendum bulletin #3) we should use 
-    ``SQLSTATE = 42000`` instead. That is what all ODBC 3.x drivers do. 
+    The SQL-92 Standard originally mentioned this ``SQLSTATE``, but
+    according to a later correction (corrigendum bulletin #3) we should use
+    ``SQLSTATE = 42000`` instead. That is what all ODBC 3.x drivers do.
 
 ``38000  external routine exception``
-    An external routine is a procedure or function which is written in a 
-    language other than SQL. ``SQLSTATE`` class ``38`` identifies exception 
-    conditions that relate to external routines. (Exceptions from SQL 
-    routines are class ``2F``.) 
+    An external routine is a procedure or function which is written in a
+    language other than SQL. ``SQLSTATE`` class ``38`` identifies exception
+    conditions that relate to external routines. (Exceptions from SQL
+    routines are class ``2F``.)
 
 ``38001  external routine exception-containing SQL not permitted``
-    The probable cause is that the ``CREATE PROCEDURE`` or ``CREATE 
-    FUNCTION`` statement contained the clause: ``NO SQL``, but the routine 
-    contains an SQL statement. 
+    The probable cause is that the ``CREATE PROCEDURE`` or ``CREATE
+    FUNCTION`` statement contained the clause: ``NO SQL``, but the routine
+    contains an SQL statement.
 
 ``38002  external routine exception-modifying SQL-data not permitted``
-    The probable cause is that the ``CREATE PROCEDURE`` or ``CREATE 
-    FUNCTION`` statement contained the clause: ``NO SQL`` or ``CONTAINS 
-    SQL`` or ``READS SQL``, but the function contains an SQL statement which 
-    can modify the database (for example, an ``UPDATE`` statement). 
+    The probable cause is that the ``CREATE PROCEDURE`` or ``CREATE
+    FUNCTION`` statement contained the clause: ``NO SQL`` or ``CONTAINS
+    SQL`` or ``READS SQL``, but the function contains an SQL statement which
+    can modify the database (for example, an ``UPDATE`` statement).
 
 ``38003  external routine exception-prohibited SQL-statement attempted``
-    The prohibited procedural SQL statements are the SQL-transaction 
-    statements (``START TRANSACTION``, ``SET TRANSACTION``, ``SET 
-    CONSTRAINTS``, ``CREATE SAVEPOINT``, ``RELEASE SAVEPOINT``, ``COMMIT``, 
-    ``ROLLBACK``) or the SQL-Connection statements (``CONNECT``, ``SET 
-    CONNECTION``, ``DISCONNECT``) or the SQL-Schema statements (``CREATE``, 
-    ``DROP``, ``ALTER``, ``GRANT``, ``REVOKE``). 
+    The prohibited procedural SQL statements are the SQL-transaction
+    statements (``START TRANSACTION``, ``SET TRANSACTION``, ``SET
+    CONSTRAINTS``, ``CREATE SAVEPOINT``, ``RELEASE SAVEPOINT``, ``COMMIT``,
+    ``ROLLBACK``) or the SQL-Connection statements (``CONNECT``, ``SET
+    CONNECTION``, ``DISCONNECT``) or the SQL-Schema statements (``CREATE``,
+    ``DROP``, ``ALTER``, ``GRANT``, ``REVOKE``).
 
 ``38004  external routine exception-reading SQL-data not permitted``
-    The probable cause is that the ``CREATE PROCEDURE`` or ``CREATE 
-    FUNCTION`` statement contained the clause: ``NO SQL`` or ``CONTAINS 
-    SQL``, but the function contains an SQL statement which reads the 
-    database (for example, a ``SELECT`` statement). 
+    The probable cause is that the ``CREATE PROCEDURE`` or ``CREATE
+    FUNCTION`` statement contained the clause: ``NO SQL`` or ``CONTAINS
+    SQL``, but the function contains an SQL statement which reads the
+    database (for example, a ``SELECT`` statement).
 
 ``39000  external routine invocation exception``
 
@@ -2030,103 +2032,103 @@ transaction``
 ``3B002  savepoint exception-too many``
 
 ``3C000  ambiguous cursor name``
-    A more appropriate wording is: duplicate <Cursor name>. In ODBC you can 
-    get this by calling ``SQLSetCursorName`` with an argument that is the 
-    name of an already-open Cursor. 
+    A more appropriate wording is: duplicate <Cursor name>. In ODBC you can
+    get this by calling ``SQLSetCursorName`` with an argument that is the
+    name of an already-open Cursor.
 
 ``3D000  invalid catalog name``
-    Presumably a <Catalog name> could be invalid if it is used as a 
-    qualifier or as the argument of ``SET CATALOG``, and does not refer to 
-    an existing Catalog or is not a valid <identifier>. However, all those 
-    situations are equally covered by ``SQLSTATE=42000`` (syntax error or 
-    access violation). For ``SQLSetConnectAttr``, the problem is with a 
-    ``SQL_ATTR_CURRENT_CATALOG`` specification. 
+    Presumably a <Catalog name> could be invalid if it is used as a
+    qualifier or as the argument of ``SET CATALOG``, and does not refer to
+    an existing Catalog or is not a valid <identifier>. However, all those
+    situations are equally covered by ``SQLSTATE=42000`` (syntax error or
+    access violation). For ``SQLSetConnectAttr``, the problem is with a
+    ``SQL_ATTR_CURRENT_CATALOG`` specification.
 
 ``3F000  invalid schema name``
-    Presumably a <Schema name> could be invalid if it is used as a qualifier 
-    or as the argument of ``SET SCHEMA``, and does not refer to an existing 
-    Schema or is not a valid <identifier>. However, all those situations are 
-    equally covered by ``SQLSTATE=42000`` (syntax error or access 
-    violation). 
+    Presumably a <Schema name> could be invalid if it is used as a qualifier
+    or as the argument of ``SET SCHEMA``, and does not refer to an existing
+    Schema or is not a valid <identifier>. However, all those situations are
+    equally covered by ``SQLSTATE=42000`` (syntax error or access
+    violation).
 
 ``3G000  invalid UDT instance``
 
 ``40000  transaction rollback``
 
 ``40001  transaction rollback-serialization failure``
-    Two SQL jobs are running simultaneously, and a concurrency problem 
-    arose. For example, using a locking protocol, there was a deadlock or, 
-    using a timestamp protocol, a younger job has read the Object. 
+    Two SQL jobs are running simultaneously, and a concurrency problem
+    arose. For example, using a locking protocol, there was a deadlock or,
+    using a timestamp protocol, a younger job has read the Object.
 
 ``40002  transaction rollback-integrity constraint violation``
-    This occurs for ``COMMIT``, if there were deferred Constraints (deferred 
-    Constraints aren't checked until ``COMMIT`` time unless ``SET 
-    CONSTRAINTS IMMEDIATE`` is executed). So: you asked for ``COMMIT``, and 
-    what you got was ``ROLLBACK``. See also: ``SQLSTATE 23000``. 
+    This occurs for ``COMMIT``, if there were deferred Constraints (deferred
+    Constraints aren't checked until ``COMMIT`` time unless ``SET
+    CONSTRAINTS IMMEDIATE`` is executed). So: you asked for ``COMMIT``, and
+    what you got was ``ROLLBACK``. See also: ``SQLSTATE 23000``.
 
 ``40003  transaction rollback-statement completion unknown``
     The SQL-Connection was lost during execution of an SQL statement.
 
 ``40004  transaction rollback-triggered action exception``
-    This occurs for ``COMMIT``, if there was a deferred Constraint -- 
-    presumably a ``FOREIGN KEY`` Constraint unless Triggers are supported by 
-    the DBMS -- and there was an attempt to violate the Constraint. See 
-    also: ``SQLSTATE 09000``, ``27000``. 
+    This occurs for ``COMMIT``, if there was a deferred Constraint --
+    presumably a ``FOREIGN KEY`` Constraint unless Triggers are supported by
+    the DBMS -- and there was an attempt to violate the Constraint. See
+    also: ``SQLSTATE 09000``, ``27000``.
 
 ``42000  syntax error or access rule violation``
-    The favourite exception. Syntax errors include not just grammar or 
-    spelling errors, but "bind problems" such as failure to find an Object. 
-    Access violations are due to lack of Privileges. A high security DBMS 
-    will try to hide from the user whether the problem is "you don't have 
-    access to ``X``" as opposed to "``X`` isn't there"; that's why these two 
-    different categories are lumped together in one ``SQLSTATE`` (thus users 
-    can't discover what the <Table name>s are by trying out all the 
-    possibilities). 
-    
+    The favourite exception. Syntax errors include not just grammar or
+    spelling errors, but "bind problems" such as failure to find an Object.
+    Access violations are due to lack of Privileges. A high security DBMS
+    will try to hide from the user whether the problem is "you don't have
+    access to ``X``" as opposed to "``X`` isn't there"; that's why these two
+    different categories are lumped together in one ``SQLSTATE`` (thus users
+    can't discover what the <Table name>s are by trying out all the
+    possibilities).
+
     .. CAUTION::
-    
-       It's easy to think that a syntax violation will always be caught during 
-       the prepare stage. Not so. Many DBMSs don't bind until the execution 
-       stage. You have to check after both ``SQLPrepare`` and ``SQLExecute``, 
-       and perhaps even after ``SQLFetch`` (because a DBMS may evaluate 
-       expressions in the select list at ``FETCH`` time, or a Column might have 
-       been dropped since the Cursor was opened). 
+
+       It's easy to think that a syntax violation will always be caught during
+       the prepare stage. Not so. Many DBMSs don't bind until the execution
+       stage. You have to check after both ``SQLPrepare`` and ``SQLExecute``,
+       and perhaps even after ``SQLFetch`` (because a DBMS may evaluate
+       expressions in the select list at ``FETCH`` time, or a Column might have
+       been dropped since the Cursor was opened).
 
 ``42S01  syntax error or access rule violation-base table or view already exists`` (ODBC 3)
-    This is caused by something like "``CREATE TABLE T ...``" when there's 
-    already a Table named T. 
+    This is caused by something like "``CREATE TABLE T ...``" when there's
+    already a Table named T.
 
 ``42S02  syntax error or access rule violation-base table or view not found`` (ODBC 3)
-    This is caused by something like "``SELECT * FROM T;``" when there's no 
-    Table named T. 
+    This is caused by something like "``SELECT * FROM T;``" when there's no
+    Table named T.
 
 ``42S11  syntax error or access rule violation-index already exists`` (ODBC 3)
     This is caused by something like "``CREATE INDEX I ON T(c);``" when there's
     already an index named I.
 
 ``42S12  syntax error or access rule violation-index not found`` (ODBC 3)
-    This is caused by something like "``DROP INDEX I;``" when there's no 
-    index named I. 
+    This is caused by something like "``DROP INDEX I;``" when there's no
+    index named I.
 
 ``42S21  syntax error or access rule violation-column already exists`` (ODBC 3)
-    This is caused by something like "``ALTER TABLE T ADD COLUMN c ...``" 
-    when Column C already exists. 
+    This is caused by something like "``ALTER TABLE T ADD COLUMN c ...``"
+    when Column C already exists.
 
 ``42S22  syntax error or access rule violation-column not found`` (ODBC 3)
-    This is caused by something like "``SELECT c FROM T;``" when Table T has 
-    no Column named C. 
+    This is caused by something like "``SELECT c FROM T;``" when Table T has
+    no Column named C.
 
 ``44000  with check option violation``
-    This is caused by something like "``CREATE VIEW V AS SELECT x FROM T 
-    WHERE x=5 WITH CHECK OPTION;``" then "``UPDATE V SET x = 6;``". The 
-    View's ``WITH CHECK OPTION`` clause is violated by the attempted 
-    ``UPDATE``, which fails. 
+    This is caused by something like "``CREATE VIEW V AS SELECT x FROM T
+    WHERE x=5 WITH CHECK OPTION;``" then "``UPDATE V SET x = 6;``". The
+    View's ``WITH CHECK OPTION`` clause is violated by the attempted
+    ``UPDATE``, which fails.
 
 ``45000  unhandled user-defined exception``
 
 ``70100  operation aborted`` (ODBC 2)
-    Possible because tasks or threads can be destroyed in some operating 
-    systems, but don't expect to see this. 
+    Possible because tasks or threads can be destroyed in some operating
+    systems, but don't expect to see this.
 
 ``H1zzz  SQL Multimedia part 1``
 
@@ -2161,249 +2163,249 @@ transaction``
 ``HY000 CLI-specific condition-invalid handle``
 
 ``CLI-specific condition-dynamic parameter value needed``
-    There is no status record for the invalid-handle exception. The return 
-    from the CLI function is -2 (``SQL_INVALID_HANDLE``), so the only test 
-    for invalid-handle is: 
-    
+    There is no status record for the invalid-handle exception. The return
+    from the CLI function is -2 (``SQL_INVALID_HANDLE``), so the only test
+    for invalid-handle is:
+
     ::
-    
+
        if (sqlreturn == SQL_INVALID_HANDLE) ...
-    
-    The "invalid handle" exception occurs if *(a)* the passed ``hstmt`` or 
-    ``hdbc`` or ``henv`` or ``hdesc`` is not a handle of any resource at all 
-    or *(b)* the passed handle refers to the wrong type of resource, for 
-    example you passed a ``hdesc`` but a ``hdbc`` was expected in this 
-    context. 
-    
-    There is no status record for the need-data exception either. The return 
-    from the CLI function is +99 (``SQL_NEED_DATA``), so the only test for 
-    need-data is: 
-    
+
+    The "invalid handle" exception occurs if *(a)* the passed ``hstmt`` or
+    ``hdbc`` or ``henv`` or ``hdesc`` is not a handle of any resource at all
+    or *(b)* the passed handle refers to the wrong type of resource, for
+    example you passed a ``hdesc`` but a ``hdbc`` was expected in this
+    context.
+
+    There is no status record for the need-data exception either. The return
+    from the CLI function is +99 (``SQL_NEED_DATA``), so the only test for
+    need-data is:
+
     ::
-    
+
        if (sqlreturn == SQL_NEED_DATA) ...
-    
+
     This exception is associated with deferred parameters.
 
 ``HY001  CLI-specific condition-memory allocation error``
-    Probable cause: a malloc failure. One possible solution is to close all 
-    other windows. If ``SQLAllocHandle(ENVIRONMENT HANDLE ...)``: the DBMS 
-    returns 0 to ``&henv``. Since there is no valid handle, you can't get 
-    diagnostics. If ``SQLAllocHandle(CONNECTION HANDLE ...)``: the DBMS 
-    returns 0 to ``&hdbc``. You can get diagnostics using the ``henv``. 
+    Probable cause: a malloc failure. One possible solution is to close all
+    other windows. If ``SQLAllocHandle(ENVIRONMENT HANDLE ...)``: the DBMS
+    returns 0 to ``&henv``. Since there is no valid handle, you can't get
+    diagnostics. If ``SQLAllocHandle(CONNECTION HANDLE ...)``: the DBMS
+    returns 0 to ``&hdbc``. You can get diagnostics using the ``henv``.
 
 ``HY002  CLI-specific condition-link-to-result-sets attribute precludes using this routine``
 
 ``HY003  CLI-specific condition-invalid data type in application descriptor``
-    Actually, the invalid <data type> is not in an application descriptor, 
-    but in the parameter of a CLI function (``SQLBindCol``, 
-    ``SQLBindParameter``, ``SQLGetData``, ``SQLGetParamData``). 
+    Actually, the invalid <data type> is not in an application descriptor,
+    but in the parameter of a CLI function (``SQLBindCol``,
+    ``SQLBindParameter``, ``SQLGetData``, ``SQLGetParamData``).
 
 ``HY004  CLI-specific condition-invalid data type``
-    The ``SQLGetTypeInfo`` function requires a ``DataType`` parameter whose 
-    value is either ``SQL_ALL_TYPES`` or one of the "concise type" codes. If 
-    the ``DataType`` parameter has an invalid value, you get this error. 
-    ``SQLSetDescField`` and ``SQLBindParameter`` parameters must also 
-    contain "concise type" codes. 
+    The ``SQLGetTypeInfo`` function requires a ``DataType`` parameter whose
+    value is either ``SQL_ALL_TYPES`` or one of the "concise type" codes. If
+    the ``DataType`` parameter has an invalid value, you get this error.
+    ``SQLSetDescField`` and ``SQLBindParameter`` parameters must also
+    contain "concise type" codes.
 
 ``HY007  CLI-specific condition-associated statement is not prepared``
-    A function (for example ``SQLGetDescField``) requires a descriptor 
-    field, but the SQL statement has not been prepared so no description 
-    exists. 
+    A function (for example ``SQLGetDescField``) requires a descriptor
+    field, but the SQL statement has not been prepared so no description
+    exists.
 
 ``HY008  CLI-specific condition-operation cancelled``
-    Many functions can operate asynchronously. Such operations can be 
-    cancelled using the ``SQLCancel`` function. That's what happened to this 
-    one. 
+    Many functions can operate asynchronously. Such operations can be
+    cancelled using the ``SQLCancel`` function. That's what happened to this
+    one.
 
 ``HY009  CLI-specific condition-invalid use of null pointer``
-    One of the parameters for a function is a pointer (address). The passed 
-    pointer (address) is 0000:0000, which isn't acceptable. Some DBMSs will 
-    return this error if they detect that the host language can't handle 
-    pointers. 
+    One of the parameters for a function is a pointer (address). The passed
+    pointer (address) is 0000:0000, which isn't acceptable. Some DBMSs will
+    return this error if they detect that the host language can't handle
+    pointers.
 
 ``HY010  CLI-specific condition-function sequence error``
-    Some functions won't work unless some other function has successfully 
-    executed. For example, it's impossible to "fetch" if you've never 
-    connected or selected. Or, an asynchronously executing function has not 
-    finished. Or, the last ``SQLExecDirect`` or ``SQLExecDirect`` call 
-    returned ``SQL_NEED_DATA`` (meaning the SQL statement has not finished 
-    executing), and you're trying to free the ``stmt``. See also: ``SQLSTATE 
-    24000``. 
+    Some functions won't work unless some other function has successfully
+    executed. For example, it's impossible to "fetch" if you've never
+    connected or selected. Or, an asynchronously executing function has not
+    finished. Or, the last ``SQLExecDirect`` or ``SQLExecDirect`` call
+    returned ``SQL_NEED_DATA`` (meaning the SQL statement has not finished
+    executing), and you're trying to free the ``stmt``. See also: ``SQLSTATE
+    24000``.
 
 ``HY011  CLI-specific condition-attribute cannot be set now``
-    Some settings cannot be changed in the middle of a transaction. For 
-    example, you can't call the function ``SQLSetConnectAttr`` to change 
-    ``SQL_ATTR_TXN_ISOLATION``, after you've already done some inserts. 
+    Some settings cannot be changed in the middle of a transaction. For
+    example, you can't call the function ``SQLSetConnectAttr`` to change
+    ``SQL_ATTR_TXN_ISOLATION``, after you've already done some inserts.
 
 ``HY012  CLI-specific condition-invalid transaction operation code``
-    For the function ``SQLEndTran``, the only possible arguments are 
-    ``SQL_COMMIT`` and ``SQL_ROLLBACK``. 
+    For the function ``SQLEndTran``, the only possible arguments are
+    ``SQL_COMMIT`` and ``SQL_ROLLBACK``.
 
 ``HY013  CLI-specific condition-memory management error``
-    Many functions can return this. Usually the reason is "low memory 
+    Many functions can return this. Usually the reason is "low memory
     conditions".
 
 ``HY014  CLI-specific condition-Limit on number of handles exceeded``
-    This can come from a routine that allocates a handle (``env``, ``dbc``, 
-    ``stmt``, ``desc``) such as ``SQLAllocHandle``. The maximum number of 
-    handles is implementation-defined for each type. 
-    
-    * If ``SQLAllocHandle(SQL_HANDLE_ENV,NULL,&henv)``: the DBMS puts a handle 
-      in ``&henv`` despite the error; however, the handle is just a skeleton -- 
-      you won't be able to use it to allocate a connection handle with. 
-    
-    * If ``SQLAllocHandle(SQL_HANDLE_DBC,henv,&hdbc)``: the DBMS puts 0 in 
-      ``&hdbc`` (``SQL_NULL_HDBC``). You can get diagnostics using the 
-      ``henv``. 
-    
-    * If ``SQLAllocHandle(SQL_HANDLE_STMT,hdbc,&hstmt)``: the DBMS puts 0 in 
-      ``&hstmt`` (``SQL_NULL_HSTMT``). You can get diagnostics using the 
-      ``hdbc``. 
-    
-    * If ``SQLAllocHandle(SQL_HANDLE_DESC,hdbc,&hdesc)``: the DBMS puts 0 in 
-      ``&hdesc`` (``SQL_NULL_HDESC``). You can get diagnostics using the 
-      ``hdbc``. 
+    This can come from a routine that allocates a handle (``env``, ``dbc``,
+    ``stmt``, ``desc``) such as ``SQLAllocHandle``. The maximum number of
+    handles is implementation-defined for each type.
+
+    * If ``SQLAllocHandle(SQL_HANDLE_ENV,NULL,&henv)``: the DBMS puts a handle
+      in ``&henv`` despite the error; however, the handle is just a skeleton --
+      you won't be able to use it to allocate a connection handle with.
+
+    * If ``SQLAllocHandle(SQL_HANDLE_DBC,henv,&hdbc)``: the DBMS puts 0 in
+      ``&hdbc`` (``SQL_NULL_HDBC``). You can get diagnostics using the
+      ``henv``.
+
+    * If ``SQLAllocHandle(SQL_HANDLE_STMT,hdbc,&hstmt)``: the DBMS puts 0 in
+      ``&hstmt`` (``SQL_NULL_HSTMT``). You can get diagnostics using the
+      ``hdbc``.
+
+    * If ``SQLAllocHandle(SQL_HANDLE_DESC,hdbc,&hdesc)``: the DBMS puts 0 in
+      ``&hdesc`` (``SQL_NULL_HDESC``). You can get diagnostics using the
+      ``hdbc``.
 
 ``HY015  CLI-specific condition-no cursor name available``
-    Obsolete -- happens only for ODBC 2.x drivers, when you call 
+    Obsolete -- happens only for ODBC 2.x drivers, when you call
     ``SQLGetCursorName``.
 
 ``HY016  CLI-specific condition-cannot modify an implementation row descriptor``
-    The target of a function (for example ``SQLCopyDesc``) was an IRD, which 
-    can't be changed. 
+    The target of a function (for example ``SQLCopyDesc``) was an IRD, which
+    can't be changed.
 
 ``HY017  CLI-specific condition-invalid use of an automatically allocated descriptor handle``
-    An attempt was made to free or change a descriptor which was not made by 
-    the application program. 
+    An attempt was made to free or change a descriptor which was not made by
+    the application program.
 
 ``HY018  CLI-specific condition-Server declined cancel request``
-    The ODBC function ``SQLCancel`` was called; it's up to the data source 
-    to decide whether this can be processed. For example, the data source 
-    might not be responding to the driver manager's requests. 
+    The ODBC function ``SQLCancel`` was called; it's up to the data source
+    to decide whether this can be processed. For example, the data source
+    might not be responding to the driver manager's requests.
 
 ``HY019  CLI-specific condition-non-character and non-binary data sent in pie    ces``
-    The function ``SQLPutData`` was called twice for the same parameter or 
-    Column; this is only allowed for character and binary data. 
+    The function ``SQLPutData`` was called twice for the same parameter or
+    Column; this is only allowed for character and binary data.
 
 ``HY020  CLI-specific condition-attempt to concatenate a null value``
-    The function ``SQLPutData`` was called twice for the same parameter or 
-    Column; in one of the calls, the passed value was ``NULL``. 
+    The function ``SQLPutData`` was called twice for the same parameter or
+    Column; in one of the calls, the passed value was ``NULL``.
 
 ``HY021  CLI-specific condition-Inconsistent descriptor information``
-    The fields of a ``desc`` have failed the consistency check. For example, 
-    the ``SQL_DESC_SCALE`` value is greater than the ``SQL_DESC_PRECISION`` 
-    value (for a ``DECIMAL`` field) or the ``SQL_DESC_TYPE`` value is 
-    ``SQL_DATETIME`` but the ``SQL_DESC_INTERVAL_CODE`` value is 6 (only 1 
-    to 5 would be legal). This error happens only for the function calls 
-    ``SQLSetDescField`` and ``SQLSetDescRec``. For other functions, 
-    inconsistency causes ``SQLSTATE 07001`` or ``07002``. 
+    The fields of a ``desc`` have failed the consistency check. For example,
+    the ``SQL_DESC_SCALE`` value is greater than the ``SQL_DESC_PRECISION``
+    value (for a ``DECIMAL`` field) or the ``SQL_DESC_TYPE`` value is
+    ``SQL_DATETIME`` but the ``SQL_DESC_INTERVAL_CODE`` value is 6 (only 1
+    to 5 would be legal). This error happens only for the function calls
+    ``SQLSetDescField`` and ``SQLSetDescRec``. For other functions,
+    inconsistency causes ``SQLSTATE 07001`` or ``07002``.
 
 ``HY024  CLI-specific condition-invalid attribute value``
-    One of the "attribute" functions was called (``SQLGetEnvAttr``, 
-    ``SQLSetEnvAttr``, ``SQLGetConnectAttr``, ``SQLSetConnectAttr``, 
-    ``SQLGetStmtAttr``, ``SQLSetStmtAttr``). The numeric value for the 
-    attribute parameter for this function is not defined. 
+    One of the "attribute" functions was called (``SQLGetEnvAttr``,
+    ``SQLSetEnvAttr``, ``SQLGetConnectAttr``, ``SQLSetConnectAttr``,
+    ``SQLGetStmtAttr``, ``SQLSetStmtAttr``). The numeric value for the
+    attribute parameter for this function is not defined.
 
-``HY055  CLI-specific condition-non-string data cannot be used with string 
+``HY055  CLI-specific condition-non-string data cannot be used with string
 routine``
 
 ``HY090  CLI-specific condition-invalid string length or buffer length``
-    You called any CLI function that passes a string value. The size 
-    parameter for this string value was less than or equal to zero, and was 
-    not equal to -3 (``SQL_NTS``). 
+    You called any CLI function that passes a string value. The size
+    parameter for this string value was less than or equal to zero, and was
+    not equal to -3 (``SQL_NTS``).
 
 ``HY091  CLI-specific condition-invalid descriptor field identifier``
-    A descriptor is a structure with information about a selected Column (in 
-    a result set); a field in that descriptor is usually identified by a 
-    numeric code; the number you used was out of bounds. For example, you 
-    can't call ``SQLColAttribute`` with a field identifier parameter = 0. 
+    A descriptor is a structure with information about a selected Column (in
+    a result set); a field in that descriptor is usually identified by a
+    numeric code; the number you used was out of bounds. For example, you
+    can't call ``SQLColAttribute`` with a field identifier parameter = 0.
 
 ``HY092  CLI-specific condition-invalid attribute/option identifier``
-    You called any CLI function that passes an option number (for example 
-    ``SQLGetConnectAttr``). The value you passed was not one of the defined 
-    values. 
+    You called any CLI function that passes an option number (for example
+    ``SQLGetConnectAttr``). The value you passed was not one of the defined
+    values.
 
 ``HY095  CLI-specific condition-Function type out of range`` (ODBC 3)
-    The ``SQLGetFunctions`` function was called, with a ``FunctionId`` 
-    parameter, the value of which is not defined for ODBC. This ``SQLSTATE`` 
-    is not mentioned in the SQL3 Standard. 
+    The ``SQLGetFunctions`` function was called, with a ``FunctionId``
+    parameter, the value of which is not defined for ODBC. This ``SQLSTATE``
+    is not mentioned in the SQL3 Standard.
 
 ``HY103  CLI-specific condition-invalid retrieval code`` (ODBC 3)
-    The ODBC function ``SQLDataSources`` or ``SQLDrivers`` was called, with 
-    a ``Direction`` parameter, the value of which does not equal 
-    ``SQL_FETCH_FIRST``, ``SQL_FETCH_NEXT``, etc. 
+    The ODBC function ``SQLDataSources`` or ``SQLDrivers`` was called, with
+    a ``Direction`` parameter, the value of which does not equal
+    ``SQL_FETCH_FIRST``, ``SQL_FETCH_NEXT``, etc.
 
 ``HY104  CLI-specific condition-invalid precision or scale value``
-    The maximum precision or scale for some <data type>s is up to the data 
-    source (i.e. sometimes the driver can't handle big things), so the 
-    ``SQLBindParameter`` function gets this return. Try querying the data 
-    source to find out what its maxima are. 
+    The maximum precision or scale for some <data type>s is up to the data
+    source (i.e. sometimes the driver can't handle big things), so the
+    ``SQLBindParameter`` function gets this return. Try querying the data
+    source to find out what its maxima are.
 
 ``HY105  CLI-specific condition-invalid parameter mode``
-    The function call (e.g.: ``SQLBindParameter``) contains an 
-    ``InputOutputMode`` parameter, the value of which is not one of: 
-    ``SQL_PARAM_MODE_IN``, ``SQL_PARAM_MODE_OUT``, ``SQL_PARAM_MODE_INOUT``. 
+    The function call (e.g.: ``SQLBindParameter``) contains an
+    ``InputOutputMode`` parameter, the value of which is not one of:
+    ``SQL_PARAM_MODE_IN``, ``SQL_PARAM_MODE_OUT``, ``SQL_PARAM_MODE_INOUT``.
 
 ``HY106  CLI-specific condition-invalid fetch orientation``
-    Only certain fetch "orientations" are allowed (e.g.: ``NEXT``, 
-    ``FIRST``, ``LAST``, ``PRIOR``, ``ABSOLUTE``, ``RELATIVE``). The value 
-    you passed wasn't one of them, for the function ``SQLFetchScroll``. Or, 
-    if the Cursor isn't a ``SCROLL`` Cursor, the only legal orientation is 
-    ``NEXT``. ODBC variations: this could also happen for 
-    ``SQLExtendedFetch``, and the name for this ``SQLSTATE`` is: Fetch type 
-    out of range. 
+    Only certain fetch "orientations" are allowed (e.g.: ``NEXT``,
+    ``FIRST``, ``LAST``, ``PRIOR``, ``ABSOLUTE``, ``RELATIVE``). The value
+    you passed wasn't one of them, for the function ``SQLFetchScroll``. Or,
+    if the Cursor isn't a ``SCROLL`` Cursor, the only legal orientation is
+    ``NEXT``. ODBC variations: this could also happen for
+    ``SQLExtendedFetch``, and the name for this ``SQLSTATE`` is: Fetch type
+    out of range.
 
 ``HY107  CLI-specific condition-Row value out of range``
-    One of the ODBC "fetch" or "set position" functions was called (e.g.: 
-    ``SQLFetch``) and the Cursor is "key set driven", but the row involved 
-    isn't in the key set's range. 
+    One of the ODBC "fetch" or "set position" functions was called (e.g.:
+    ``SQLFetch``) and the Cursor is "key set driven", but the row involved
+    isn't in the key set's range.
 
 ``HY109  CLI-specific condition-invalid cursor position``
-    A row could not be fetched, probably because it has been deleted or 
-    because it is now locked. 
+    A row could not be fetched, probably because it has been deleted or
+    because it is now locked.
 
 ``HY110  CLI-specific condition-invalid driver completion`` (ODBC 3)
-    The ODBC function ``SQLDriverConnect`` contains a ``DriverCompletion`` 
-    parameter, the value of which is not defined for ODBC. This ``SQLSTATE`` 
-    is not mentioned in the SQL Standard. 
+    The ODBC function ``SQLDriverConnect`` contains a ``DriverCompletion``
+    parameter, the value of which is not defined for ODBC. This ``SQLSTATE``
+    is not mentioned in the SQL Standard.
 
 ``HY111  CLI-specific condition-invalid bookmark value`` (ODBC 3)
-    The ODBC function ``SQLExtendedFetch`` or ``SQLFetchScroll`` was called, 
-    with a ``FetchOrientation`` parameter, the value of which was not 
-    defined for ODBC, or was a null pointer. This ``SQLSTATE`` is not 
-    mentioned in the SQL Standard. 
+    The ODBC function ``SQLExtendedFetch`` or ``SQLFetchScroll`` was called,
+    with a ``FetchOrientation`` parameter, the value of which was not
+    defined for ODBC, or was a null pointer. This ``SQLSTATE`` is not
+    mentioned in the SQL Standard.
 
 ``HYC00  CLI-specific condition-optional feature not implemented`` (ODBC 3)
-    Many of the ODBC functions have optional features. It is unlikely that 
-    any driver will support every optional feature. When the driver doesn't, 
-    this is the error you'll get. See also: ``SQLSTATE 0A000`` (which 
-    applies to unimplemented features outside the CLI) and ``SQLSTATE 
-    IM001`` (which applies to unsupported ODBC functions rather than 
-    features). The ODBC manual refers to ``HYC00`` as "particularly 
-    significant". 
+    Many of the ODBC functions have optional features. It is unlikely that
+    any driver will support every optional feature. When the driver doesn't,
+    this is the error you'll get. See also: ``SQLSTATE 0A000`` (which
+    applies to unimplemented features outside the CLI) and ``SQLSTATE
+    IM001`` (which applies to unsupported ODBC functions rather than
+    features). The ODBC manual refers to ``HYC00`` as "particularly
+    significant".
 
 ``HYT00  CLI-specific condition-timeout expired`` (ODBC 3)
-    You can specify a timeout value in milliseconds (with the 
-    ``SQLSetStmtAttr`` ODBC function call). If the timeout value that you 
-    set goes by and the statement is unfinished, this return happens. 
+    You can specify a timeout value in milliseconds (with the
+    ``SQLSetStmtAttr`` ODBC function call). If the timeout value that you
+    set goes by and the statement is unfinished, this return happens.
 
 ``HYT01  CLI-specific condition-connection timeout expired`` (ODBC 3)
-    This is similar to ``HYT00``, but it applies to the connection rather 
-    than to the statement. 
+    This is similar to ``HYT00``, but it applies to the connection rather
+    than to the statement.
 
 ``HZzzz  Remote Database Access``
-    The Remote Database Access standard, ISO/IEC 9579-2, defines several 
-    subclass code values which may be passed on via SQL, but are not defined 
-    within SQL. These will all be in the class HZ. 
+    The Remote Database Access standard, ISO/IEC 9579-2, defines several
+    subclass code values which may be passed on via SQL, but are not defined
+    within SQL. These will all be in the class HZ.
 
 ``IM001  driver does not support this function`` (ODBC 2+3)
-    There are a lot of ODBC functions. Some drivers don't support them all, 
-    especially since ODBC 3.x is still new (and Microsoft keeps changing 
-    it). So this error comes from the driver. Compare ``SQLSTATE HYC00``. 
+    There are a lot of ODBC functions. Some drivers don't support them all,
+    especially since ODBC 3.x is still new (and Microsoft keeps changing
+    it). So this error comes from the driver. Compare ``SQLSTATE HYC00``.
 
 ``IM002  Data source name not found and no default driver specified`` (ODBC 2+3)
-    This happens when you're connecting with ODBC, and there's no DSN 
+    This happens when you're connecting with ODBC, and there's no DSN
     registered.
 
 ``IM003  specified driver could not be loaded`` (ODBC 2+3)
@@ -2411,44 +2413,44 @@ routine``
     driver manager is searching.
 
 ``IM004  driver's SQLAllocHandle on SQL_HANDLE_ENV failed`` (ODBC 2+3)
-    Usually this would indicate low memory, or that the maximum number of 
-    handles is exceeded, or a problem with function sequence. 
+    Usually this would indicate low memory, or that the maximum number of
+    handles is exceeded, or a problem with function sequence.
 
 ``IM005  driver's SQLAllocHandle on SQL_HANDLE_DBC failed`` (ODBC 2+3)
-    Usually this would indicate low memory, or that the maximum number of 
-    handles is exceeded, or a problem with function sequence. 
+    Usually this would indicate low memory, or that the maximum number of
+    handles is exceeded, or a problem with function sequence.
 
 ``IM006  driver's SQLSetConnectAttr failed`` (ODBC 2+3)
-    A connection error (during ``SQLBrowseConnect`` or ``SQLConnect`` or 
-    ``SQLDriverConnect``). 
+    A connection error (during ``SQLBrowseConnect`` or ``SQLConnect`` or
+    ``SQLDriverConnect``).
 
 ``IM007  no data source or driver specified; dialog prohibited`` (ODBC 2+3)
     An error return from the ODBC function call ``SQLDriverConnect``.
 
 ``IM008  dialog failed`` (ODBC 2+3)
-    The ``SQLDriverConnect`` function puts up a dialog box; presumably the 
-    user did not end with "OK". 
+    The ``SQLDriverConnect`` function puts up a dialog box; presumably the
+    user did not end with "OK".
 
 ``IM009  unable to load translation DLL`` (ODBC 2+3)
-    A failure during connect or during ``SQLSetConnectAttr``, probably due 
-    to a missing DLL, which may indicate an installation error. 
+    A failure during connect or during ``SQLSetConnectAttr``, probably due
+    to a missing DLL, which may indicate an installation error.
 
 ``IM010  data source name too long`` (ODBC 3)
-    The ODBC connection functions (``SQLBrowseConnect`` or ``SQLConnect`` or 
-    ``SQLDriverConnect``) have a maximum size for the name of the data 
-    source (DSN). You've exceeded it. 
+    The ODBC connection functions (``SQLBrowseConnect`` or ``SQLConnect`` or
+    ``SQLDriverConnect``) have a maximum size for the name of the data
+    source (DSN). You've exceeded it.
 
 ``IM011  driver name too long`` (ODBC 3)
-    The ``SQLBrowseConnect`` and ``SQLDriverConnect`` functions have a 
-    maximum size for the name of the driver. You've exceeded it. 
+    The ``SQLBrowseConnect`` and ``SQLDriverConnect`` functions have a
+    maximum size for the name of the driver. You've exceeded it.
 
 ``IM012  driver keyword syntax error`` (ODBC 3)
-    The ``SQLBrowseConnect`` or ``SQLDriverConnect`` functions require data 
-    in a fixed format. 
+    The ``SQLBrowseConnect`` or ``SQLDriverConnect`` functions require data
+    in a fixed format.
 
 ``IM013  trace file error`` (ODBC 3)
-    Couldn't perform an operation on the trace file, perhaps a failure to 
-    write because of a disk-full situation. 
+    Couldn't perform an operation on the trace file, perhaps a failure to
+    write because of a disk-full situation.
 
 ``IM014  invalid name of file DSN`` (ODBC 3)
     The ``SQLDriverConnect`` function requires a valid identifier.
@@ -2460,5 +2462,5 @@ routine``
 
 ``OK000  resignal when handler not active``
 
-And that's it for CLI diagnostics. In the next chapter, we'll take a look at 
+And that's it for CLI diagnostics. In the next chapter, we'll take a look at
 some general functions.

--- a/docs/chapters/48.rst
+++ b/docs/chapters/48.rst
@@ -4,12 +4,14 @@
 Chapter 48 -- SQL/CLI: General Functions
 ========================================
 
-In this chapter, we discuss ``SQLDataSources``, ``SQLGetFunctions`` and 
-``SQLGetInfo``. We call these the "general" functions because they are used 
-primarily in applications which are not tied to a specific DBMS or a specific 
-database. Generalized applications need to find out what is available, as part 
-of a long initialization process. Here are the descriptions of the three 
-general functions. 
+.. include:: ../_include/note.rst
+
+In this chapter, we discuss ``SQLDataSources``, ``SQLGetFunctions`` and
+``SQLGetInfo``. We call these the "general" functions because they are used
+primarily in applications which are not tied to a specific DBMS or a specific
+database. Generalized applications need to find out what is available, as part
+of a long initialization process. Here are the descriptions of the three
+general functions.
 
 .. rubric:: Table of Contents
 
@@ -59,40 +61,40 @@ SQLDataSources
 
 **Notes:**
 
-* The SQL Standard is firm about the meaning of the term "data source": the 
-  ``SQLDataSources`` function is supposed to return names of SQL-servers. For 
-  some single-tier desktop DBMSs (which are not based on a client-server 
-  architecture), it is more reasonable to expect that the names returned here 
-  will be names of databases. In any case, the name is something you can use in 
-  a ``SQLConnect`` call. 
+* The SQL Standard is firm about the meaning of the term "data source": the
+  ``SQLDataSources`` function is supposed to return names of SQL-servers. For
+  some single-tier desktop DBMSs (which are not based on a client-server
+  architecture), it is more reasonable to expect that the names returned here
+  will be names of databases. In any case, the name is something you can use in
+  a ``SQLConnect`` call.
 
-* You would use this function for browsing ("What servers can I connect to?") 
-  or for checking availability ("Is server ``X`` up yet?"). In many commercial 
-  installations the application is tightly linked to a particular server, so 
-  calling ``SQLDataSources`` has no point -- either you can call ``SQLConnect`` 
-  and succeed, or you cannot. There is a big implementation-defined question 
-  here, namely, how does anybody know what servers are out there? That depends 
-  on how the system is configured, but -- sometimes -- there is a query to see 
-  what names are established on the network, or a directory search for Catalog 
-  files. 
+* You would use this function for browsing ("What servers can I connect to?")
+  or for checking availability ("Is server ``X`` up yet?"). In many commercial
+  installations the application is tightly linked to a particular server, so
+  calling ``SQLDataSources`` has no point -- either you can call ``SQLConnect``
+  and succeed, or you cannot. There is a big implementation-defined question
+  here, namely, how does anybody know what servers are out there? That depends
+  on how the system is configured, but -- sometimes -- there is a query to see
+  what names are established on the network, or a directory search for Catalog
+  files.
 
-* In theory, the maximum length of ``ServerName`` should be the 
-  implementation-defined maximum length of a ``VARCHAR`` string. In practice, 
-  the maximum length of ``ServerName`` is 128 characters. 
+* In theory, the maximum length of ``ServerName`` should be the
+  implementation-defined maximum length of a ``VARCHAR`` string. In practice,
+  the maximum length of ``ServerName`` is 128 characters.
 
-* This is one of the very few functions for which the input handle is a 
-  ``henv``. You can call ``SQLGetDataSources`` before allocating a ``dbc`` or 
-  connecting. There might be several data sources associated with an ``env``. 
+* This is one of the very few functions for which the input handle is a
+  ``henv``. You can call ``SQLGetDataSources`` before allocating a ``dbc`` or
+  connecting. There might be several data sources associated with an ``env``.
 
-* Imagine that there is a Table "``Data Sources``" containing two ``CHAR`` 
-  Columns: "``servername``" or "``databasename``", and "``description``". The 
-  ``SQLDataSources`` function will ``FETCH`` a single row from this Table. 
-  ``SQLDataSources`` would have been implemented as a Catalog function -- that 
-  is, it would have returned a result set -- if it were not for the 
-  inconvenient fact that we want to retrieve data sources information before we 
-  connect. 
+* Imagine that there is a Table "``Data Sources``" containing two ``CHAR``
+  Columns: "``servername``" or "``databasename``", and "``description``". The
+  ``SQLDataSources`` function will ``FETCH`` a single row from this Table.
+  ``SQLDataSources`` would have been implemented as a Catalog function -- that
+  is, it would have returned a result set -- if it were not for the
+  inconvenient fact that we want to retrieve data sources information before we
+  connect.
 
-**Example:** This example displays a list of available servers; assume that 
+**Example:** This example displays a list of available servers; assume that
 the "``Data Sources``" Table looks like this:
 
 ::
@@ -124,11 +126,11 @@ the "``Data Sources``" Table looks like this:
        printf("ServerName = %s. Description = %s.\n",name,description); }
       SQLFreeHandle(SQL_HANDLE_ENV,henv);
 
-**ODBC:** This function has been available since ODBC 1.0. The Driver Manager 
-handles the call, by checking the registry of data sources which have been 
-installed using the ODBC installation program. In fact, ``SQLDataSources`` is 
-very much an ODBC sort of call, since it is difficult to see how one could find 
-a server list without using some sort of non-standard "Driver Manager". 
+**ODBC:** This function has been available since ODBC 1.0. The Driver Manager
+handles the call, by checking the registry of data sources which have been
+installed using the ODBC installation program. In fact, ``SQLDataSources`` is
+very much an ODBC sort of call, since it is difficult to see how one could find
+a server list without using some sort of non-standard "Driver Manager".
 
 .. TIP::
 
@@ -149,11 +151,11 @@ SQLGetFunctions
     SQLSMALLINT *Supported          /* pointer to 16-bit output */
     );
 
-**Job:** Find out whether a specified CLI function is supported. The legal list 
-of ``FunctionID`` values, as defined (with ``#define``) in ``sqlcli.h``, 
-follows -- function codes are in alphabetical order; the version of standard 
-SQL, or ODBC, which requires support of the function is noted after the 
-function's numeric code: 
+**Job:** Find out whether a specified CLI function is supported. The legal list
+of ``FunctionID`` values, as defined (with ``#define``) in ``sqlcli.h``,
+follows -- function codes are in alphabetical order; the version of standard
+SQL, or ODBC, which requires support of the function is noted after the
+function's numeric code:
 
 ::
 
@@ -260,30 +262,30 @@ function's numeric code:
 
 **Notes:**
 
-* ``SQL_API_SQLCOLATTRIBUTE`` and ``SQL_API_SQLCOLATTRIBUTES`` have the same 
-  value: 6. This error is no longer important, since ``SQLColAttributes`` was 
-  only an ODBC 2.0 function. 
+* ``SQL_API_SQLCOLATTRIBUTE`` and ``SQL_API_SQLCOLATTRIBUTES`` have the same
+  value: 6. This error is no longer important, since ``SQLColAttributes`` was
+  only an ODBC 2.0 function.
 
-* Calling ``SQLGetFunctions(...,SQL_API_SQLGETFUNCTION,...)`` looks a little 
-  like asking a person "Are you awake?", i.e.: the answer is either "yes" or 
-  you get no answer at all. But in some contexts it's a perfectly reasonable 
-  question. For instance, all versions of ODBC include a Driver Manager -- a 
-  DLL layer which is separate from the DBMS itself (the "driver" and the "data 
-  source"). In an ODBC context, you're really asking the Driver Manager a 
-  question about the driver, and that's a question you can expect either a 
-  "yes" or a "no" answer for. 
+* Calling ``SQLGetFunctions(...,SQL_API_SQLGETFUNCTION,...)`` looks a little
+  like asking a person "Are you awake?", i.e.: the answer is either "yes" or
+  you get no answer at all. But in some contexts it's a perfectly reasonable
+  question. For instance, all versions of ODBC include a Driver Manager -- a
+  DLL layer which is separate from the DBMS itself (the "driver" and the "data
+  source"). In an ODBC context, you're really asking the Driver Manager a
+  question about the driver, and that's a question you can expect either a
+  "yes" or a "no" answer for.
 
-* It's clear from the ``FunctionID`` value chart that some CLI functions are 
-  old, some are new, some are implementation-specific, some are standard. 
-  That's why it makes sense to call ``SQLGetFunctions`` right after connecting, 
-  and branch to an appropriate path depending on which functions are supported. 
-  The ``SQLGetInfo`` function is useful for the same sort of purpose. 
+* It's clear from the ``FunctionID`` value chart that some CLI functions are
+  old, some are new, some are implementation-specific, some are standard.
+  That's why it makes sense to call ``SQLGetFunctions`` right after connecting,
+  and branch to an appropriate path depending on which functions are supported.
+  The ``SQLGetInfo`` function is useful for the same sort of purpose.
 
-* If you are using MS-Windows and you are calling the DBMS directly, the 
-  question you really want to ask is: is the function name exported? 
+* If you are using MS-Windows and you are calling the DBMS directly, the
+  question you really want to ask is: is the function name exported?
 
-**Example:** Although Microsoft's documentation marks the ODBC function 
-``SQLStatistics()`` as "ISO 92", it's not an ISO Standard function. So 
+**Example:** Although Microsoft's documentation marks the ODBC function
+``SQLStatistics()`` as "ISO 92", it's not an ISO Standard function. So
 before using it, we will ask whether our DBMS supports it. Here's how.
 
 ::
@@ -310,7 +312,7 @@ before using it, we will ask whether our DBMS supports it. Here's how.
         SQLFreeHandle(SQL_HANDLE_DBC,...);
         SQLFreeHandle(SQL_HANDLE_ENV,...);
 
-**ODBC:** The ``SQLGetFunctions`` function has been around since ODBC 
+**ODBC:** The ``SQLGetFunctions`` function has been around since ODBC
 version 1.0. The third parameter, ``*Supported``, can be a pointer to an array.
 
 SQLGetInfo
@@ -328,572 +330,572 @@ SQLGetInfo
     SQLINTEGER *StringLength        /* pointer to 32-bit output */
     );
 
-**Job:** Ask whether a DBMS supports a specified feature, and if it does, which 
-of several possible syntax variations the DBMS uses. 
+**Job:** Ask whether a DBMS supports a specified feature, and if it does, which
+of several possible syntax variations the DBMS uses.
 
-The ``SQLGetInfo`` function's ``InfoType`` parameter has 47 possible values, 
-which we'll describe in the following paragraphs. In what follows, each 
-paragraph begins with a value (the ``InfoType`` value), a name (the ``#define`` 
-of this value in ``sqlcli.h``) and the <data type> of the value that 
-``SQLGetInfo`` returns, followed by a few remarks. 
+The ``SQLGetInfo`` function's ``InfoType`` parameter has 47 possible values,
+which we'll describe in the following paragraphs. In what follows, each
+paragraph begins with a value (the ``InfoType`` value), a name (the ``#define``
+of this value in ``sqlcli.h``) and the <data type> of the value that
+``SQLGetInfo`` returns, followed by a few remarks.
 
-``24 SQL_ACCESSIBLE_ROUTINES -- CHAR(1)`` The result is '``Y``' if 
+``24 SQL_ACCESSIBLE_ROUTINES -- CHAR(1)`` The result is '``Y``' if
 routines metadata -- such as the rows in
 ``INFORMATION_SCHEMA.ROUTINES`` -- is accessible only to users who hold ``EXECUTE``
 Privileges on routines; otherwise the result is '``N``'. In ODBC, this code does
 not exist; ``24`` is the code for ``SQL_CURSOR_ROLLBACK_BEHAVIOR``.
 
-* ``19 SQL_ACCESSIBLE_TABLES -- CHAR(1)`` The result is '``Y``' if Tables 
-  metadata -- such as the rows in ``INFORMATION_SCHEMA.TABLES`` -- is 
-  accessible only to users who hold ``SELECT`` Privileges on Tables; otherwise 
-  the result is '``N``'. A standard DBMS should return '``N``', since access to 
-  ``INFORMATION_SCHEMA`` Views is possible if you hold any Privilege, not just 
-  the ``SELECT`` Privilege. This code determines the operation of the CLI 
-  Catalog functions: ``SQLColumnPrivileges``, ``SQLColumns``, 
-  ``SQLForeignKeys``, ``SQLPrimaryKeys``, ``SQLResultSetStructure``, 
-  ``SQLSpecialColumns``, ``SQLTablePrivileges``, ``SQLTables``. In ODBC, this 
-  code exists, but the meaning is different. 
+* ``19 SQL_ACCESSIBLE_TABLES -- CHAR(1)`` The result is '``Y``' if Tables
+  metadata -- such as the rows in ``INFORMATION_SCHEMA.TABLES`` -- is
+  accessible only to users who hold ``SELECT`` Privileges on Tables; otherwise
+  the result is '``N``'. A standard DBMS should return '``N``', since access to
+  ``INFORMATION_SCHEMA`` Views is possible if you hold any Privilege, not just
+  the ``SELECT`` Privilege. This code determines the operation of the CLI
+  Catalog functions: ``SQLColumnPrivileges``, ``SQLColumns``,
+  ``SQLForeignKeys``, ``SQLPrimaryKeys``, ``SQLResultSetStructure``,
+  ``SQLSpecialColumns``, ``SQLTablePrivileges``, ``SQLTables``. In ODBC, this
+  code exists, but the meaning is different.
 
-* ``86 SQL_ALTER_TABLE -- INTEGER`` The return is a bit map: one bit on for 
+* ``86 SQL_ALTER_TABLE -- INTEGER`` The return is a bit map: one bit on for
   each ``ALTER TABLE`` clause the DBMS supports:
 
    * If ``ALTER TABLE ... ADD COLUMN``:
      ::
-     
+
         0001 hex (SQL_AT_ADD_COLUMN)
-     
+
    * If ``ALTER TABLE ... DROP COLUMN``:
-     
+
      ::
-     
+
         0002 hex (SQL_AT_DROP_COLUMN)
-     
+
    * If ``ALTER TABLE ... ALTER COLUMN``:
-     
+
      ::
-     
+
         0004 hex (SQL_AT_ALTER_COLUMN)
-     
+
    * If ``ALTER TABLE ... ADD CONSTRAINT``:
-     
+
      ::
-     
+
         0008 hex (SQL_AT_ADD_CONSTRAINT)
-     
+
    * If ``ALTER TABLE ... DROP CONSTRAINT``:
-     
+
      ::
-     
+
         0010 hex (SQL_AT_DROP_CONSTRAINT)
-     
-Any SQL-92 DBMS must return ``001b hex`` (all bits except ``ALTER COLUMN`` 
-on). Any SQL3 DBMS must return ``001f hex`` (all bits on). In ODBC, this 
+
+Any SQL-92 DBMS must return ``001b hex`` (all bits except ``ALTER COLUMN``
+on). Any SQL3 DBMS must return ``001f hex`` (all bits on). In ODBC, this
 code exists but the meaning is different.
 
-* ``10003 SQL_CATALOG_NAME -- CHAR(1)`` The return is '``Y``' if the DBMS 
-  supports <Catalog name>s (as qualifiers, presumably); '``N``' if not. Any 
-  SQL-92 DBMS must return '``Y``'. 
+* ``10003 SQL_CATALOG_NAME -- CHAR(1)`` The return is '``Y``' if the DBMS
+  supports <Catalog name>s (as qualifiers, presumably); '``N``' if not. Any
+  SQL-92 DBMS must return '``Y``'.
 
-* ``10004 SQL_COLLATING_SEQUENCE -- CHAR(254)`` The return is the <identifier> 
-  of "the default Collation of [the server]" -- which is ambiguous. Probably 
-  it's the <identifier> of the default Collation of the ``dbc``\'s default 
-  Character set -- which is useless. If you want the Schema's Character set, 
-  ``SELECT`` from ``INFORMATION_SCHEMA.SCHEMATA``. If you want the Collation of 
-  a Base table's Column, ``SELECT`` from ``INFORMATION_SCHEMA.COLUMNS``. If you 
-  want the Collation of a result set Column, call the ``SQLGetDescField`` 
-  function. In ODBC, the designation for this code is ``SQL_COLLATION_SEQ``, 
-  and "``ISO 8859-1``" or "``EBCDIC``" are possible returns. 
+* ``10004 SQL_COLLATING_SEQUENCE -- CHAR(254)`` The return is the <identifier>
+  of "the default Collation of [the server]" -- which is ambiguous. Probably
+  it's the <identifier> of the default Collation of the ``dbc``\'s default
+  Character set -- which is useless. If you want the Schema's Character set,
+  ``SELECT`` from ``INFORMATION_SCHEMA.SCHEMATA``. If you want the Collation of
+  a Base table's Column, ``SELECT`` from ``INFORMATION_SCHEMA.COLUMNS``. If you
+  want the Collation of a result set Column, call the ``SQLGetDescField``
+  function. In ODBC, the designation for this code is ``SQL_COLLATION_SEQ``,
+  and "``ISO 8859-1``" or "``EBCDIC``" are possible returns.
 
-* ``23 SQL_CURSOR_COMMIT_BEHAVIOR -- SMALLINT`` The return is a bit map, with 
-  one bit on, determined by what actions the DBMS takes when ``COMMIT`` 
-  happens: 
+* ``23 SQL_CURSOR_COMMIT_BEHAVIOR -- SMALLINT`` The return is a bit map, with
+  one bit on, determined by what actions the DBMS takes when ``COMMIT``
+  happens:
 
    * [close Cursor, delete prepared statements] ``DELETE``:
-     
+
      ::
-     
+
        0000 hex (SQL_CB_DELETE)
-     
+
    * [close Cursor, keep prepared statements] ``CLOSE``:
-     
+
      ::
-     
+
        0001 hex (SQL_CB_CLOSE)
-     
+
    * [keep Cursor open, keep prepared statements] ``PRESERVE``:
-     
+
      ::
-     
+
        0002 hex (SQL_CB_PRESERVE)
-     
+
      A standard SQL DBMS should return ``0000 hex (SQL_CB_DELETE)``.
 
-* ``XXX CURSOR HOLDABLE -- XXX`` The return is ``1`` (``SQL_HOLDABLE``) if 
-  the DBMS supports holdable Cursors; otherwise it is ``0`` 
+* ``XXX CURSOR HOLDABLE -- XXX`` The return is ``1`` (``SQL_HOLDABLE``) if
+  the DBMS supports holdable Cursors; otherwise it is ``0``
   (``SQL_NONHOLDABLE``).
 
-* ``10001 SQL_CURSOR_SENSITIVITY -- INTEGER`` The return is a bit map, with 
-  zero or more bits on, determined by the DBMS's behaviour when rows are 
+* ``10001 SQL_CURSOR_SENSITIVITY -- INTEGER`` The return is a bit map, with
+  zero or more bits on, determined by the DBMS's behaviour when rows are
   updated outside the Cursor:
-  
+
    * [don't see rows updated during same transaction]:
-     
+
      ::
-     
+
        0001 hex (SQL_INSENSITIVE)
-     
+
    * [see rows updated during same transaction]:
-     
+
      ::
-     
+
        0002 hex (SQL_SENSITIVE)
-     
+
    * [can't tell whether we see them or not]:
-     
+
      ::
-     
+
        0000 hex (SQL_UNSPECIFIED) or 0000 hex (SQL_ASENSITIVE)
-     
-* ``2 SQL_DATA_SOURCE_NAME -- CHAR(128)`` The return is the name of a data 
-  source (in client/server terms: a server name). This is the name that was 
+
+* ``2 SQL_DATA_SOURCE_NAME -- CHAR(128)`` The return is the name of a data
+  source (in client/server terms: a server name). This is the name that was
   passed in the ``SQLConnect`` call.
 
-* ``25 SQL_DATA_SOURCE_READ_ONLY -- CHAR(1)`` The return is '``Y``' if the 
-  data source (in client/server terms: the server) cannot allow data to be 
-  "modified" -- an undefined word. Presumably, the meaning is: every 
-  transaction begins with the implicit statement ``SET TRANSACTION READ ONLY``. 
+* ``25 SQL_DATA_SOURCE_READ_ONLY -- CHAR(1)`` The return is '``Y``' if the
+  data source (in client/server terms: the server) cannot allow data to be
+  "modified" -- an undefined word. Presumably, the meaning is: every
+  transaction begins with the implicit statement ``SET TRANSACTION READ ONLY``.
 
-* ``17 SQL_DBMS_NAME -- CHAR(254)`` The return is the name of the DBMS. 
-  It's implementation-defined, but one can assume that there will be a 
+* ``17 SQL_DBMS_NAME -- CHAR(254)`` The return is the name of the DBMS.
+  It's implementation-defined, but one can assume that there will be a
   vendor name here. The ``sqlcli.h`` file does not contain ``SQL_DBMS_NAME``.
 
-* ``18 SQL_DBMS_VERSION -- CHAR(254)`` The return is the version number of 
-  the DBMS, in a rigid format: ``nn.nn.nnnn``\ [optional description], where 
-  ``n`` is any decimal digit. Examples: "``00.00.0000``", "``01.02.03 
-  Vendor X's Version #1 Release #2 Patch #3``". In ODBC, the name is 
+* ``18 SQL_DBMS_VERSION -- CHAR(254)`` The return is the version number of
+  the DBMS, in a rigid format: ``nn.nn.nnnn``\ [optional description], where
+  ``n`` is any decimal digit. Examples: "``00.00.0000``", "``01.02.03
+  Vendor X's Version #1 Release #2 Patch #3``". In ODBC, the name is
   ``SQL_DBMS_VER``.
 
-* ``26 SQL_DEFAULT_TRANSACTION_ISOLATION -- INTEGER`` The return is a 
-  bitmask, with one bit on for the default transaction isolation level -- 
-  that is, what the transaction isolation level is if you can't execute 
-  ``SET TRANSACTION ISOLATION LEVEL {READ COMMITTED | READ UNCOMMITTED | 
+* ``26 SQL_DEFAULT_TRANSACTION_ISOLATION -- INTEGER`` The return is a
+  bitmask, with one bit on for the default transaction isolation level --
+  that is, what the transaction isolation level is if you can't execute
+  ``SET TRANSACTION ISOLATION LEVEL {READ COMMITTED | READ UNCOMMITTED |
   REPEATABLE READ | SERIALIZABLE}``. The possible values are:
-  
+
   ::
-  
+
     0001 hex (SQL_TXN_READ_UNCOMMITTED)
     0002 hex (SQL_TXN_READ_COMMITTED)
     0004 hex (SQL_TXN_REPEATABLE_READ)
     0008 hex (SQL_TXN_SERIALIZABLE)
-  
+
   A standard DBMS should return ``SQL_TXN_SERIALIZABLE``.
 
-* ``10002 SQL_DESCRIBE_PARAMETER -- CHAR(1)`` The return is '``Y``' if the 
-  DBMS is capable of "describing dynamic parameters" -- which is ambiguous. 
-  Apparently, the return has nothing to do with the DBMS's ability to 
-  support "auto-populate of IPD" or the non-standard ``SQLDescribeParameter`` 
-  function. Apparently, all DBMSs which support the embedded SQL ``DESCRIBE 
-  INPUT`` statement should return '``Y``'; otherwise they should return 
+* ``10002 SQL_DESCRIBE_PARAMETER -- CHAR(1)`` The return is '``Y``' if the
+  DBMS is capable of "describing dynamic parameters" -- which is ambiguous.
+  Apparently, the return has nothing to do with the DBMS's ability to
+  support "auto-populate of IPD" or the non-standard ``SQLDescribeParameter``
+  function. Apparently, all DBMSs which support the embedded SQL ``DESCRIBE
+  INPUT`` statement should return '``Y``'; otherwise they should return
   '``N``'.
 
-* ``8 SQL_FETCH_DIRECTION -- INTEGER`` The return is a bitmask, with zero or 
-  more bits on, depending on the options one can use with the 
+* ``8 SQL_FETCH_DIRECTION -- INTEGER`` The return is a bitmask, with zero or
+  more bits on, depending on the options one can use with the
   ``SQLFetchScroll`` function. The possible values are:
-  
+
   ::
-  
+
      0001 hex (SQL_FD_FETCH_NEXT)
      0002 hex (SQL_FD_FETCH_FIRST)
      0004 hex (SQL_FD_FETCH_LAST)
      0008 hex (SQL_FD_FETCH_PRIOR)
      0010 hex (SQL_FD_FETCH_ABSOLUTE)
      0020 hex (SQL_FD_FETCH_RELATIVE)
-  
+
   A standard DBMS should return ``003f hex`` -- that is, all bits on.
 
-* ``81 SQL_GETDATA_EXTENSIONS -- INTEGER`` The return is a bitmask, with zero 
-  or more bits on, depending on the DBMS's ability to handle out-of-order 
-  ``SQLGetData`` calls. Minimally, a DBMS allows ``SQLGetData`` only for 
-  Columns that were not bound with ``SQLBindCol``, and only in sequence (that 
-  is, after getting information for Column ``n``, you can only get information 
-  for Column ``n+1``). The possible options are: 
-  
+* ``81 SQL_GETDATA_EXTENSIONS -- INTEGER`` The return is a bitmask, with zero
+  or more bits on, depending on the DBMS's ability to handle out-of-order
+  ``SQLGetData`` calls. Minimally, a DBMS allows ``SQLGetData`` only for
+  Columns that were not bound with ``SQLBindCol``, and only in sequence (that
+  is, after getting information for Column ``n``, you can only get information
+  for Column ``n+1``). The possible options are:
+
    * [if you can call ``SQLGetData`` for bound Columns]:
-     
+
      ::
-     
+
        0001 hex (SQL_GD_ANY_COLUMN)
-     
+
    * [if you can call ``SQLGetData`` in any order]:
-     
+
      ::
-     
+
        0002 hex (SQL_GD_ANY_ORDER)
-     
-* ``20000 SQL_GETPARAMDATA_EXTENSIONS -- INTEGER`` The return is a bitmask, 
-  with zero or more bits on, depending on the DBMS's ability to handle 
-  out-of-order ``SQLGetParamData`` calls. Minimally, a DBMS allows 
-  ``SQLGetParamData`` only for Columns that were not bound, and only in 
-  sequence (that is, after getting information for parameter ``n`` you can only 
-  get information for parameter ``n+1``). The possible options are: 
-  
+
+* ``20000 SQL_GETPARAMDATA_EXTENSIONS -- INTEGER`` The return is a bitmask,
+  with zero or more bits on, depending on the DBMS's ability to handle
+  out-of-order ``SQLGetParamData`` calls. Minimally, a DBMS allows
+  ``SQLGetParamData`` only for Columns that were not bound, and only in
+  sequence (that is, after getting information for parameter ``n`` you can only
+  get information for parameter ``n+1``). The possible options are:
+
    * [if you can call ``SQLGetParamData`` for bound Columns]:
-     
+
      ::
-     
+
        0001 hex (SQL_GPD_ANY_COLUMN)
-     
+
    * [if you can call ``SQLGetParamData`` in any order]:
-     
+
      ::
-     
+
        0002 hex (SQL_GPD_ANY_ORDER)
-     
+
      Compare this with ``SQL_GETDATA_EXTENSIONS``.
-     
-* ``28 SQL_<identifier>_CASE -- SMALLINT`` Returns a number between ``1`` and 
-  ``4``, depending how the DBMS stores <regular identifier>s. The possible 
-  options are: 
-  
+
+* ``28 SQL_<identifier>_CASE -- SMALLINT`` Returns a number between ``1`` and
+  ``4``, depending how the DBMS stores <regular identifier>s. The possible
+  options are:
+
    * [change to upper case]:
-     
+
      ::
-     
+
        1 (SQL_IC_UPPER)
-     
+
    * [change to lower case]:
-     
+
      ::
-     
+
        2 (SQL_IC_LOWER)
-     
+
    * [don't change case]:
-     
+
      ::
-     
+
        3 (SQL_IC_SENSITIVE)
-     
+
    * [don't change case, but do case-insensitive searches]:
-     
+
      ::
-     
+
        4 (SQL_IC_MIXED)
-     
-     A standard DBMS should always return ``SQL_IC_UPPER``, since only 
+
+     A standard DBMS should always return ``SQL_IC_UPPER``, since only
      <delimited identifier>s are stored in mixed case.
 
-* ``73 SQL_INTEGRITY -- CHAR(1) The return is '``Y``' if the DBMS supports 
-  basic integrity Constraints: ``NOT NULL``, ``UNIQUE``, ``PRIMARY KEY``, 
-  ``FOREIGN KEY ... NO ACTION``, ``CHECK`` and Column defaults. Otherwise the 
-  return is '``N``'. A standard DBMS should return '``Y``'. In ODBC, code 
-  ``73`` is ``SQL_OPT_IEF``, and the return is '``Y``' if the DBMS supports the 
-  optional integrity enhancement facility of SQL-89. 
+* ``73 SQL_INTEGRITY -- CHAR(1) The return is '``Y``' if the DBMS supports
+  basic integrity Constraints: ``NOT NULL``, ``UNIQUE``, ``PRIMARY KEY``,
+  ``FOREIGN KEY ... NO ACTION``, ``CHECK`` and Column defaults. Otherwise the
+  return is '``N``'. A standard DBMS should return '``Y``'. In ODBC, code
+  ``73`` is ``SQL_OPT_IEF``, and the return is '``Y``' if the DBMS supports the
+  optional integrity enhancement facility of SQL-89.
 
-* ``34 SQL_MAXIMUM_CATALOG_NAME_LENGTH -- SMALLINT`` The return is the length, 
-  in characters, of the largest possible <Catalog name>, without qualifiers or 
-  introducers. Expect 18 for an SQL-89 DBMS, 128 for a later DBMS. 
+* ``34 SQL_MAXIMUM_CATALOG_NAME_LENGTH -- SMALLINT`` The return is the length,
+  in characters, of the largest possible <Catalog name>, without qualifiers or
+  introducers. Expect 18 for an SQL-89 DBMS, 128 for a later DBMS.
 
-* ``30 SQL_MAXIMUM_COLUMN_NAME_LENGTH -- SMALLINT`` The return is the length, 
-  in characters, of the largest possible <Column name>, without qualifiers or 
-  introducers. Expect 18 for an SQL-89 DBMS, 128 for a later DBMS. 
+* ``30 SQL_MAXIMUM_COLUMN_NAME_LENGTH -- SMALLINT`` The return is the length,
+  in characters, of the largest possible <Column name>, without qualifiers or
+  introducers. Expect 18 for an SQL-89 DBMS, 128 for a later DBMS.
 
-* ``97 SQL_MAXIMUM_COLUMNS_IN_GROUP_BY -- SMALLINT`` The return is the largest 
-  number of Columns that a ``GROUP BY`` clause can hold (zero if that's unknown 
-  or unlimited). Expect 6 for a DBMS that meets the FIPS 127-2 entry-level 
-  spec, 15 for a DBMS that meets the FIPS 127-2 intermediate-level spec. 
+* ``97 SQL_MAXIMUM_COLUMNS_IN_GROUP_BY -- SMALLINT`` The return is the largest
+  number of Columns that a ``GROUP BY`` clause can hold (zero if that's unknown
+  or unlimited). Expect 6 for a DBMS that meets the FIPS 127-2 entry-level
+  spec, 15 for a DBMS that meets the FIPS 127-2 intermediate-level spec.
 
-* ``99 SQL_MAXIMUM_COLUMNS_IN_ORDER_BY -- SMALLINT`` The return is the largest 
-  number of Columns that an ``ORDER BY`` clause can hold (zero if that's 
-  unknown or unlimited). Expect 6 for a DBMS that meets the FIPS 127-2 
-  entry-level spec, 15 for a DBMS that meets the FIPS 127-2 intermediate-level 
-  spec. 
+* ``99 SQL_MAXIMUM_COLUMNS_IN_ORDER_BY -- SMALLINT`` The return is the largest
+  number of Columns that an ``ORDER BY`` clause can hold (zero if that's
+  unknown or unlimited). Expect 6 for a DBMS that meets the FIPS 127-2
+  entry-level spec, 15 for a DBMS that meets the FIPS 127-2 intermediate-level
+  spec.
 
-* ``100 SQL_MAXIMUM_COLUMNS_IN_SELECT -- SMALLINT`` The return is the largest 
-  number of Columns that a select list can hold (zero if that's unknown or 
-  unlimited). Expect 100 for a DBMS that meets the FIPS 127-2 entry-level spec, 
-  250 for a DBMS that meets the FIPS 127-2 intermediate-level spec. 
+* ``100 SQL_MAXIMUM_COLUMNS_IN_SELECT -- SMALLINT`` The return is the largest
+  number of Columns that a select list can hold (zero if that's unknown or
+  unlimited). Expect 100 for a DBMS that meets the FIPS 127-2 entry-level spec,
+  250 for a DBMS that meets the FIPS 127-2 intermediate-level spec.
 
-* ``101 SQL_MAXIMUM_COLUMNS_IN_TABLE -- SMALLINT`` The return is the largest 
-  number of Columns that a Base table can hold (zero if that's unknown or 
-  unlimited). Expect 100 for a DBMS that meets the FIPS 127-2 entry-level spec, 
-  250 for a DBMS that meets the FIPS 127-2 intermediate-level spec. 
+* ``101 SQL_MAXIMUM_COLUMNS_IN_TABLE -- SMALLINT`` The return is the largest
+  number of Columns that a Base table can hold (zero if that's unknown or
+  unlimited). Expect 100 for a DBMS that meets the FIPS 127-2 entry-level spec,
+  250 for a DBMS that meets the FIPS 127-2 intermediate-level spec.
 
-* ``1 SQL_MAXIMUM_CONCURRENT_ACTIVITIES -- SMALLINT`` The return is the largest 
-  number of ``stmt``\s that can be active at the same time. With some 
-  implementations, it might be possible to allocate two ``stmt``\s, i.e.: call 
-  ``SQLAllocHandle(SQL_HANDLE_STMT,...)`` twice, but impossible to "select" 
-  with both ``hstmt#1`` and ``hstmt#2``. The return is zero if maximum 
-  concurrent activities is unknown. (A ``stmt`` is "active" if it is associated 
-  with an open Cursor or a deferred parameter.) 
+* ``1 SQL_MAXIMUM_CONCURRENT_ACTIVITIES -- SMALLINT`` The return is the largest
+  number of ``stmt``\s that can be active at the same time. With some
+  implementations, it might be possible to allocate two ``stmt``\s, i.e.: call
+  ``SQLAllocHandle(SQL_HANDLE_STMT,...)`` twice, but impossible to "select"
+  with both ``hstmt#1`` and ``hstmt#2``. The return is zero if maximum
+  concurrent activities is unknown. (A ``stmt`` is "active" if it is associated
+  with an open Cursor or a deferred parameter.)
 
-* ``31 SQL_MAXIMUM_CURSOR_NAME_LENGTH -- SMALLINT`` The return is the length, 
-  in characters, of the largest possible <Cursor name>, without qualifiers or 
-  introducers. Expect 18 for an SQL-89 DBMS, 128 for a later DBMS. 
+* ``31 SQL_MAXIMUM_CURSOR_NAME_LENGTH -- SMALLINT`` The return is the length,
+  in characters, of the largest possible <Cursor name>, without qualifiers or
+  introducers. Expect 18 for an SQL-89 DBMS, 128 for a later DBMS.
 
-* ``0 SQL_MAXIMUM_DRIVER_CONNECTIONS -- SMALLINT`` The return is the maximum 
-  number of connections between one driver and one server, or the maximum 
-  number of connections period, or zero if the maximum is not fixed. 
+* ``0 SQL_MAXIMUM_DRIVER_CONNECTIONS -- SMALLINT`` The return is the maximum
+  number of connections between one driver and one server, or the maximum
+  number of connections period, or zero if the maximum is not fixed.
 
-* ``10005 SQL_MAXIMUM_<identifier>_LENGTH -- SMALLINT`` The return is the 
-  length, in characters, of the largest possible <identifier> for any kind of 
-  Object. This value won't be greater than any of the 
-  ``SQL_MAXIMUM_..._NAME_LENGTH`` values. Expect 18 for an SQL-89 DBMS, 128 for 
-  a later DBMS. 
+* ``10005 SQL_MAXIMUM_<identifier>_LENGTH -- SMALLINT`` The return is the
+  length, in characters, of the largest possible <identifier> for any kind of
+  Object. This value won't be greater than any of the
+  ``SQL_MAXIMUM_..._NAME_LENGTH`` values. Expect 18 for an SQL-89 DBMS, 128 for
+  a later DBMS.
 
-* ``32 SQL_MAXIMUM_SCHEMA_NAME_LENGTH -- SMALLINT`` The return is the length, 
-  in characters, of the largest possible <Schema name>, without qualifiers or 
-  introducers. Expect 18 for an SQL-89 DBMS, 128 for a later DBMS. 
+* ``32 SQL_MAXIMUM_SCHEMA_NAME_LENGTH -- SMALLINT`` The return is the length,
+  in characters, of the largest possible <Schema name>, without qualifiers or
+  introducers. Expect 18 for an SQL-89 DBMS, 128 for a later DBMS.
 
-* ``20000 SQL_MAXIMUM_STMT_OCTETS -- SMALLINT`` << XXX the number is wrong, 
-  20000 is ``SQL_GETPARAMDATA_EXTENSIONS`` >> The return is the maximum number 
-  of octets that can exist in any SQL statement, or zero if there's no fixed 
-  limit. This is the maximum size of the string parameter in an ``SQLPrepare`` 
-  or ``SQLExecDirect`` function call. In ODBC, this code does not exist; the 
-  ODBC code ``SQL_MAXIMUM_STATEMENT_LENGTH`` is a different value. 
+* ``20000 SQL_MAXIMUM_STMT_OCTETS -- SMALLINT`` << XXX the number is wrong,
+  20000 is ``SQL_GETPARAMDATA_EXTENSIONS`` >> The return is the maximum number
+  of octets that can exist in any SQL statement, or zero if there's no fixed
+  limit. This is the maximum size of the string parameter in an ``SQLPrepare``
+  or ``SQLExecDirect`` function call. In ODBC, this code does not exist; the
+  ODBC code ``SQL_MAXIMUM_STATEMENT_LENGTH`` is a different value.
 
-* ``20001 SQL_MAXIMUM_STMT_OCTETS_DATA -- SMALLINT`` The return is the maximum 
-  number of octets that can exist in an SQL-data statement (such as 
-  ``INSERT``), or zero if there's no fixed limit. 
+* ``20001 SQL_MAXIMUM_STMT_OCTETS_DATA -- SMALLINT`` The return is the maximum
+  number of octets that can exist in an SQL-data statement (such as
+  ``INSERT``), or zero if there's no fixed limit.
 
-* ``20002 SQL_MAXIMUM_STMT_OCTETS_SCHEMA -- SMALLINT`` The return is the 
-  maximum number of octets that can exist in an SQL-Schema statement (such as 
-  ``CREATE SCHEMA``), or zero if there's no fixed limit. 
+* ``20002 SQL_MAXIMUM_STMT_OCTETS_SCHEMA -- SMALLINT`` The return is the
+  maximum number of octets that can exist in an SQL-Schema statement (such as
+  ``CREATE SCHEMA``), or zero if there's no fixed limit.
 
-* ``35 SQL_MAXIMUM_TABLE_NAME_LENGTH -- SMALLINT`` The return is the length, in 
-  characters, of the largest possible <Table name>, without qualifiers or 
-  introducers. Expect 18 for an SQL-89 DBMS, 128 for a later DBMS. But don't be 
-  surprised if it's smaller: many implementations treat <Table name> as "file 
-  name", and are therefore subject to whatever constraints the operating system 
-  imposes. 
+* ``35 SQL_MAXIMUM_TABLE_NAME_LENGTH -- SMALLINT`` The return is the length, in
+  characters, of the largest possible <Table name>, without qualifiers or
+  introducers. Expect 18 for an SQL-89 DBMS, 128 for a later DBMS. But don't be
+  surprised if it's smaller: many implementations treat <Table name> as "file
+  name", and are therefore subject to whatever constraints the operating system
+  imposes.
 
-* ``106 SQL_MAXIMUM_TABLES_IN_SELECT -- SMALLINT`` The return is the maximum 
-  number of <Table name>s which may appear in a query's ``FROM`` clause -- that 
-  is, after ``SELECT ... FROM``. This will be less than or equal to the maximum 
-  number of joins, and will be less than or equal to the maximum number of 
-  <Table reference>s in an SQL statement as a whole, after Views are expanded. 
-  A FIPS entry-level DBMS would return 15 for the maximum number of <Table 
-  reference>s in an SQL statement, a FIPS intermediate-level DBMS would return 
-  50. 
+* ``106 SQL_MAXIMUM_TABLES_IN_SELECT -- SMALLINT`` The return is the maximum
+  number of <Table name>s which may appear in a query's ``FROM`` clause -- that
+  is, after ``SELECT ... FROM``. This will be less than or equal to the maximum
+  number of joins, and will be less than or equal to the maximum number of
+  <Table reference>s in an SQL statement as a whole, after Views are expanded.
+  A FIPS entry-level DBMS would return 15 for the maximum number of <Table
+  reference>s in an SQL statement, a FIPS intermediate-level DBMS would return
+  50.
 
-* ``107 SQL_MAXIMUM_USER_NAME_LENGTH -- SMALLINT`` The return is the length, in 
-  characters, of the largest possible <AuthorizationID>, without introducers or 
-  qualifiers. The value is the same as the contents of ``SESSION_USER``. Expect 
-  18 from an SQL-89 or FIPS 127-2 entry level DBMS, expect 128 from a more 
-  powerful DBMS -- unless the DBMS gets <AuthorizationID>s from an outside 
-  source, such as the operating system's login name. In that case, the limit 
-  ultimately depends on what the operating system says. 
+* ``107 SQL_MAXIMUM_USER_NAME_LENGTH -- SMALLINT`` The return is the length, in
+  characters, of the largest possible <AuthorizationID>, without introducers or
+  qualifiers. The value is the same as the contents of ``SESSION_USER``. Expect
+  18 from an SQL-89 or FIPS 127-2 entry level DBMS, expect 128 from a more
+  powerful DBMS -- unless the DBMS gets <AuthorizationID>s from an outside
+  source, such as the operating system's login name. In that case, the limit
+  ultimately depends on what the operating system says.
 
-* ``85 SQL_NULL_COLLATION -- SMALLINT`` Returns a number between 1 and 2, 
-  depending on the placement of ``NULL`` values in sort sequences (``ORDER 
-  BY``). The possible options are: 
-  
+* ``85 SQL_NULL_COLLATION -- SMALLINT`` Returns a number between 1 and 2,
+  depending on the placement of ``NULL`` values in sort sequences (``ORDER
+  BY``). The possible options are:
+
    * [treat ``NULL``\s as "greater than" all other values]:
-     
-     ::
-     
-       1 (SQL_NC_HIGH)
-     
-   * [treat ``NULL``\s as "less than" all other values]:
-     
-     ::
-     
-       2 (SQL_NC_LOW)
-     
-* ``90 SQL_ORDER_BY_COLUMNS_IN_SELECT -- CHAR(1)`` Returns '``Y``' if the DBMS 
-  allows only those ``ORDER BY`` Columns which also appear in the select list; 
-  otherwise '``N``'. For example: ``SELECT column_1 FROM Table_1 ORDER BY 
-  column_2;`` is illegal in SQL-92 (so an SQL-92 DBMS would return '``Y``'), 
-  but is legal in SQL3. 
 
-* ``115 SQL_OUTER_JOIN_CAPABILITIES -- INTEGER`` (Not ``CHAR(1)``, there was an 
-  error in early versions of the SQL Standard.) The return is a bitmask, with 
-  zero or more bits on, depending on the outer join variations that the DBMS 
-  supports. The possible options are: 
-  
+     ::
+
+       1 (SQL_NC_HIGH)
+
+   * [treat ``NULL``\s as "less than" all other values]:
+
+     ::
+
+       2 (SQL_NC_LOW)
+
+* ``90 SQL_ORDER_BY_COLUMNS_IN_SELECT -- CHAR(1)`` Returns '``Y``' if the DBMS
+  allows only those ``ORDER BY`` Columns which also appear in the select list;
+  otherwise '``N``'. For example: ``SELECT column_1 FROM Table_1 ORDER BY
+  column_2;`` is illegal in SQL-92 (so an SQL-92 DBMS would return '``Y``'),
+  but is legal in SQL3.
+
+* ``115 SQL_OUTER_JOIN_CAPABILITIES -- INTEGER`` (Not ``CHAR(1)``, there was an
+  error in early versions of the SQL Standard.) The return is a bitmask, with
+  zero or more bits on, depending on the outer join variations that the DBMS
+  supports. The possible options are:
+
    * [simple LEFT OUTER JOIN]:
-     
+
      ::
-     
+
        0001 hex (SQL_OUTER_JOIN_LEFT)
-     
+
    * [simple RIGHT OUTER JOIN]:
-     
+
      ::
-     
+
        0002 hex (SQL_OUTER_JOIN_RIGHT)
-     
+
    * [FULL OUTER JOIN works]:
-     
+
      ::
-     
+
        0004 hex(SQL_OUTER_JOIN_FULL)
-     
+
    * [outer joins may be nested]:
-     
+
      ::
-     
+
        0008 hex(SQL_OUTER_JOIN_NESTED)
-     
+
    * [ON-clause Columns needn't be in Table order]:
-     
+
      ::
-     
+
        0010 hex (SQL_OUTER_JOIN_NOT_ORDERED)
-     
+
    * [inner Table can be INNER JOIN]:
-     
+
      ::
-     
+
        0020 hex (SQL_OUTER_JOIN_INNER)
-     
+
    * [ON predicate needn't be "=" comparison]:
-     
+
      ::
-     
+
        0040 hex (SQL_OUTER_JOIN_ALL_COMPARISON_OPS)
-     
-* ``20003 SQL_REF_LENGTH -- SMALLINT`` The return is the length, in octets, 
+
+* ``20003 SQL_REF_LENGTH -- SMALLINT`` The return is the length, in octets,
   of a <reference type>
 
-* ``43 SQL_SCROLL_CONCURRENCY -- INTEGER`` The return is a bitmask, with 
-  zero or more bits on, depending on the DBMS's ability to handle 
-  concurrency (multi-user) problems while dealing with scroll Cursors. The 
+* ``43 SQL_SCROLL_CONCURRENCY -- INTEGER`` The return is a bitmask, with
+  zero or more bits on, depending on the DBMS's ability to handle
+  concurrency (multi-user) problems while dealing with scroll Cursors. The
   possible options are:
-  
+
    * [read-only scrollable Cursors are okay]:
-     
+
      ::
-     
+
        0001 hex (SQL_SCCO_READ_ONLY)
-     
-   * [updatable scrollable Cursors are okay in conjunction with lowest 
+
+   * [updatable scrollable Cursors are okay in conjunction with lowest
      locking level]:
-     
+
      ::
-     
+
        0002 hex (SQL_SCCO_LOCK)
-     
-   * [updatable scrollable Cursors are okay in conjunction with optimistic 
+
+   * [updatable scrollable Cursors are okay in conjunction with optimistic
      concurrency -- row <identifier>s or timestamps]:
-     
+
      ::
-     
+
        0004 hex SQL_SCCO_OPT_ROWVER)
-     
-   * [updatable scrollable Cursors are okay in conjunction with optimistic 
+
+   * [updatable scrollable Cursors are okay in conjunction with optimistic
      concurrency -- comparing values]:
-     
+
      ::
-     
+
        0008 hex (SQL_SCCO_OPT_VALUES)
-     
-* ``14 SQL_SEARCH_PATTERN_ESCAPE -- CHAR(1)`` The return is the fixed escape 
-  character which can be used for pattern matching in some of the CLI Catalog 
-  functions (e.g.: ``SQLTables``). Conceptually: if the search-pattern-escape 
-  is ``'~'``, then the metadata search conducted for such functions implicitly 
-  contains a clause "``... LIKE ... ESCAPE '~' ...``". In ODBC, the DBMS may 
-  return '' if search-pattern escape is not supported for Catalog functions. 
 
-* ``13 SQL_SERVER_NAME -- CHAR(128)`` The return is a character string: the 
-  implementation-defined character string which is the "actual name" of a 
-  server. This often will be the same as the string returned for 
-  ``SQL_DATA_SOURCE_NAME``, but some implementations make a distinction between 
-  "data source" and "server". 
+* ``14 SQL_SEARCH_PATTERN_ESCAPE -- CHAR(1)`` The return is the fixed escape
+  character which can be used for pattern matching in some of the CLI Catalog
+  functions (e.g.: ``SQLTables``). Conceptually: if the search-pattern-escape
+  is ``'~'``, then the metadata search conducted for such functions implicitly
+  contains a clause "``... LIKE ... ESCAPE '~' ...``". In ODBC, the DBMS may
+  return '' if search-pattern escape is not supported for Catalog functions.
 
-* ``94 SQL_SPECIAL_CHARACTERS -- CHAR(254)`` The return is a character string 
-  containing all characters "other than upper case letters, lower case letters, 
-  digits and underscore" which can appear in <regular identifier>s. 
-  
-   * Note 1: This definition has nothing to do with the SQL Standard's 
+* ``13 SQL_SERVER_NAME -- CHAR(128)`` The return is a character string: the
+  implementation-defined character string which is the "actual name" of a
+  server. This often will be the same as the string returned for
+  ``SQL_DATA_SOURCE_NAME``, but some implementations make a distinction between
+  "data source" and "server".
+
+* ``94 SQL_SPECIAL_CHARACTERS -- CHAR(254)`` The return is a character string
+  containing all characters "other than upper case letters, lower case letters,
+  digits and underscore" which can appear in <regular identifier>s.
+
+   * Note 1: This definition has nothing to do with the SQL Standard's
      definition for special characters.
-   
+
    * Note 2: This definition is not the same as the definition ODBC uses.
-   
-   * Note 3: An SQL standard DBMS will return a blank string here. If you want 
-     to use strange non-alphabetic characters in names, use <delimited 
+
+   * Note 3: An SQL standard DBMS will return a blank string here. If you want
+     to use strange non-alphabetic characters in names, use <delimited
      identifier>s.
 
-* ``46 SQL_TRANSACTION_CAPABLE -- SMALLINT`` The return is a number indicating 
-  what sort of SQL statements the DBMS allows within a transaction. The 
+* ``46 SQL_TRANSACTION_CAPABLE -- SMALLINT`` The return is a number indicating
+  what sort of SQL statements the DBMS allows within a transaction. The
   possible options are:
-  
+
    * [transactions are not supported at all]:
-     
+
      ::
-     
+
        0 (SQL_TC_NONE)
-     
+
    * [DML only, DDL causes error]:
-     
+
      ::
-     
+
        1 (SQL_TC_DML)
-     
+
    * [DML okay, DDL okay]:
-     
+
      ::
-     
+
        2 (SQL_TC_ALL)
-     
+
    * [DML okay, DDL causes ``COMMIT``]:
-     
+
      ::
-     
+
        3 (SQL_TC_COMMIT)
-     
+
    * [DML okay, DDL is ignored]:
-     
+
      ::
-     
+
        4 (SQL_TC_IGNORE)
 
-  DML stands for "data manipulation language" (``SELECT``, ``INSERT``, etc.); 
-  DDL stands for "data definition language" (``ALTER``, ``DROP``, ``GRANT``, 
-  ``CREATE``, ``REVOKE``). This addresses one of the implementation-defined 
-  questions in standard SQL: is a DDL statement just like any other or does it 
-  have to be in a transaction of its own? Since many DBMSs will automatically 
-  ``COMMIT`` before and after a DDL statement, you can expect the most common 
-  return to be ``SQL_TC_COMMIT``. No standard SQL DBMS will return 
-  ``SQL_TC_NONE``. In ODBC, the code name is ``SQL_TXN_CAPABLE``. 
+  DML stands for "data manipulation language" (``SELECT``, ``INSERT``, etc.);
+  DDL stands for "data definition language" (``ALTER``, ``DROP``, ``GRANT``,
+  ``CREATE``, ``REVOKE``). This addresses one of the implementation-defined
+  questions in standard SQL: is a DDL statement just like any other or does it
+  have to be in a transaction of its own? Since many DBMSs will automatically
+  ``COMMIT`` before and after a DDL statement, you can expect the most common
+  return to be ``SQL_TC_COMMIT``. No standard SQL DBMS will return
+  ``SQL_TC_NONE``. In ODBC, the code name is ``SQL_TXN_CAPABLE``.
 
-* ``72 SQL_TRANSACTION_ISOLATION_OPTION -- INTEGER`` The return is a bitmask, 
-  with zero or more bits on, depending on the isolation levels the DBMS 
+* ``72 SQL_TRANSACTION_ISOLATION_OPTION -- INTEGER`` The return is a bitmask,
+  with zero or more bits on, depending on the isolation levels the DBMS
   supports. The possible options are:
-  
-   * [supports ``READ UNCOMMITTED`` level]:
-     
-     ::
-     
-       0001 hex (SQL_TRANSACTION_READ_UNCOMMITTED)
-     
-   * [supports ``READ COMMITTED`` level]:
-     
-     ::
-     
-       0002 hex (SQL_TRANSACTION_READ_COMMITTED)
-     
-   * [supports ``REPEATABLE READ`` level]:
-     
-     ::
-     
-       0004 hex (SQL_TRANSACTION_REPEATABLE_READ)
-     
-   * [supports ``SERIALIZABLE`` level]:
-     
-     ::
-     
-       0008 hex (SQL_TRANSACTION_SERIALIZABLE)
-     
-  Standard SQL DBMSs will at least return ``SQL_TRANSACTION_SERIALIZABLE``, 
-  since ``SERIALIZABLE`` must be the default isolation level. Standard SQL 
-  DBMSs will allow all four options in ``SET TRANSACTION`` statements, but it's 
-  implementation-defined whether a DBMS can in fact go to a higher level. For 
-  instance, the DBMS may respond to a ``SET TRANSACTION ISOLATION LEVEL 
-  REPEATABLE READ;`` request by setting the isolation level to 
-  ``SERIALIZABLE``, a higher level. In ODBC, the code name is 
-  ``SQL_TXN_ISOLATION_OPTION``. 
 
-* ``47 SQL_USER_NAME -- CHAR(128)`` The return is a character string which is 
+   * [supports ``READ UNCOMMITTED`` level]:
+
+     ::
+
+       0001 hex (SQL_TRANSACTION_READ_UNCOMMITTED)
+
+   * [supports ``READ COMMITTED`` level]:
+
+     ::
+
+       0002 hex (SQL_TRANSACTION_READ_COMMITTED)
+
+   * [supports ``REPEATABLE READ`` level]:
+
+     ::
+
+       0004 hex (SQL_TRANSACTION_REPEATABLE_READ)
+
+   * [supports ``SERIALIZABLE`` level]:
+
+     ::
+
+       0008 hex (SQL_TRANSACTION_SERIALIZABLE)
+
+  Standard SQL DBMSs will at least return ``SQL_TRANSACTION_SERIALIZABLE``,
+  since ``SERIALIZABLE`` must be the default isolation level. Standard SQL
+  DBMSs will allow all four options in ``SET TRANSACTION`` statements, but it's
+  implementation-defined whether a DBMS can in fact go to a higher level. For
+  instance, the DBMS may respond to a ``SET TRANSACTION ISOLATION LEVEL
+  REPEATABLE READ;`` request by setting the isolation level to
+  ``SERIALIZABLE``, a higher level. In ODBC, the code name is
+  ``SQL_TXN_ISOLATION_OPTION``.
+
+* ``47 SQL_USER_NAME -- CHAR(128)`` The return is a character string which is
   the same value ``CURRENT_USER`` function.
 
 **Algorithm:**
@@ -910,21 +912,21 @@ code exists but the meaning is different.
 
 **Notes:**
 
-* You want to write a portable DBMS application? Then you have to keep asking 
-  yourself: does every DBMS support the feature(s) you're using, in the way you 
-  use them? Hint: the answer is no. We've come a long way in the last few 
-  years, and the support for "standard SQL" is a lot better than it once was. 
-  But there are always DBMSs behind the curve, and always applications that 
-  push the envelope. The ``SQLGetInfo`` function is designed to provide 
-  information for the most common questions and unresolved issues. 
+* You want to write a portable DBMS application? Then you have to keep asking
+  yourself: does every DBMS support the feature(s) you're using, in the way you
+  use them? Hint: the answer is no. We've come a long way in the last few
+  years, and the support for "standard SQL" is a lot better than it once was.
+  But there are always DBMSs behind the curve, and always applications that
+  push the envelope. The ``SQLGetInfo`` function is designed to provide
+  information for the most common questions and unresolved issues.
 
-* Many ``SQLGetInfo`` variants ask about non-standard features or non-standard 
-  behaviour. If you know that your DBMS is completely standard, then you 
-  shouldn't have to ask these questions. 
+* Many ``SQLGetInfo`` variants ask about non-standard features or non-standard
+  behaviour. If you know that your DBMS is completely standard, then you
+  shouldn't have to ask these questions.
 
-**Example:** In this code snippet we will use the four main types of 
-``SQLGetInfo`` returns: to a smallint, to a bitmask, to a ``CHAR(1)`` string 
-and to a long string. We assume that ``SQLConnect`` has happened already. 
+**Example:** In this code snippet we will use the four main types of
+``SQLGetInfo`` returns: to a smallint, to a bitmask, to a ``CHAR(1)`` string
+and to a long string. We assume that ``SQLConnect`` has happened already.
 
 ::
 
@@ -967,8 +969,8 @@ Compare the ODBC prototype for ``SQLGetInfo`` with the standard SQL prototype:
         SQLSMALLINT *StringLength     SQLINTEGER *StringLength
         );                            );
 
-The types are incompatible! This will probably be fixed by the time you read 
-this -- check this book's web site to see how the matter was resolved. 
+The types are incompatible! This will probably be fixed by the time you read
+this -- check this book's web site to see how the matter was resolved.
 
-And that's it for the CLI general functions. In the next chapter, we'll take a 
+And that's it for the CLI general functions. In the next chapter, we'll take a
 look at the deferred parameter functions.

--- a/docs/chapters/49.rst
+++ b/docs/chapters/49.rst
@@ -4,10 +4,12 @@
 Chapter 49 -- SQL/CLI: Deferred Parameter Functions
 ===================================================
 
-This short chapter describes an option for passing input parameters after 
-execution begins. [Obscure Rule] applies for the whole thing. 
+.. include:: ../_include/note.rst
 
-The concept behind deferred parameters is illustrated by these two flow charts: 
+This short chapter describes an option for passing input parameters after
+execution begins. [Obscure Rule] applies for the whole thing.
+
+The concept behind deferred parameters is illustrated by these two flow charts:
 
 ::
 
@@ -29,28 +31,28 @@ The concept behind deferred parameters is illustrated by these two flow charts:
                                        - SQLExecute (continued) -
                                        --------------------------
 
-Briefly stated: in the immediate-parameter situation all necessary information 
-is supplied before SQL statement execution begins; in the deferred-parameter 
-situation the execution is interrupted and the host supplies the missing 
-information by calling ``SQLParam`` and ``SQLPutData``. 
+Briefly stated: in the immediate-parameter situation all necessary information
+is supplied before SQL statement execution begins; in the deferred-parameter
+situation the execution is interrupted and the host supplies the missing
+information by calling ``SQLParam`` and ``SQLPutData``.
 
-Programmers can survive with immediate parameters alone. Indeed, in all the 
-previous chapters we have assumed that deferred parameters won't happen -- had 
-we allowed for them, we would have had to do some things differently. 
+Programmers can survive with immediate parameters alone. Indeed, in all the
+previous chapters we have assumed that deferred parameters won't happen -- had
+we allowed for them, we would have had to do some things differently.
 
-The reasons for use of deferred parameters are: 
+The reasons for use of deferred parameters are:
 
-* Long strings can be passed a piece at a time. This was an important thing in 
-  the days of 16-bit operating systems, when the maximum string size was 
-  effectively limited by the segment size. 
+* Long strings can be passed a piece at a time. This was an important thing in
+  the days of 16-bit operating systems, when the maximum string size was
+  effectively limited by the segment size.
 
-* Microsoft uses deferred parameters in ODBC examples and test programs. 
+* Microsoft uses deferred parameters in ODBC examples and test programs.
 
-These are the days of 32-bit operating systems. Passing large buffers is no 
-longer a problem. However, deferred parameters are still part of the standard 
-SQL CLI. You might see them in legacy code, or in some exotic applications (for 
-example, packet transfers). You will not see deferred parameters in embedded 
-SQL or PSM applications. 
+These are the days of 32-bit operating systems. Passing large buffers is no
+longer a problem. However, deferred parameters are still part of the standard
+SQL CLI. You might see them in legacy code, or in some exotic applications (for
+example, packet transfers). You will not see deferred parameters in embedded
+SQL or PSM applications.
 
 .. rubric:: Table of Contents
 
@@ -81,7 +83,7 @@ For example:
     SQLGetStmtAttr(hstmt,SQL_ATTR_IMP_PARAM_DESC,&hdesc,NULL,NULL);
     SQLSetDescField(hdesc,1,SQL_DESC_OCTET_LENGTH_POINTER,&dp,NULL);
 
-* Looking for ``SQL_NEED_DATA`` after ``SQLExecDirect`` or ``SQLExecDirect`` 
+* Looking for ``SQL_NEED_DATA`` after ``SQLExecDirect`` or ``SQLExecDirect``
   -- for example:
 
 ::
@@ -89,14 +91,14 @@ For example:
     sqlreturn = SQLExecute(hstmt);
     if (sqlreturn == SQL_NEED_DATA) /* deferred parameter seen ... */
 
-* Looping -- calling ``SQLParamData`` for each parameter and calling 
+* Looping -- calling ``SQLParamData`` for each parameter and calling
   ``SQLPutData`` for each piece of data in each parameter.
 
-The two CLI functions needed for deferred parameter support are 
-``SQLParamData`` and ``SQLPutData``; their descriptions follow. We'll also 
-describe ``SQLCancel`` in this chapter -- it might be used to cancel functions 
-which are waiting for deferred parameters (hence its inclusion here), but might 
-have unrelated uses as well. 
+The two CLI functions needed for deferred parameter support are
+``SQLParamData`` and ``SQLPutData``; their descriptions follow. We'll also
+describe ``SQLCancel`` in this chapter -- it might be used to cancel functions
+which are waiting for deferred parameters (hence its inclusion here), but might
+have unrelated uses as well.
 
 SQLParamData
 ============
@@ -110,8 +112,8 @@ SQLParamData
     SQLPOINTER *Value              /* pointer to ANY* output */
     );
 
-**Job:** Check whether a deferred parameter value is needed. If so: interrupt; 
-if not: continue with previously-interrupted statement execution. 
+**Job:** Check whether a deferred parameter value is needed. If so: interrupt;
+if not: continue with previously-interrupted statement execution.
 
 **Algorithm:**
 
@@ -136,31 +138,31 @@ if not: continue with previously-interrupted statement execution.
 
 **Notes:**
 
-* ``SQLParamData`` is needed if ``SQLExecute`` or ``SQLExecDirect`` returns 
-  ``SQL_NEED_DATA (+99)``. In its turn, ``SQLParamData`` causes a further 
-  generation of ``SQL_NEED_DATA`` (if there are more parameters to process), or 
-  else it finishes off the execution that began with ``SQLExecute`` or 
-  ``SQLExecDirect``. 
+* ``SQLParamData`` is needed if ``SQLExecute`` or ``SQLExecDirect`` returns
+  ``SQL_NEED_DATA (+99)``. In its turn, ``SQLParamData`` causes a further
+  generation of ``SQL_NEED_DATA`` (if there are more parameters to process), or
+  else it finishes off the execution that began with ``SQLExecute`` or
+  ``SQLExecDirect``.
 
-* If ``SQL_NEED_DATA`` has been returned, the deferred parameter must be dealt 
-  with. You will get an error if you attempt to call any of these functions -- 
-  ``SQLCopyDesc``, ``SQLFreeHandle``, ``SQLEndTran``, ``SQLDisconnect``, 
-  ``SQLGetDescField``, ``SQLGetDescRec``, ``SQLSetDescField``, 
-  ``SQLSetDescRec`` -- using the same ``hstmt``, or using a ``hdesc`` 
-  associated with the deferred parameter. A ``stmt`` with a deferred parameter 
-  is considered to be "active". An active ``stmt`` may be cancelled (with the 
-  ``SQLCancel`` function), but the only recommended action is to call 
-  ``SQLParamData``. 
+* If ``SQL_NEED_DATA`` has been returned, the deferred parameter must be dealt
+  with. You will get an error if you attempt to call any of these functions --
+  ``SQLCopyDesc``, ``SQLFreeHandle``, ``SQLEndTran``, ``SQLDisconnect``,
+  ``SQLGetDescField``, ``SQLGetDescRec``, ``SQLSetDescField``,
+  ``SQLSetDescRec`` -- using the same ``hstmt``, or using a ``hdesc``
+  associated with the deferred parameter. A ``stmt`` with a deferred parameter
+  is considered to be "active". An active ``stmt`` may be cancelled (with the
+  ``SQLCancel`` function), but the only recommended action is to call
+  ``SQLParamData``.
 
-* ``SQL_NEED_DATA`` is a positive value ``(+99)``. Therefore, if you use 
-  deferred parameters, you must not use the blithe code we've used in our 
-  examples so far: 
-  
+* ``SQL_NEED_DATA`` is a positive value ``(+99)``. Therefore, if you use
+  deferred parameters, you must not use the blithe code we've used in our
+  examples so far:
+
   ::
-  
+
      if (sqlreturn < 0) /* error */
      if (sqlreturn >= 0) /* all's well, must be warning or success */
-  
+
   As we said earlier, some of your operating assumptions must change if this
   option is used.
 
@@ -204,40 +206,40 @@ SQLPutData
 * ``SQLPutData`` can be used repeatedly if (for a long character or binary
   string) the data must be supplied in pieces.
 
-* Nullness trumps deferrability. If there's an indicator and it's ``-1 
-  (SQL_NULL_DATA)``, then the parameter passed is ``NULL`` -- there is no 
+* Nullness trumps deferrability. If there's an indicator and it's ``-1
+  (SQL_NULL_DATA)``, then the parameter passed is ``NULL`` -- there is no
   deferring.
 
-**Example:** In the following example, we will pass ``CHAR(4)`` parameters in 
-four separate pieces, one character at a time. This is absurdly small -- 
-usually pieces are at least 2 kilobytes -- but it illustrates the method 
-nicely. Try to imagine that the data is input from some large file, or 
-pipeline. The algorithm works like this: 
+**Example:** In the following example, we will pass ``CHAR(4)`` parameters in
+four separate pieces, one character at a time. This is absurdly small --
+usually pieces are at least 2 kilobytes -- but it illustrates the method
+nicely. Try to imagine that the data is input from some large file, or
+pipeline. The algorithm works like this:
 
 * Application initializes in the usual way.
 
 * Application prepares an ``INSERT`` statement.
 
-* Applications calls ``SQLBindParameter`` for two ``SQL_DATA_AT_EXEC`` 
-  parameters. The application identifies the parameters as #1 and #2 -- later, 
-  those values will be retrieved by ``SQLParamData``. Thus the values identify 
-  which parameter is being processed. 
+* Applications calls ``SQLBindParameter`` for two ``SQL_DATA_AT_EXEC``
+  parameters. The application identifies the parameters as #1 and #2 -- later,
+  those values will be retrieved by ``SQLParamData``. Thus the values identify
+  which parameter is being processed.
 
-* Application calls ``SQLExecute`` for the prepared ``INSERT`` statement. DBMS 
-  returns ``SQL_NEED_DATA`` because ``SQL_DATA_AT_EXEC`` parameters exist. 
+* Application calls ``SQLExecute`` for the prepared ``INSERT`` statement. DBMS
+  returns ``SQL_NEED_DATA`` because ``SQL_DATA_AT_EXEC`` parameters exist.
 
-* Application calls ``SQLParamData``. DBMS returns ``SQL_NEED_DATA`` because 
-  ``SQL_DATA_AT_EXEC`` parameters exist. DBMS also fills in the parameter 
-  number -- #1 -- from ``SQLBindParameter`` pass. Loop: 
-  
+* Application calls ``SQLParamData``. DBMS returns ``SQL_NEED_DATA`` because
+  ``SQL_DATA_AT_EXEC`` parameters exist. DBMS also fills in the parameter
+  number -- #1 -- from ``SQLBindParameter`` pass. Loop:
+
    * Application calls ``SQLPutData`` for the next piece.
-   
-   * Loop ends when the application has no more pieces.
-   
-* Application calls ``SQLParamdata`` again. DBMS returns ``SQL_SUCCESS`` 
-  because there are no more parameters to process. 
 
-* Application cleans up in the usual way. 
+   * Loop ends when the application has no more pieces.
+
+* Application calls ``SQLParamdata`` again. DBMS returns ``SQL_SUCCESS``
+  because there are no more parameters to process.
+
+* Application cleans up in the usual way.
 
 ::
 
@@ -323,16 +325,16 @@ SQLCancel
     SQLHSTMT hstmt                        /* 32-bit input */
     );
 
-**Job:** (Try to) stop a currently-executing function. There are two things 
+**Job:** (Try to) stop a currently-executing function. There are two things
 that "currently-executing" might mean:
 
 * Scenario #1: The ``hstmt`` is associated with a deferred parameter.
 
-* Scenario #2: A routine associated with the ``stmt`` might be running 
-  "concurrently". For example, in an MS-Windows environment, you might call a 
-  CLI function in one thread, but now you're in another thread, and the 
-  function is still running. You know what the ``stmt`` handle is and you want 
-  to stop the function. 
+* Scenario #2: A routine associated with the ``stmt`` might be running
+  "concurrently". For example, in an MS-Windows environment, you might call a
+  CLI function in one thread, but now you're in another thread, and the
+  function is still running. You know what the ``stmt`` handle is and you want
+  to stop the function.
 
 **Algorithm:**
 
@@ -343,9 +345,9 @@ For Scenario #1:
    Clear the diagnostics area.
    Disassociate the statement source and parameter number from the stmt.
 
-It is now possible to call ``SQLEndTran``, ``SQLDisconnect``, 
-``SQLFreeHandle``, etc. -- otherwise, you would have to fill in the 
-deferred-parameter values. See the description of deferred parameters. 
+It is now possible to call ``SQLEndTran``, ``SQLDisconnect``,
+``SQLFreeHandle``, etc. -- otherwise, you would have to fill in the
+deferred-parameter values. See the description of deferred parameters.
 
 For Scenario #2
 
@@ -361,27 +363,27 @@ For Scenario #2
     If (cancel succeeds)
       The server returns: okay.
 
-The cancelled routine can leave diagnostics behind, if it was running 
-asynchronously. (However, in ODBC, a routine which was cancelled from another 
-thread will leave no diagnostics behind.) 
+The cancelled routine can leave diagnostics behind, if it was running
+asynchronously. (However, in ODBC, a routine which was cancelled from another
+thread will leave no diagnostics behind.)
 
 **Notes:**
 
-* A "successful completion" of this function doesn't mean much; it only means 
-  that the server has seen and accepted the request to cancel. More significant 
-  is the return that the cancelled function returns: ``HY008 CLI-specific 
-  condition-operation cancelled.`` 
+* A "successful completion" of this function doesn't mean much; it only means
+  that the server has seen and accepted the request to cancel. More significant
+  is the return that the cancelled function returns: ``HY008 CLI-specific
+  condition-operation cancelled.``
 
-* We believe that ``SQLCancel`` is used most frequently for the situation 
-  described as "Scenario #1". For the situation described as "Scenario #2", 
-  there is heavy dependence on operating-system features so it is not possible 
-  to specify exactly how ``SQLCancel`` works in standard SQL. 
+* We believe that ``SQLCancel`` is used most frequently for the situation
+  described as "Scenario #1". For the situation described as "Scenario #2",
+  there is heavy dependence on operating-system features so it is not possible
+  to specify exactly how ``SQLCancel`` works in standard SQL.
 
-* The cancelled routine might have already done some diagnostics and the 
-  diagnostics area is not cleared. Other than that, a cancelled routine leaves 
-  no effect. 
+* The cancelled routine might have already done some diagnostics and the
+  diagnostics area is not cleared. Other than that, a cancelled routine leaves
+  no effect.
 
-**Example:** This example shows the use of ``SQLCancel`` against an active 
+**Example:** This example shows the use of ``SQLCancel`` against an active
 process with deferred parameters.
 
 ::
@@ -392,12 +394,12 @@ process with deferred parameters.
    if (SQLExecute(hstmt) == SQL_NEED_DATA) {
      SQLCancel(hstmt); }
 
-This example shows the use of ``SQLCancel`` against an asynchronous process on 
-another thread. It works like this: suppose you are shutting down, and there is 
-some asynch/other-thread function that you've given up on. To make sure you are 
-cancelling, you have to check two things: "Did ``SQLCancel`` work?" (that tells 
-you that the server accepts the request to cancel), and "Did the cancelled 
-function fail? (that tells you that the server succeeded in cancelling). 
+This example shows the use of ``SQLCancel`` against an asynchronous process on
+another thread. It works like this: suppose you are shutting down, and there is
+some asynch/other-thread function that you've given up on. To make sure you are
+cancelling, you have to check two things: "Did ``SQLCancel`` work?" (that tells
+you that the server accepts the request to cancel), and "Did the cancelled
+function fail? (that tells you that the server succeeded in cancelling).
 
 ::
 
@@ -418,11 +420,11 @@ function fail? (that tells you that the server succeeded in cancelling).
             /* Probably the function finished normally, i.e. the */
             /* SQLCancel arrived too late. The statement is over. */
 
-**ODBC:** The ``SQLCancel`` function has been around since ODBC 1.0. In ODBC 
-2.x, ``SQLCancel(StatementHandle)`` was precisely the same as 
-``SQLFreeStmt(StatementHandle,SQL_CLOSE)`` if there was no asynch running. That 
-is no longer so! If you want to close a Cursor, with ODBC 3.x or with the 
-standard CLI, you must use ``SQLCloseCursor (hstmt)``. 
+**ODBC:** The ``SQLCancel`` function has been around since ODBC 1.0. In ODBC
+2.x, ``SQLCancel(StatementHandle)`` was precisely the same as
+``SQLFreeStmt(StatementHandle,SQL_CLOSE)`` if there was no asynch running. That
+is no longer so! If you want to close a Cursor, with ODBC 3.x or with the
+standard CLI, you must use ``SQLCloseCursor (hstmt)``.
 
-And that's it for the CLI deferred parameter functions. In the next chapter, 
-we'll take a look at the locator functions. 
+And that's it for the CLI deferred parameter functions. In the next chapter,
+we'll take a look at the locator functions.

--- a/docs/chapters/50.rst
+++ b/docs/chapters/50.rst
@@ -4,10 +4,12 @@
 Chapter 50 -- SQL/CLI: Locator Functions
 ========================================
 
-In this chapter, we'll describe the CLI locator functions: ``SQLGetLength``, 
-``SQLGetPosition`` and ``SQLGetSubstring``. These functions are used with 
-locators of ``BLOB``\s and ``CLOB``\s. They are new in SQL3; as far as we know, 
-no DBMS supports them. Our description is therefore fairly brief. 
+.. include:: ../_include/note.rst
+
+In this chapter, we'll describe the CLI locator functions: ``SQLGetLength``,
+``SQLGetPosition`` and ``SQLGetSubstring``. These functions are used with
+locators of ``BLOB``\s and ``CLOB``\s. They are new in SQL3; as far as we know,
+no DBMS supports them. Our description is therefore fairly brief.
 
 .. rubric:: Table of Contents
 
@@ -17,38 +19,38 @@ no DBMS supports them. Our description is therefore fairly brief.
 What is a Locator?
 ==================
 
-When you assign the value of a ``BLOB``, ``CLOB``, ``NCLOB``, ``UDT`` or 
-``ARRAY`` to an embedded host language variable or a host language parameter, 
-your DBMS generates and assigns a locator to the target, to uniquely identify a 
-value of the corresponding type. The locator is a 4-octet, non-zero integer 
-(that is, locators are 32-bit ``INT``\s), and exists only until the current 
-transaction ends (unless it is held). 
+When you assign the value of a ``BLOB``, ``CLOB``, ``NCLOB``, ``UDT`` or
+``ARRAY`` to an embedded host language variable or a host language parameter,
+your DBMS generates and assigns a locator to the target, to uniquely identify a
+value of the corresponding type. The locator is a 4-octet, non-zero integer
+(that is, locators are 32-bit ``INT``\s), and exists only until the current
+transaction ends (unless it is held).
 
-Locators have certain properties. 
+Locators have certain properties.
 
 * A locator may be either valid or invalid.
 
 * A locator may be a holdable locator.
 
-When a locator is initially created, it is marked valid and (if applicable) not 
-holdable. You have to execute a ``HOLD LOCATOR`` statement before the end of 
-the transaction in which a locator is created if you want that locator to be 
-holdable. A non-holdable locator remains valid until the end of the transaction 
-in which it was generated, unless it is explicitly made invalid by a ``FREE 
-LOCATOR`` statement or a ``ROLLBACK WITH SAVEPOINT`` statement. A holdable 
-locator may remain valid beyond the end of the transaction in which it was 
-generated; it becomes invalid when you execute a ``FREE LOCATOR`` statement, a 
-``ROLLBACK WITH SAVEPOINT`` statement with a ``SAVEPOINT`` clause or if the 
-transaction in which it is generated (or any subsequent transaction) is rolled 
-back. All locators are made invalid when the current SQL-session ends. 
+When a locator is initially created, it is marked valid and (if applicable) not
+holdable. You have to execute a ``HOLD LOCATOR`` statement before the end of
+the transaction in which a locator is created if you want that locator to be
+holdable. A non-holdable locator remains valid until the end of the transaction
+in which it was generated, unless it is explicitly made invalid by a ``FREE
+LOCATOR`` statement or a ``ROLLBACK WITH SAVEPOINT`` statement. A holdable
+locator may remain valid beyond the end of the transaction in which it was
+generated; it becomes invalid when you execute a ``FREE LOCATOR`` statement, a
+``ROLLBACK WITH SAVEPOINT`` statement with a ``SAVEPOINT`` clause or if the
+transaction in which it is generated (or any subsequent transaction) is rolled
+back. All locators are made invalid when the current SQL-session ends.
 
-The following items can have the "data type" ``LOCATOR``: a host variable, a 
-host parameter, an SQL parameter in an external routine and a value returned by 
-external function. To specify an item as a locator, add the <keyword>s ``AS 
-LOCATOR`` to the specification. According to the SQL Standard, this then allows 
-the passing of very large data values "without transferring the entire value to 
-and from the SQL-agent". That is -- if you're dealing with an image, why do 
-this: 
+The following items can have the "data type" ``LOCATOR``: a host variable, a
+host parameter, an SQL parameter in an external routine and a value returned by
+external function. To specify an item as a locator, add the <keyword>s ``AS
+LOCATOR`` to the specification. According to the SQL Standard, this then allows
+the passing of very large data values "without transferring the entire value to
+and from the SQL-agent". That is -- if you're dealing with an image, why do
+this:
 
 * DBMS reads into DBMS memory
 
@@ -64,42 +66,42 @@ of each follow.
 *FREE LOCATOR Statement*
 ------------------------
 
-The ``FREE LOCATOR`` statement removes the association between a locator 
-variable or parameter and the value represented by that locator. The required 
-syntax for the ``FREE LOCATOR`` statement is: 
+The ``FREE LOCATOR`` statement removes the association between a locator
+variable or parameter and the value represented by that locator. The required
+syntax for the ``FREE LOCATOR`` statement is:
 
 ::
 
     FREE LOCATOR :host_parameter_name> [ {,:host_parameter_name}... ]
 
-The ``FREE LOCATOR`` statement frees one or more locators -- that is, it marks 
-the locators identified by the <host parameter name>s as invalid. 
+The ``FREE LOCATOR`` statement frees one or more locators -- that is, it marks
+the locators identified by the <host parameter name>s as invalid.
 
-If you want to restrict your code to Core SQL, don't use the ``FREE LOCATOR`` 
-statement. 
+If you want to restrict your code to Core SQL, don't use the ``FREE LOCATOR``
+statement.
 
 *HOLD LOCATOR Statement*
 ------------------------
 
-The ``HOLD LOCATOR`` statement marks a locator variable or parameter as a 
-holdable locator. The required syntax for the ``HOLD LOCATOR`` statement is: 
+The ``HOLD LOCATOR`` statement marks a locator variable or parameter as a
+holdable locator. The required syntax for the ``HOLD LOCATOR`` statement is:
 
 ::
 
     HOLD LOCATOR :host_parameter_name> [ {,:host_parameter_name}... ]
 
-The ``HOLD LOCATOR`` statement lets you change the status of one or more 
-locators from non-holdable to holdable. The difference between the two status 
-has to do with when a locator becomes invalid: a non-holdable locator remains 
-valid until the end of the transaction in which it was generated (unless it is 
-explicitly made invalid), while a holdable locator may remain valid beyond the 
-end of the transaction in which it was generated. All locators are made invalid 
-when the current SQL-session ends. 
+The ``HOLD LOCATOR`` statement lets you change the status of one or more
+locators from non-holdable to holdable. The difference between the two status
+has to do with when a locator becomes invalid: a non-holdable locator remains
+valid until the end of the transaction in which it was generated (unless it is
+explicitly made invalid), while a holdable locator may remain valid beyond the
+end of the transaction in which it was generated. All locators are made invalid
+when the current SQL-session ends.
 
-If you want to restrict your code to Core SQL, don't use the ``HOLD LOCATOR`` 
-statement. 
+If you want to restrict your code to Core SQL, don't use the ``HOLD LOCATOR``
+statement.
 
-The rest of this chapter describes the three CLI locator functions. 
+The rest of this chapter describes the three CLI locator functions.
 
 SQLGetLength
 ============
@@ -116,7 +118,7 @@ SQLGetLength
     SQLINTEGER *IndicatorValue      /* pointer to 32-bit output */
     );
 
-**Job:** Return the length of the value represented by a ``BLOB``, ``CLOB``, 
+**Job:** Return the length of the value represented by a ``BLOB``, ``CLOB``,
 ``NCLOB``, ``UDT`` or ``ARRAY`` locator.
 
 **Algorithm:**
@@ -135,7 +137,7 @@ SQLGetLength
     Or (LocatorType==SQL_UDT_LOCATOR and Locator doesn't refer to a UDT)
     Or (LocatorType==SQL_ARRAY_LOCATOR and Locator doesn't refer to an ARRAY)
       return error: dynamic SQL error-restricted data type attribute violation
-    
+
     Case:
     If (the Large Object's value is NULL)
       If (IndicatorValue is a null pointer)
@@ -155,7 +157,7 @@ SQLGetLength
 
 **Notes:**
 
-* The octet length and the character length will be the same value only if 
+* The octet length and the character length will be the same value only if
   8-bit Character sets are in use.
 
 **Example:**
@@ -191,7 +193,7 @@ SQLGetPosition
     SQLINTEGER *IndicatorValue        /* pointer to 32-bit integer */
     );
 
-**Job:** Return the position of a passed string within a ``BLOB``, ``CLOB``, 
+**Job:** Return the position of a passed string within a ``BLOB``, ``CLOB``,
 ``NCLOB``, ``UDT`` or ``ARRAY``.
 
 **Algorithm:**
@@ -241,8 +243,8 @@ SQLGetSubstring
     SQLINTEGER *StringLength,             /* pointer to integer output */
     SQLINTEGER *IndicatorValue);          /* pointer to integer output */
 
-**Job:** Extract a portion of a ``BLOB``, ``CLOB``, ``NCLOB``, ``UDT`` or 
-``ARRAY``, returning the result as a string or, alternatively, as a new 
+**Job:** Extract a portion of a ``BLOB``, ``CLOB``, ``NCLOB``, ``UDT`` or
+``ARRAY``, returning the result as a string or, alternatively, as a new
 ``BLOB``, ``CLOB``, ``NCLOB``, ``UDT`` or ``ARRAY``.
 
 **Algorithm:**

--- a/docs/chapters/51.rst
+++ b/docs/chapters/51.rst
@@ -4,11 +4,13 @@
 Chapter 51 -- SQL/CLI: Catalog Functions
 ========================================
 
-The CLI Catalog functions are so called because they involve implicit searches 
-of the metadata -- what in pre-SQL-92 days was known as the *system catalog*. 
-Nowadays the metadata is in ``INFORMATION_SCHEMA``. The functions, and the 
-``INFORMATION_SCHEMA`` Views which provides most of the information for them, 
-are: 
+.. include:: ../_include/note.rst
+
+The CLI Catalog functions are so called because they involve implicit searches
+of the metadata -- what in pre-SQL-92 days was known as the *system catalog*.
+Nowadays the metadata is in ``INFORMATION_SCHEMA``. The functions, and the
+``INFORMATION_SCHEMA`` Views which provides most of the information for them,
+are:
 
 +--------------------------+------------------------------------------------------+
 | Function                 | Related ``INFORMATION_SCHEMA`` View(s)               |
@@ -61,95 +63,95 @@ Catalogs and use the simple mechanisms you already know. It's cleaner to
 Some necessary preliminaries
 ============================
 
-Calling a Catalog function is equivalent to calling ``SQLExecDirect`` with an 
-argument containing a ``SELECT`` statement. That means that data is returned in 
-a result set. You may traverse the rows in the result set using ``SQLFetch`` or 
-``SQLFetchScroll``. You should call ``SQLCloseCursor`` when there is nothing 
-more to fetch. 
+Calling a Catalog function is equivalent to calling ``SQLExecDirect`` with an
+argument containing a ``SELECT`` statement. That means that data is returned in
+a result set. You may traverse the rows in the result set using ``SQLFetch`` or
+``SQLFetchScroll``. You should call ``SQLCloseCursor`` when there is nothing
+more to fetch.
 
-For most Catalog functions, you pass (character string) input parameters to 
-specify which rows should be selected for the result set. There are several 
-rules concerning these input parameters. There is no use trying to figure out 
-what the rationale is behind these rules. You'll simply have to learn them if 
-you want Catalog functions to work reliably. Here they are: 
+For most Catalog functions, you pass (character string) input parameters to
+specify which rows should be selected for the result set. There are several
+rules concerning these input parameters. There is no use trying to figure out
+what the rationale is behind these rules. You'll simply have to learn them if
+you want Catalog functions to work reliably. Here they are:
 
-* Accessible tables. You may recall that there is an option to the  
-  ``SQLGetInfo`` function, namely ``SQL_ACCESSIBLE_TABLES``, which returns as 
+* Accessible tables. You may recall that there is an option to the
+  ``SQLGetInfo`` function, namely ``SQL_ACCESSIBLE_TABLES``, which returns as
   follows:
-  
+
    * ``'Y'``: the DBMS only returns information about Tables to users
      who have ``SELECT`` Privileges on the Tables.
 
    * ``'N'``: the DBMS returns information about Tables based on some
      other, implementation-defined, criterion.
-     
-     In fact, all standard DBMSs should return ``'N'`` because information is 
-     available to users who have any Privileges on the Tables, not necessarily 
-     just ``SELECT`` Privileges. In all that follows, we will just assume that 
-     the ``INFORMATION_SCHEMA`` rows are the rows that would be available in 
-     standard SQL. 
 
-* Catalogs. Not every DBMS supports Catalogs. For the cases where we say that a 
-  <Catalog name> is retrieved, it is possible that the actual retrieval will be 
-  ``NULL``. Once again, this is a case where ``NULL`` means "not applicable". 
+     In fact, all standard DBMSs should return ``'N'`` because information is
+     available to users who have any Privileges on the Tables, not necessarily
+     just ``SELECT`` Privileges. In all that follows, we will just assume that
+     the ``INFORMATION_SCHEMA`` rows are the rows that would be available in
+     standard SQL.
 
-* Length. All input-string parameters are accompanied by a ``SMALLINT`` 
-  parameter -- the "length". This length should be the number of octets in the 
-  input string. The special value ``SQL_NTS`` is permissible. The special value 
-  ``0`` (zero) is permissible, and a zero-length string means "don't care" -- 
-  for example, if you pass a zero-length string for a parameter named 
-  ``*SchemaName``, the DBMS will accept all <Schema name>s in the Catalog. 
+* Catalogs. Not every DBMS supports Catalogs. For the cases where we say that a
+  <Catalog name> is retrieved, it is possible that the actual retrieval will be
+  ``NULL``. Once again, this is a case where ``NULL`` means "not applicable".
 
-* Metadata ID. You may recall that there is an option to the ``SQLGetStmtAttr`` 
-  function, namely ``SQL_ATTR_METADATA_ID``, which returns either ``TRUE`` (the 
-  ``METADATA ID`` attribute is ``TRUE``) or ``FALSE`` (the ``METADATA ID`` 
-  attribute is ``FALSE``). 
-  
+* Length. All input-string parameters are accompanied by a ``SMALLINT``
+  parameter -- the "length". This length should be the number of octets in the
+  input string. The special value ``SQL_NTS`` is permissible. The special value
+  ``0`` (zero) is permissible, and a zero-length string means "don't care" --
+  for example, if you pass a zero-length string for a parameter named
+  ``*SchemaName``, the DBMS will accept all <Schema name>s in the Catalog.
+
+* Metadata ID. You may recall that there is an option to the ``SQLGetStmtAttr``
+  function, namely ``SQL_ATTR_METADATA_ID``, which returns either ``TRUE`` (the
+  ``METADATA ID`` attribute is ``TRUE``) or ``FALSE`` (the ``METADATA ID``
+  attribute is ``FALSE``).
+
    * If ``METADATA ID`` is ``TRUE``:
-   
-     * If there is such a thing as a <Catalog name> (which is the case in all 
-       standard DBMSs), then you must not pass a null pointer for any Catalog 
-       function parameter which is labelled ``*CatalogName``. Passing a null 
-       pointer will result in the error: ``HY009 CLI-specific condition-invalid 
-       use of null pointer``. 
-       
-     * You must not pass a null pointer for any Catalog function parameter which 
-       is labelled ``*SchemaName``. Passing a null pointer will result in the 
-       error: ``HY009 CLI-specific condition-invalid use of null pointer``. 
-       
-     * You may pass a string which begins and ends with quotes, as is the custom 
-       for <delimited identifier>s. If you do pass a quoted string, the quotes 
-       are stripped and the string is not converted to upper case. If you don't 
-       pass a quoted string, the string is converted to upper case. 
-   
+
+     * If there is such a thing as a <Catalog name> (which is the case in all
+       standard DBMSs), then you must not pass a null pointer for any Catalog
+       function parameter which is labelled ``*CatalogName``. Passing a null
+       pointer will result in the error: ``HY009 CLI-specific condition-invalid
+       use of null pointer``.
+
+     * You must not pass a null pointer for any Catalog function parameter which
+       is labelled ``*SchemaName``. Passing a null pointer will result in the
+       error: ``HY009 CLI-specific condition-invalid use of null pointer``.
+
+     * You may pass a string which begins and ends with quotes, as is the custom
+       for <delimited identifier>s. If you do pass a quoted string, the quotes
+       are stripped and the string is not converted to upper case. If you don't
+       pass a quoted string, the string is converted to upper case.
+
    * If ``METADATA ID`` is ``FALSE``:
-   
-     * You may pass a null pointer for any string parameter. Doing so is 
-       equivalent to passing a string with zero length. 
-       
-     * The string may be treated as a search pattern; that is, wild cards are 
-       allowed as they are in ``LIKE`` predicates. If you need to find out what 
-       the value is for the escape character, call 
-       ``SQLGetInfo(hstmt,SQL_SEARCH_PATTERN_ESCAPE,...)``. 
-       
+
+     * You may pass a null pointer for any string parameter. Doing so is
+       equivalent to passing a string with zero length.
+
+     * The string may be treated as a search pattern; that is, wild cards are
+       allowed as they are in ``LIKE`` predicates. If you need to find out what
+       the value is for the escape character, call
+       ``SQLGetInfo(hstmt,SQL_SEARCH_PATTERN_ESCAPE,...)``.
+
        .. TIP::
-       
-          You'll only have to learn one set of rules if ``METADATA ID`` is 
-          always ``TRUE``. Therefore, as soon as you allocate a ``stmt``, 
+
+          You'll only have to learn one set of rules if ``METADATA ID`` is
+          always ``TRUE``. Therefore, as soon as you allocate a ``stmt``,
           execute this function:
-          
+
           ::
-          
+
             SQLSetStmtAttr(hstmt,SQL_ATTR_METADATA_ID,&1,NULL);
-          
-          and leave it that way. Henceforward, we'll forget about the 
+
+          and leave it that way. Henceforward, we'll forget about the
           possibility that ``METADATA ID`` could be ``FALSE``.
 
-In ODBC, searching is different in significant ways: quotes are not stripped, 
-<identifier>s are always converted to upper case, regardless of the value of 
-METADATA ID. If quotes are not present, then trail spaces are trimmed. The 
-character used for <delimited identifier>s may be something other than a quote 
-mark. 
+In ODBC, searching is different in significant ways: quotes are not stripped,
+<identifier>s are always converted to upper case, regardless of the value of
+METADATA ID. If quotes are not present, then trail spaces are trimmed. The
+character used for <delimited identifier>s may be something other than a quote
+mark.
 
 .. TIP::
 
@@ -219,9 +221,9 @@ SQLColumnPrivileges
     hstmt,CatalogName,SQL_NTS,SchemaName,SQL_NTS,TableName,
     SQL_NTS,ColumnName,SQL_NTS);
 
-**ODBC:** ``SQLColumnPrivileges`` has been around since ODBC 1.0. However, 
-searching is significantly different: see the earlier section titled "Some 
-Necessary Preliminaries". 
+**ODBC:** ``SQLColumnPrivileges`` has been around since ODBC 1.0. However,
+searching is significantly different: see the earlier section titled "Some
+Necessary Preliminaries".
 
 SQLColumns
 ==========
@@ -419,47 +421,47 @@ SQLColumns
 
 **Notes:**
 
-* The algorithm's ``SELECT`` statement does not reflect some minor matters. See 
-  the earlier section titled "Some Necessary Preliminaries". 
+* The algorithm's ``SELECT`` statement does not reflect some minor matters. See
+  the earlier section titled "Some Necessary Preliminaries".
 
-* Some of the newer SQL3 <data type>s, for instance ``BOOLEAN``, are not yet 
-  representable by a numeric ``DATA_TYPE`` code. 
+* Some of the newer SQL3 <data type>s, for instance ``BOOLEAN``, are not yet
+  representable by a numeric ``DATA_TYPE`` code.
 
-* ``TYPE_NAME`` is implementation-defined. This field is supposed to 
-  accommodate DBMSs which use non-standard <data type> names. 
+* ``TYPE_NAME`` is implementation-defined. This field is supposed to
+  accommodate DBMSs which use non-standard <data type> names.
 
-* ``COLUMN_SIZE`` is implementation-defined when the <data type> is 
-  ``SMALLINT``, ``INTEGER``, ``REAL``, ``FLOAT`` or ``DOUBLE PRECISION``. For 
-  what's above, we assumed that the DBMS will return ``NUMERIC_PRECISION``. 
+* ``COLUMN_SIZE`` is implementation-defined when the <data type> is
+  ``SMALLINT``, ``INTEGER``, ``REAL``, ``FLOAT`` or ``DOUBLE PRECISION``. For
+  what's above, we assumed that the DBMS will return ``NUMERIC_PRECISION``.
 
-* What's above does not show all the calculations required for ``INTERVAL`` 
-  <data type>s. Put simply, the rule is that ``COLUMN_SIZE`` is the number of 
-  positions. 
+* What's above does not show all the calculations required for ``INTERVAL``
+  <data type>s. Put simply, the rule is that ``COLUMN_SIZE`` is the number of
+  positions.
 
-* ``BUFFER_LENGTH`` is implementation-defined. The intent is that the value 
-  should be the number of octets transferred during ``SQLFetch`` or 
-  ``SQLFetchScroll``, so for character string <data type>s the source would be 
-  the ``CHARACTER_OCTET_LENGTH`` Column in ``INFORMATION_SCHEMA.COLUMNS``. 
+* ``BUFFER_LENGTH`` is implementation-defined. The intent is that the value
+  should be the number of octets transferred during ``SQLFetch`` or
+  ``SQLFetchScroll``, so for character string <data type>s the source would be
+  the ``CHARACTER_OCTET_LENGTH`` Column in ``INFORMATION_SCHEMA.COLUMNS``.
 
-* ``REMARKS`` is implementation-defined. 
+* ``REMARKS`` is implementation-defined.
 
-* ``SQL_DATA_TYPE`` is not defined at all. What's above is what we believe was 
-  the intention. 
+* ``SQL_DATA_TYPE`` is not defined at all. What's above is what we believe was
+  the intention.
 
-* For ``SQL_DATETIME_SUB``, the Standard contains errors. What's above is what 
-  we believe was the intention. 
+* For ``SQL_DATETIME_SUB``, the Standard contains errors. What's above is what
+  we believe was the intention.
 
-* ``SQL_DATA_TYPE``, ``CHAR_OCTET_LENGTH``, ``ORDINAL_POSITION`` and 
-  ``IS_NULLABLE`` are not defined in the Standard. What's above is what we 
-  believe was the intention. 
+* ``SQL_DATA_TYPE``, ``CHAR_OCTET_LENGTH``, ``ORDINAL_POSITION`` and
+  ``IS_NULLABLE`` are not defined in the Standard. What's above is what we
+  believe was the intention.
 
-* The Columns ``UDT_CAT``, ``UDT_SCHEM`` and ``UDT_NAME`` are strictly SQL3 
-  (for user-defined types). To run the query with an SQL-92 DBMS, remove the 
-  references to those fields. 
+* The Columns ``UDT_CAT``, ``UDT_SCHEM`` and ``UDT_NAME`` are strictly SQL3
+  (for user-defined types). To run the query with an SQL-92 DBMS, remove the
+  references to those fields.
 
-**Example:** Given <Table name> ``T``, make an SQL statement which selects all 
-the Columns in ``T`` without using the "*" shorthand. For example: if ``T`` has 
-two Columns -- ``COLUMN_1`` and ``COLUMN_2`` -- the output string will be: 
+**Example:** Given <Table name> ``T``, make an SQL statement which selects all
+the Columns in ``T`` without using the "*" shorthand. For example: if ``T`` has
+two Columns -- ``COLUMN_1`` and ``COLUMN_2`` -- the output string will be:
 
 ::
 
@@ -515,20 +517,20 @@ SQLForeignKeys
     SQLSMALLINT NameLength6       /* 16-bit input */
     );
 
-**Job:** Depending on the input parameters, ``SQLForeignKeys`` will either 
-*(a)* return a result set with information about a referenced Table, *(b)* 
-return a result set with information about a referencing Table or *(c)* both 
-*(a)* and *(b)*. By definition, every foreign key is associated with one 
-referencing Table, one referenced Table and one primary or unique key. The 
-returned result set will contain information about them too. 
+**Job:** Depending on the input parameters, ``SQLForeignKeys`` will either
+*(a)* return a result set with information about a referenced Table, *(b)*
+return a result set with information about a referencing Table or *(c)* both
+*(a)* and *(b)*. By definition, every foreign key is associated with one
+referencing Table, one referenced Table and one primary or unique key. The
+returned result set will contain information about them too.
 
-**Algorithm:** To visualize how the DBMS gets the result set and what it will 
-contain, assume that the DBMS makes a View and then ``SELECT``\s from it. We 
-are trying, in the following ``CREATE VIEW`` statement, to make it clear what 
-each <Column name> will be (that's why there are ``AS`` clauses) and what each 
-Column <data type> will be (that's why there are ``/* comments */``). The View 
-we're creating is a join of three ``INFORMATION_SCHEMA`` Views: 
-``KEY_COLUMN_USAGE``, ``REFERENTIAL_CONSTRAINTS`` and ``TABLE_CONSTRAINTS``. 
+**Algorithm:** To visualize how the DBMS gets the result set and what it will
+contain, assume that the DBMS makes a View and then ``SELECT``\s from it. We
+are trying, in the following ``CREATE VIEW`` statement, to make it clear what
+each <Column name> will be (that's why there are ``AS`` clauses) and what each
+Column <data type> will be (that's why there are ``/* comments */``). The View
+we're creating is a join of three ``INFORMATION_SCHEMA`` Views:
+``KEY_COLUMN_USAGE``, ``REFERENTIAL_CONSTRAINTS`` and ``TABLE_CONSTRAINTS``.
 
 ::
 
@@ -570,7 +572,7 @@ we're creating is a join of three ``INFORMATION_SCHEMA`` Views:
 
 Incidentally, the Standard needs 15 pages to express the above, so this is a
 tribute to the expressive power of the ``SELECT`` statement. To get our result
-set, we will ``SELECT`` from this View. For the sake of an example, assume 
+set, we will ``SELECT`` from this View. For the sake of an example, assume
 there are three Tables, with these definitions:
 
 ::
@@ -600,9 +602,9 @@ looking for primary key:
    AND UK_CATALOG_NAME = ?   /* included if *PKCatalogName is passed */
    ORDER BY FK_table_cat,FK_table_schem,FK_TABLE_NAME,ORDINAL_POSITION;
 
-What this means is: if you pass ``*PKTableName = 'T2'``, you get a result set 
-with information about every ``FOREIGN KEY`` Constraint that references ``T2``. 
-Given the above example Tables, the result of this call: 
+What this means is: if you pass ``*PKTableName = 'T2'``, you get a result set
+with information about every ``FOREIGN KEY`` Constraint that references ``T2``.
+Given the above example Tables, the result of this call:
 
 ::
 
@@ -616,7 +618,7 @@ is:
 | ``T2``            | ``T2_COL_1``       | ``T3``            | ``T3_COL_1``       |
 +-------------------+--------------------+-------------------+--------------------+
 
-[2] If the ``*FKTableName`` parameter is passed, search the temporary View 
+[2] If the ``*FKTableName`` parameter is passed, search the temporary View
 looking for foreign key:
 
 ::
@@ -627,9 +629,9 @@ looking for foreign key:
     AND FK_CATALOG_NAME = ?      /* included if FKCatalogName is passed */
     ORDER BY FK_table_cat,FK_table_schem,FK_TABLE_NAME,ORDINAL_POSITION;
 
-What this means is: if you pass ``*FKTableName = 'T2'``, you get a result set 
-with information about all the foreign keys defined in ``T2``. Given the above 
-example Tables, the result of this call: 
+What this means is: if you pass ``*FKTableName = 'T2'``, you get a result set
+with information about all the foreign keys defined in ``T2``. Given the above
+example Tables, the result of this call:
 
 ::
 
@@ -643,7 +645,7 @@ is:
 | ``T1``            | ``T1_COL_1``       | ``T2``            | ``T2_COL_1``       |
 +-------------------+--------------------+-------------------+--------------------+
 
-[3] If both the ``*PKTableName`` and ``*FKTableName`` parameters are passed, 
+[3] If both the ``*PKTableName`` and ``*FKTableName`` parameters are passed,
 then search the temporary View looking for both primary and foreign key:
 
 ::
@@ -657,9 +659,9 @@ then search the temporary View looking for both primary and foreign key:
     AND FK_CATALOG_NAME = ?      /* included if FKCatalogName is passed */
     ORDER BY FK_table_cat,FK_table_schem,FK_TABLE_NAME,ORDINAL_POSITION;
 
-What this means is: if you pass ``*PKTableName = 'T1'`` and ``*FKTableName = 
-'T3'``, you get a result set with information about one of the foreign keys 
-that's in ``T3``. Given the above example Tables, the result of this call: 
+What this means is: if you pass ``*PKTableName = 'T1'`` and ``*FKTableName =
+'T3'``, you get a result set with information about one of the foreign keys
+that's in ``T3``. Given the above example Tables, the result of this call:
 
 ::
 
@@ -681,7 +683,7 @@ is:
 * For readability, this example only shows the joins on "name" Columns
   -- it omits the joins on "Schema" and "Catalog" Columns.
 
-**Example:** This function call might put several rows in the result set, since 
+**Example:** This function call might put several rows in the result set, since
 we are asking for "any Catalog", "any Schema".
 
 ::
@@ -698,7 +700,7 @@ we are asking for "any Catalog", "any Schema".
             "",0,        /* Foreign Schema */
             "",0);       /* Foreign Table  */
 
-**ODBC:** The ``SQLForeignKeys`` function has been around since ODBC 1.0. Most 
+**ODBC:** The ``SQLForeignKeys`` function has been around since ODBC 1.0. Most
 of the <Column name>s are different in ODBC. That's partly because ODBC only
 recognizes references to primary keys, it doesn't expect that foreign keys
 could reference unique keys.
@@ -715,15 +717,15 @@ SQLGetTypeInfo
     SQLSMALLINT DataType            /* 16-bit input */
     );
 
-**Job:** Return a result set, with one row for each <data type> that the DBMS 
+**Job:** Return a result set, with one row for each <data type> that the DBMS
 supports. It is possible to select a particular <data type>.
 
-**Algorithm:** The SQL Standard asks us to pretend that there is a 
-``TYPE_INFO`` Table containing information about the <data type>: its name, 
-whether there is a scale, the SQL <data type> code and so on. To help the 
-pretense, we have actually made an ``INFORMATION_SCHEMA`` View which is defined 
-according to the Standard's specification. PLEASE SEE THE DESCRIPTION OF THE 
-TYPE_INFO VIEW IN OUR CHAPTER ON CATALOGS FOR A COMPLETE DESCRIPTION. 
+**Algorithm:** The SQL Standard asks us to pretend that there is a
+``TYPE_INFO`` Table containing information about the <data type>: its name,
+whether there is a scale, the SQL <data type> code and so on. To help the
+pretense, we have actually made an ``INFORMATION_SCHEMA`` View which is defined
+according to the Standard's specification. PLEASE SEE THE DESCRIPTION OF THE
+TYPE_INFO VIEW IN OUR CHAPTER ON CATALOGS FOR A COMPLETE DESCRIPTION.
 
 Assuming that such a View exists, the DBMS algorithm is simple:
 
@@ -743,25 +745,25 @@ then in effect this search happens:
       FROM   INFORMATION_SCHEMA.TYPE_INFO
       WHERE  DATA_TYPE = ?;
 
-where the parameter marker ? stands for "the value of the ``DataType`` 
+where the parameter marker ? stands for "the value of the ``DataType``
 parameter".
 
 **Notes:**
 
-* Much of the information returned by ``SQLGetTypeInfo`` is stuff you already 
-  know, because it's standard. What you should worry about is the parts 
-  labelled "implementation-defined". For example, the maximum size of a 
-  ``CHAR`` Column varies from DBMS to DBMS. Unfortunately, the ``TYPE_INFO`` 
-  View lacks a few items which might be useful -- such as the Character set. 
+* Much of the information returned by ``SQLGetTypeInfo`` is stuff you already
+  know, because it's standard. What you should worry about is the parts
+  labelled "implementation-defined". For example, the maximum size of a
+  ``CHAR`` Column varies from DBMS to DBMS. Unfortunately, the ``TYPE_INFO``
+  View lacks a few items which might be useful -- such as the Character set.
 
-* A typical application: if you allow the user to create Tables, it's handy to 
-  call ``SQLGetTypeInfo`` and display list boxes (showing the localized <data 
-  type> names) or explanatory notes based on implementation-defined maxima. 
+* A typical application: if you allow the user to create Tables, it's handy to
+  call ``SQLGetTypeInfo`` and display list boxes (showing the localized <data
+  type> names) or explanatory notes based on implementation-defined maxima.
 
-**Example:** This Column will display "10", because the third Column in 
-``INFORMATION_SCHEMA.TYPE_INFO`` is ``COLUMN_SIZE`` and the Column size for a 
-``DATE`` <data type> is always 10 positions. The value of ``SQL_TYPE_DATE`` is 
-91. 
+**Example:** This Column will display "10", because the third Column in
+``INFORMATION_SCHEMA.TYPE_INFO`` is ``COLUMN_SIZE`` and the Column size for a
+``DATE`` <data type> is always 10 positions. The value of ``SQL_TYPE_DATE`` is
+91.
 
 ::
 
@@ -775,9 +777,9 @@ parameter".
   SQLCloseCursor;
   printf("column size = %d\n",column_size);
 
-**ODBC:** ``SQLGetTypeInfo`` has been around since ODBC 1.0, but many of the 
-Columns are new in ODBC 3.0. The implicit ``SELECT`` statements contain the 
-clause ``ORDER BY DATA_TYPE``. 
+**ODBC:** ``SQLGetTypeInfo`` has been around since ODBC 1.0, but many of the
+Columns are new in ODBC 3.0. The implicit ``SELECT`` statements contain the
+clause ``ORDER BY DATA_TYPE``.
 
 SQLParameters
 =============
@@ -842,24 +844,24 @@ SQLParameters
 
 **Notes:**
 
-* The algorithm's ``SELECT`` statement does not reflect some minor matters. See 
-  the earlier section titled "Some Necessary Preliminaries". 
+* The algorithm's ``SELECT`` statement does not reflect some minor matters. See
+  the earlier section titled "Some Necessary Preliminaries".
 
-* For the result set's ``DATA_TYPE``, ``BUFFER_LENGTH``, ``DECIMAL_DIGITS`` and 
-  ``SQL_DATA_TYPE`` Columns, the DBMS uses the same calculations that it uses 
-  for the ``SQLColumns`` function -- see the long ``CASE`` expressions in the 
-  ``SQLColumns`` description. 
+* For the result set's ``DATA_TYPE``, ``BUFFER_LENGTH``, ``DECIMAL_DIGITS`` and
+  ``SQL_DATA_TYPE`` Columns, the DBMS uses the same calculations that it uses
+  for the ``SQLColumns`` function -- see the long ``CASE`` expressions in the
+  ``SQLColumns`` description.
 
-* The value in ``TYPE_NAME`` is implementation-defined; in our implementation 
-  we defined that it's the same as ``PARAMETERS.DATA_TYPE``. 
+* The value in ``TYPE_NAME`` is implementation-defined; in our implementation
+  we defined that it's the same as ``PARAMETERS.DATA_TYPE``.
 
-* The value in the result set's ``PARAMETER_SIZE`` Column is the same as the 
-  value in the ``BUFFER_SIZE`` Column. (Although ``PARAMETER_SIZE`` and 
-  ``BUFFER_SIZE`` depend on several implementation-defined rules, we believe 
-  that any practical DBMS will employ the same rules for both Columns.) 
+* The value in the result set's ``PARAMETER_SIZE`` Column is the same as the
+  value in the ``BUFFER_SIZE`` Column. (Although ``PARAMETER_SIZE`` and
+  ``BUFFER_SIZE`` depend on several implementation-defined rules, we believe
+  that any practical DBMS will employ the same rules for both Columns.)
 
-* The DBMS will only return rows for routines that you have ``EXECUTE`` 
-  Privileges on. 
+* The DBMS will only return rows for routines that you have ``EXECUTE``
+  Privileges on.
 
 **Example:**
 
@@ -890,7 +892,7 @@ SQLPrimaryKeys
     SQLSMALLINT NameLength3         /* 16-bit input */
     );
 
-**Job:** Given a <Table name>, return a list of the Columns in the Table's 
+**Job:** Given a <Table name>, return a list of the Columns in the Table's
 primary key. The return is a result set.
 
 **Algorithm:**
@@ -921,9 +923,9 @@ primary key. The return is a result set.
 
 **Notes:**
 
-* The only returned rows are for ``PRIMARY KEY`` Constraints. If there is a 
-  ``UNIQUE`` Constraint -- even a ``UNIQUE`` Constraint that is referenced by a 
-  foreign key -- ``SQLPrimaryKeys`` will not see it. 
+* The only returned rows are for ``PRIMARY KEY`` Constraints. If there is a
+  ``UNIQUE`` Constraint -- even a ``UNIQUE`` Constraint that is referenced by a
+  foreign key -- ``SQLPrimaryKeys`` will not see it.
 
 **Example:**
 
@@ -938,9 +940,9 @@ primary key. The return is a result set.
       SQLPrimaryKeys(
         hstmt,"OCELOT",sizeof("OCELOT"),"OCELOT",sizeof("OCELOT"),"",0);
 
-**ODBC:** The ``SQLPrimaryKeys`` function has been around since ODBC 1.0. The 
-name of the fifth returned Column is ``KEY_SEQ`` instead of 
-``ORDINAL_POSITION``. 
+**ODBC:** The ``SQLPrimaryKeys`` function has been around since ODBC 1.0. The
+name of the fifth returned Column is ``KEY_SEQ`` instead of
+``ORDINAL_POSITION``.
 
 SQLRoutinePrivileges
 ====================
@@ -986,11 +988,11 @@ SQLRoutinePrivileges
 
 **Notes:**
 
-* In SQL-92, there is no such thing as a routine. Therefore 
-  ``SQLRoutinePrivileges`` is supported only by SQL3 DBMSs. 
+* In SQL-92, there is no such thing as a routine. Therefore
+  ``SQLRoutinePrivileges`` is supported only by SQL3 DBMSs.
 
-* The value in the ``RoutineName`` parameter is matched against 
-  ``ROUTINE_NAME``, not ``SPECIFIC_NAME``. 
+* The value in the ``RoutineName`` parameter is matched against
+  ``ROUTINE_NAME``, not ``SPECIFIC_NAME``.
 
 **Example:**
 
@@ -1094,13 +1096,13 @@ SQLRoutines
 * The first variant is:
 
   ::
-  
+
      SQLRoutines(hstmt,"%",1,"",0,"",0,"",0);
 
   This is effectively equivalent to:
 
   ::
-  
+
      SELECT DISTINCT ROUTINE_CATALOG AS routine_cat,
                       CAST(NULL AS VARCHAR(128)),
                       CAST(NULL AS VARCHAR(128)),
@@ -1109,15 +1111,15 @@ SQLRoutines
      FROM INFORMATION_SCHEMA.ROUTINES;
 
 * The second variant is:
-  
+
   ::
-  
+
      SQLRoutines(hstmt,"",0,"%",1,"",0,"",0);
-  
+
   This is effectively equivalent to:
-  
+
   ::
-  
+
      SELECT DISTINCT CAST(NULL AS VARCHAR(128)),
                       ROUTINE_SCHEMA AS ROUTINE_SCHEM,
                       CAST(NULL AS VARCHAR(128)),
@@ -1126,15 +1128,15 @@ SQLRoutines
      FROM INFORMATION_SCHEMA.ROUTINES;
 
 * The third variant is:
-  
+
   ::
-  
+
      SQLRoutines(hstmt,"",0,"",0,"",0,"%",1);
-  
+
   This is effectively equivalent to:
-  
+
   ::
-  
+
      SELECT DISTINCT CAST(NULL AS VARCHAR(128)),
                       CAST(NULL AS VARCHAR(128)),
                       CAST(NULL AS VARCHAR(128)),
@@ -1177,7 +1179,7 @@ SQLSpecialColumns
     SQLSMALLINT Nullable            /* 16-bit input */
     );
 
-**Job:** Show the Columns that can be used for uniquely identifying a row in a 
+**Job:** Show the Columns that can be used for uniquely identifying a row in a
 given Table.
 
 **Algorithm:**
@@ -1215,44 +1217,44 @@ given Table.
 
 * We have used ... in the algorithm's select list as a shorthand. The
   meaning of this shorthand is that the same inputs and calculations should be
-  used as were used in the lengthy ``CASE`` expressions for the ``SQLColumns`` 
+  used as were used in the lengthy ``CASE`` expressions for the ``SQLColumns``
   function.
 
 * Don't worry about the outre' select list in the algorithm. The only
   thing that you really need is the <Column name> and the scope. All the rest
-  can be found using straightforward selections from ``INFORMATION_SCHEMA`` 
+  can be found using straightforward selections from ``INFORMATION_SCHEMA``
   Views.
 
 * It's implementation-defined which Columns make the "best rowid" and
   have a particular "scope".
 
 * The Special Column Type can be:
-  
+
    * 1  ``SQL_BEST_ROWID``
 
 * The Scope of Row Id can be:
-  
+
    * 0 ``SQL_SCOPE_CURRENT_ROW`` (valid while Cursor is positioned on
      that row -- the ODBC name is ``SQL_SCOPE_CURROW``)
-   
+
    * 1  ``SQL_SCOPE_TRANSACTION`` (valid until transaction ends)
-   
+
    * 2  ``SQL_SCOPE_SESSION`` (valid until SQL-session ends)
-   
+
 * How does the DBMS pick what Columns are special?
-  
+
    * First choice: the "rowid".
-   
+
    * Second choice: a single Column which is defined as ``UNIQUE`` or
      ``PRIMARY KEY``.
-   
+
    * Third choice: a combination of Columns which make up a ``UNIQUE``
      or ``PRIMARY KEY``.
-   
+
    * Fourth choice: a "serial number" Column.
-   
+
    * Fifth choice: a "timestamp" Column (the Sybase way).
-  
+
   Columns lose points if nullable; gain points if short, numeric, constrained.
 
 * What's a pseudo-column? Perhaps it's called the ROWID (Oracle),
@@ -1261,11 +1263,11 @@ given Table.
   that pseudo-columns exist in the ``COLUMNS`` View.
 
 * The Pseudo Column Flag can be:
-  
+
    * 0 ``SQL_PSEUDO_UNKNOWN``
-   
+
    * 1 ``SQL_PSEUDO_NOT_PSEUDO``
-   
+
    * 2 ``SQL_PSEUDO_PSEUDO``
 
 * Many DBMSs support "rowid" as a unique identifier. The rowid is often
@@ -1295,7 +1297,7 @@ given Table.
 * There might be no rows returned. But if you define every Table with a
   primary or unique key, ``SQLSpecialColumns`` can't fail.
 
-* Because calculation happens à la ``SQLColumns``, the ``COLUMN_SIZE`` for 
+* Because calculation happens à la ``SQLColumns``, the ``COLUMN_SIZE`` for
   ``BIT`` and ``BIT VARYING`` <data type>s is a length in bits.
 
 **Example:**
@@ -1314,11 +1316,11 @@ given Table.
       SQL_SCOPE_TRANSACTION,       /* Scope */
       SQL_PSEUDO_UNKNOWN);         /* Nullable */
 
-**ODBC:** The ``SQLSpecialColumns`` function has been in ODBC since version 
-1.0. Perhaps because it depends on non-standard features, ``SQLSpecialColumns`` 
-wasn't in the SQL-92 CLI (but was in X/Open). Besides the "best rowid" option, 
-one can ask about Columns which are automatically changed whenever there is an 
-update (e.g.: Sybase's TIMESTAMP Column). 
+**ODBC:** The ``SQLSpecialColumns`` function has been in ODBC since version
+1.0. Perhaps because it depends on non-standard features, ``SQLSpecialColumns``
+wasn't in the SQL-92 CLI (but was in X/Open). Besides the "best rowid" option,
+one can ask about Columns which are automatically changed whenever there is an
+update (e.g.: Sybase's TIMESTAMP Column).
 
 SQLTablePrivileges
 ==================
@@ -1368,20 +1370,20 @@ SQLTablePrivileges
 
 * If you lack the ``UPDATE`` Privilege on a Table T, that does not prove
   that this SQL statement:
-  
+
   ::
-  
+
      UPDATE T SET column_1 = 5;
-  
-  is illegal for you. You might have a Column ``UPDATE`` Privilege on 
-  ``COLUMN_1`` only (Column Privileges are discovered by calling 
-  ``SQLColumnPrivileges`` or selecting from 
-  ``INFORMATION_SCHEMA.COLUMN_PRIVILEGES``). You might hold a Role or an 
-  implementation-defined "super user" Privilege. So the only guaranteed proof 
-  is: try it and see. Seriously: 
-  
+
+  is illegal for you. You might have a Column ``UPDATE`` Privilege on
+  ``COLUMN_1`` only (Column Privileges are discovered by calling
+  ``SQLColumnPrivileges`` or selecting from
+  ``INFORMATION_SCHEMA.COLUMN_PRIVILEGES``). You might hold a Role or an
+  implementation-defined "super user" Privilege. So the only guaranteed proof
+  is: try it and see. Seriously:
+
   ::
-  
+
       x=SQLExecDirect(hstmt,"UPDATE T SET column_1=5 WHERE 1=2;",SQL_NTS);
       if (x<0) {
         SQLGetDiagField(...<sqlstate>)
@@ -1392,10 +1394,10 @@ SQLTablePrivileges
           /* UPDATE failed but for some other reason. Test is no good. */ }
       else {
         /* UPDATE succeeded, so you have the right Privileges. */  }
-  
-  The key for this tip is to use an always-``FALSE`` condition in the ``WHERE`` 
-  clause -- do not try setting the Column to itself and do not depend on 
-  ``ROLLBACK``. 
+
+  The key for this tip is to use an always-``FALSE`` condition in the ``WHERE``
+  clause -- do not try setting the Column to itself and do not depend on
+  ``ROLLBACK``.
 
 **Example:**
 
@@ -1407,7 +1409,7 @@ SQLTablePrivileges
       SQLTablePrivileges(hstmt,"",0,"",0,"",0);
       ...
 
-**ODBC:** The ``SQLTablePrivileges`` function has been around since ODBC 
+**ODBC:** The ``SQLTablePrivileges`` function has been around since ODBC
 version 1.0.
 
 SQLTables
@@ -1467,80 +1469,80 @@ SQLTables
 
 **Notes:**
 
-* The ``*TableType`` parameter is a wrinkle which is hard to show in an SQL 
-  statement but it's reasonably straightforward. The idea is that there are 
-  five general categories of Tables: the ``INFORMATION_SCHEMA Views`` 
-  (``'SYSTEM TABLE'``), all other Views (``'VIEW'``), ordinary Base tables 
-  (``'TABLE'``) and the two kinds of temporary Tables (``'GLOBAL TEMPORARY'`` 
-  or ``'LOCAL TEMPORARY'``). To restrict to the categories you want, pass a 
-  commalist in ``*TableType`` -- for example: ``'SYSTEM TABLE','VIEW'``. Or 
-  pass ``SYSTEM TABLE,VIEW`` (the quote marks are optional). Or pass nothing 
-  (if you pass a blank string, the DBMS returns Tables in all categories). 
+* The ``*TableType`` parameter is a wrinkle which is hard to show in an SQL
+  statement but it's reasonably straightforward. The idea is that there are
+  five general categories of Tables: the ``INFORMATION_SCHEMA Views``
+  (``'SYSTEM TABLE'``), all other Views (``'VIEW'``), ordinary Base tables
+  (``'TABLE'``) and the two kinds of temporary Tables (``'GLOBAL TEMPORARY'``
+  or ``'LOCAL TEMPORARY'``). To restrict to the categories you want, pass a
+  commalist in ``*TableType`` -- for example: ``'SYSTEM TABLE','VIEW'``. Or
+  pass ``SYSTEM TABLE,VIEW`` (the quote marks are optional). Or pass nothing
+  (if you pass a blank string, the DBMS returns Tables in all categories).
 
-* The algorithm's ``SELECT`` statement does not reflect some minor matters. See 
-  the earlier section titled "Some Necessary Preliminaries". 
+* The algorithm's ``SELECT`` statement does not reflect some minor matters. See
+  the earlier section titled "Some Necessary Preliminaries".
 
-* The ``REMARKS`` Column is supposed to contain an implementation-defined 
-  description of the Table. For IBM's DB2 this would be the value that you 
-  enter with a ``COMMENT`` statement. 
+* The ``REMARKS`` Column is supposed to contain an implementation-defined
+  description of the Table. For IBM's DB2 this would be the value that you
+  enter with a ``COMMENT`` statement.
 
-* Many Windows applications have a "File" menu item and within that an 
-  "Open..." menu item, for putting a dialog box on the screen. Your database 
-  application doesn't have files -- it has Tables -- but the dialog box should 
-  look similar. 
+* Many Windows applications have a "File" menu item and within that an
+  "Open..." menu item, for putting a dialog box on the screen. Your database
+  application doesn't have files -- it has Tables -- but the dialog box should
+  look similar.
 
-* ``SQLTables`` was not available in SQL-92; it is new to SQL with SQL3. 
+* ``SQLTables`` was not available in SQL-92; it is new to SQL with SQL3.
 
-* [Obscure Rule] There are three variants of ``SQLTables`` which are so 
-  different, they should be regarded as different functions. These variants are 
-  easily recognized by the arguments: one argument is always "%" and the others 
-  are always "" (blank strings). The variants always return result sets with 
-  five Columns. 
-  
+* [Obscure Rule] There are three variants of ``SQLTables`` which are so
+  different, they should be regarded as different functions. These variants are
+  easily recognized by the arguments: one argument is always "%" and the others
+  are always "" (blank strings). The variants always return result sets with
+  five Columns.
+
    * The first variant is:
-     
+
      ::
-     
+
        SQLTables(hstmt,"%",1,"",0,"",0,"",0);
-     
+
      This is effectively equivalent to:
-     
+
      ::
-     
+
        SELECT DISTINCT TABLE_CATALOG AS table_cat,
                        CAST(NULL AS VARCHAR(128)),
                        CAST(NULL AS VARCHAR(128)),
                        CAST(NULL AS VARCHAR(254)),
                        CAST(NULL AS VARCHAR(254))
        FROM INFORMATION_SCHEMA.TABLES;
-     
+
    * The second variant is:
-     
+
      ::
-     
+
        SQLTables(hstmt,"",0,"%",1,"",0,"",0);
-     
+
      This is effectively equivalent to:
-     
+
      ::
-     
+
        SELECT DISTINCT CAST(NULL AS VARCHAR(128)),
                        TABLE_SCHEMA AS table_schem,
                        CAST(NULL AS VARCHAR(128)),
                        CAST(NULL AS VARCHAR(254)),
                        CAST(NULL AS VARCHAR(254))
        FROM INFORMATION_SCHEMA.TABLES;
-     
+
    * The third variant is:
-     
+
      ::
-     
+
        SQLTables(hstmt,"",0,"",0,"",0,"%",1);
-     
+
      This is effectively equivalent to:
-     
+
      ::
-     
+
        SELECT DISTINCT CAST(NULL AS VARCHAR(128)),
                         CAST(NULL AS VARCHAR(128)),
                         CAST(NULL AS VARCHAR(128)),
@@ -1557,13 +1559,13 @@ SQLTables
                         AS TABLE_TYPE,
                        CAST(NULL AS VARCHAR(254))
         FROM INFORMATION_SCHEMA.TABLES;
-  
-  There are no Privilege checks: with variant ``SQLTables`` functions, you can 
-  find Tables that you have no Privileges on. Compare the variant 
+
+  There are no Privilege checks: with variant ``SQLTables`` functions, you can
+  find Tables that you have no Privileges on. Compare the variant
   ``SQLRoutines`` functions.
-  
+
   ::
-  
+
       #include "sqlcli.h"
       SQLHSTMT hstmt;
       ...
@@ -1586,39 +1588,39 @@ SQLTables
       SQLTables(hstmt,NULL,0,NULL,0,TEXT("q%"),SQL_NTS,
       TEXT("'TABLE'"),SQL_NTS);
 
-**ODBC:** The ``SQLTables`` function has been around since ODBC version 1.0. In 
-ODBC, the result set is guaranteed to be in order by ``TABLE_CAT``, 
-``TABLE_SCHEM``, ``TABLE_NAME`` ... -- this order is not specified in the 
-Standard but it will probably be the case. 
+**ODBC:** The ``SQLTables`` function has been around since ODBC version 1.0. In
+ODBC, the result set is guaranteed to be in order by ``TABLE_CAT``,
+``TABLE_SCHEM``, ``TABLE_NAME`` ... -- this order is not specified in the
+Standard but it will probably be the case.
 
 THE END
 =======
 
-The description of SQL/CLI is -- at long last -- finished. Here's a summary of 
-some of the good and the bad and the ugly points that we've talked about in the 
-past several chapters: 
+The description of SQL/CLI is -- at long last -- finished. Here's a summary of
+some of the good and the bad and the ugly points that we've talked about in the
+past several chapters:
 
-* The impedance-mismatch problem is solved. It's considerably easier, for the 
-  vendor especially, to supply a library of functions rather than to allow 
-  mixing of host language code with SQL code. Since most programmers are well 
-  acquainted with the concept of a function library, there are no strong 
-  objections to the practice. 
+* The impedance-mismatch problem is solved. It's considerably easier, for the
+  vendor especially, to supply a library of functions rather than to allow
+  mixing of host language code with SQL code. Since most programmers are well
+  acquainted with the concept of a function library, there are no strong
+  objections to the practice.
 
-* The CLI's functionality is analogous to that of "dynamic SQL" in the embedded 
-  SQL specification. The absence of "static SQL" does entail that there will 
-  have to be some parsing and binding at runtime which, in theory, could have 
-  been done once and for all when the program was produced. 
+* The CLI's functionality is analogous to that of "dynamic SQL" in the embedded
+  SQL specification. The absence of "static SQL" does entail that there will
+  have to be some parsing and binding at runtime which, in theory, could have
+  been done once and for all when the program was produced.
 
-* A considerable debt is owed by the programming community to SAG, X/Open and 
-  Microsoft. Before the CLI came along, SQL was a much smaller deal. The use of 
-  the CLI has opened up the power of database programming to a much wider 
-  audience than the embedded SQL and PSM styles were ever likely to produce. 
-  Particularly this is true for shrink-wrapped software. 
+* A considerable debt is owed by the programming community to SAG, X/Open and
+  Microsoft. Before the CLI came along, SQL was a much smaller deal. The use of
+  the CLI has opened up the power of database programming to a much wider
+  audience than the embedded SQL and PSM styles were ever likely to produce.
+  Particularly this is true for shrink-wrapped software.
 
-* The CLI contains many redundancies. 
+* The CLI contains many redundancies.
 
-* The CLI specifications often appear to be influenced by ideas which run 
-  counter to the general spirit of SQL. 
+* The CLI specifications often appear to be influenced by ideas which run
+  counter to the general spirit of SQL.
 
-* The CLI is much more complex than it would have been if a single design team 
-  had started with standard SQL-92 as a base. 
+* The CLI is much more complex than it would have been if a single design team
+  had started with standard SQL-92 as a base.

--- a/docs/chapters/52.rst
+++ b/docs/chapters/52.rst
@@ -4,34 +4,36 @@
 Chapter 52 -- Module Binding Style
 ==================================
 
-SQL DBMSs communicate with SQL applications through a common programming 
-language interface that is invoked through one of the SQL Standard-defined 
-binding styles, or interface options. There are three main approaches to 
-writing complete programs with SQL: 
+.. include:: ../_include/note.rst
 
-1. With embedded SQL, you can put SQL statements directly into host programs. 
+SQL DBMSs communicate with SQL applications through a common programming
+language interface that is invoked through one of the SQL Standard-defined
+binding styles, or interface options. There are three main approaches to
+writing complete programs with SQL:
+
+1. With embedded SQL, you can put SQL statements directly into host programs.
    We described this binding style earlier.
 
-2. With SQL/CLI, you can call a SQL DBMS's library from a host program. This 
+2. With SQL/CLI, you can call a SQL DBMS's library from a host program. This
    binding style was the subject of the last several chapters.
 
-3. With the Module language, you can dispense with host programs and write 
-   entire Modules in SQL. You'll still have to call these Modules from one of 
-   the standard host languages though. The Module language binding style is the 
+3. With the Module language, you can dispense with host programs and write
+   entire Modules in SQL. You'll still have to call these Modules from one of
+   the standard host languages though. The Module language binding style is the
    subject of this chapter.
 
-Because we believe that SQL/CLI will quickly become the SQL interface of 
-choice, this chapter omits large amounts of detail, in favour of providing the 
-necessary detail in our chapters on SQL/CLI. 
+Because we believe that SQL/CLI will quickly become the SQL interface of
+choice, this chapter omits large amounts of detail, in favour of providing the
+necessary detail in our chapters on SQL/CLI.
 
 .. NOTE::
 
-   The SQL Standard actually describes three kinds of SQL Module, each of which 
-   has certain characteristics and contains various kinds of Module Objects 
-   (principally, routines). An SQL-client Module contains only 
-   externally-invoked procedures, an SQL-session Module contains only SQL 
-   statements prepared in that SQL-session and an SQL-server Module -- the 
-   SQL/PSM type -- is a Schema Object that contains only SQL-invoked routines. 
+   The SQL Standard actually describes three kinds of SQL Module, each of which
+   has certain characteristics and contains various kinds of Module Objects
+   (principally, routines). An SQL-client Module contains only
+   externally-invoked procedures, an SQL-session Module contains only SQL
+   statements prepared in that SQL-session and an SQL-server Module -- the
+   SQL/PSM type -- is a Schema Object that contains only SQL-invoked routines.
 
 .. rubric:: Table of Contents
 
@@ -41,28 +43,28 @@ necessary detail in our chapters on SQL/CLI.
 SQL-client Modules
 ==================
 
-SQL-client Modules are programming modules that contain externally-invoked 
-procedures -- that is, SQL procedures that are invoked by a host language. 
-Generally speaking, this methodology is really the basic SQL binding style: all 
-of the binding styles -- direct SQL, embedded SQL, CLI or SQL-client Modules -- 
-at least conceptually, involve a program module. Before SQL/PSM came on the 
-scene, SQL "module language" was the only way to identify SQL Modules. But now, 
-with the advent of SQL/PSM and (far better) of SQL/CLI, we believe this method 
-of utilizing SQL will rapidly become obsolete and so we give only a brief 
-description here. 
+SQL-client Modules are programming modules that contain externally-invoked
+procedures -- that is, SQL procedures that are invoked by a host language.
+Generally speaking, this methodology is really the basic SQL binding style: all
+of the binding styles -- direct SQL, embedded SQL, CLI or SQL-client Modules --
+at least conceptually, involve a program module. Before SQL/PSM came on the
+scene, SQL "module language" was the only way to identify SQL Modules. But now,
+with the advent of SQL/PSM and (far better) of SQL/CLI, we believe this method
+of utilizing SQL will rapidly become obsolete and so we give only a brief
+description here.
 
-An SQL-client Module is an Object -- a programming module -- that you define 
-with SQL's module language: a subset of SQL that allows you to write database 
-routines in pure SQL. It contains SQL statements that will operate on your 
-SQL-data, and you link it (in some implementation-defined way) with modules of 
-code in one or more of the Standard's host languages. The database routines are 
-called *externally-invoked procedures* because they are invoked by the host 
-language program to which you link the Module they belong to. 
+An SQL-client Module is an Object -- a programming module -- that you define
+with SQL's module language: a subset of SQL that allows you to write database
+routines in pure SQL. It contains SQL statements that will operate on your
+SQL-data, and you link it (in some implementation-defined way) with modules of
+code in one or more of the Standard's host languages. The database routines are
+called *externally-invoked procedures* because they are invoked by the host
+language program to which you link the Module they belong to.
 
 MODULE Statement
 ================
 
-The ``MODULE`` statement defines an SQL-client Module. The required syntax for 
+The ``MODULE`` statement defines an SQL-client Module. The required syntax for
 the ``MODULE`` statement is:
 
 ::
@@ -76,76 +78,76 @@ the ``MODULE`` statement is:
      [ TRANSFORM GROUP {<group name> | {<group name> FOR TYPE <UDT name>} , ...} ]
      [ DECLARE TABLE statement(s) ]
      <Module contents>...
-     
+
           <Module authorization clause> ::=
           SCHEMA <Schema name> |
           AUTHORIZATION <AuthorizationID> |
           SCHEMA <Schema name> AUTHORIZATION <AuthorizationID>
-          
+
           <Module contents> ::=
           DECLARE CURSOR statement(s) |
           PROCEDURE statement(s)
 
-An SQL-client Module doesn't have to be named (unless the Module's ``LANGUAGE`` 
-clause specifies ADA, in which case you must give the Module a valid Ada 
-library unit name); your SQL-environment can contain multiple unnamed SQL- 
-client Modules. If you do name an SQL-client Module, though, you must give it a 
-unique name (for all SQL-client Modules) in your SQL-environment. A <SQL-client 
-Module name> is a <regular identifier> or a <delimited identifier>. 
+An SQL-client Module doesn't have to be named (unless the Module's ``LANGUAGE``
+clause specifies ADA, in which case you must give the Module a valid Ada
+library unit name); your SQL-environment can contain multiple unnamed SQL-
+client Modules. If you do name an SQL-client Module, though, you must give it a
+unique name (for all SQL-client Modules) in your SQL-environment. A <SQL-client
+Module name> is a <regular identifier> or a <delimited identifier>.
 
-The optional ``NAMES ARE`` clause provides the name of the Module's default 
-Character set: the Character set that your DBMS will use for any character 
-strings in the Module that don't include an explicit Character set 
-specification. If you omit this clause, the Module's default Character set is 
-chosen by your DBMS, and must contain at least every <SQL language character>. 
+The optional ``NAMES ARE`` clause provides the name of the Module's default
+Character set: the Character set that your DBMS will use for any character
+strings in the Module that don't include an explicit Character set
+specification. If you omit this clause, the Module's default Character set is
+chosen by your DBMS, and must contain at least every <SQL language character>.
 
-The ``LANGUAGE`` clause provides the name of the host language that will invoke 
-the routines this Module contains. 
+The ``LANGUAGE`` clause provides the name of the host language that will invoke
+the routines this Module contains.
 
-The Module authorization clause provides either the Module's default Schema, 
-the Module's <AuthorizationID> or both (at least one must be included). 
+The Module authorization clause provides either the Module's default Schema,
+the Module's <AuthorizationID> or both (at least one must be included).
 
-* ``SCHEMA`` <Schema name> provides an explicit <Schema name> -- this will be 
-  the default <Schema name> qualifier for any Objects referred to in the Module 
-  without explicit qualifiers. If you omit this clause, the default <Schema 
-  name> defaults to the value in the ``AUTHORIZATION`` clause. 
+* ``SCHEMA`` <Schema name> provides an explicit <Schema name> -- this will be
+  the default <Schema name> qualifier for any Objects referred to in the Module
+  without explicit qualifiers. If you omit this clause, the default <Schema
+  name> defaults to the value in the ``AUTHORIZATION`` clause.
 
-* ``AUTHORIZATION`` <AuthorizationID> provides an explicit <AuthorizationID> to 
-  be the owner of the Module -- this will be the <AuthorizationID> whose 
-  Privileges will be checked when the Module's SQL statements are executed. If 
-  you omit this clause, your DBMS will treat the SQL-session <AuthorizationID> 
-  as the Module's owner at runtime. 
+* ``AUTHORIZATION`` <AuthorizationID> provides an explicit <AuthorizationID> to
+  be the owner of the Module -- this will be the <AuthorizationID> whose
+  Privileges will be checked when the Module's SQL statements are executed. If
+  you omit this clause, your DBMS will treat the SQL-session <AuthorizationID>
+  as the Module's owner at runtime.
 
-The optional ``PATH`` clause provides a list of <Schema name>s that will be 
-used as the Module's default path -- that is, the qualifying <Schema name>s 
-that will be used for any unqualified <Routine name>s in this Module. You can 
-name zero or more Schemas in this clause (your DBMS will pick the one that 
-matches the unqualified routine best at runtime); each Schema in the list must 
-belong to the same Catalog that this Module's default Schema belongs to. If you 
-omit this clause, it will default to a list of Schemas, containing at least 
-this Module's default Schema, chosen by your DBMS. 
+The optional ``PATH`` clause provides a list of <Schema name>s that will be
+used as the Module's default path -- that is, the qualifying <Schema name>s
+that will be used for any unqualified <Routine name>s in this Module. You can
+name zero or more Schemas in this clause (your DBMS will pick the one that
+matches the unqualified routine best at runtime); each Schema in the list must
+belong to the same Catalog that this Module's default Schema belongs to. If you
+omit this clause, it will default to a list of Schemas, containing at least
+this Module's default Schema, chosen by your DBMS.
 
-The optional ``TRANSFORM GROUP`` clause provides a <group name> for each UDT 
-parameter that has no locator; see our chapter on UDTs. 
+The optional ``TRANSFORM GROUP`` clause provides a <group name> for each UDT
+parameter that has no locator; see our chapter on UDTs.
 
-You can declare zero or more temporary Tables for the Module. Each will be 
-visible only to the Module you declare them in. 
+You can declare zero or more temporary Tables for the Module. Each will be
+visible only to the Module you declare them in.
 
-The <Module contents> clause is the meat of the Module -- it contains the SQL 
-statements that do the work you need done on your SQL-data. You can declare 
-zero or more Cursors here (see our chapter on embedded SQL), as well as one or 
-more externally-invoked procedures (with the ``PROCEDURE`` statement, see 
-below). 
+The <Module contents> clause is the meat of the Module -- it contains the SQL
+statements that do the work you need done on your SQL-data. You can declare
+zero or more Cursors here (see our chapter on embedded SQL), as well as one or
+more externally-invoked procedures (with the ``PROCEDURE`` statement, see
+below).
 
-If you want to restrict your code to Core SQL, don't use the ``NAMES ARE`` 
-clause, the ``PATH`` clause, the ``TRANSFORM GROUP`` clause or any ``DECLARE 
-TABLE`` statements in a ``MODULE`` statement. 
+If you want to restrict your code to Core SQL, don't use the ``NAMES ARE``
+clause, the ``PATH`` clause, the ``TRANSFORM GROUP`` clause or any ``DECLARE
+TABLE`` statements in a ``MODULE`` statement.
 
 PROCEDURE Statement
 ===================
 
-The ``PROCEDURE`` statement defines an externally-invoked procedure. The 
-required syntax for the ``PROCEDURE`` statement is: 
+The ``PROCEDURE`` statement defines an externally-invoked procedure. The
+required syntax for the ``PROCEDURE`` statement is:
 
 ::
 
@@ -153,75 +155,75 @@ required syntax for the ``PROCEDURE`` statement is:
     {(<host parameter declaration> [ {,<host parameter declaration>}... ] ) |
     <host parameter declaration>...};
     SQL procedure statement;
-    
+
        <host parameter declaration> ::=
        :<host parameter name> <data type> [ AS LOCATOR ] |
        SQLSTATE
 
-An externally-invoked procedure is an SQL procedure that is called from a host 
-language program. It belongs to an SQL-client Module, and must have a 
-<procedure name> that is unique (for all procedures) within that Module. A 
-<procedure name> is a <regular identifier> or a <delimited identifier> and 
-should conform to the host language you'll be calling it from. 
+An externally-invoked procedure is an SQL procedure that is called from a host
+language program. It belongs to an SQL-client Module, and must have a
+<procedure name> that is unique (for all procedures) within that Module. A
+<procedure name> is a <regular identifier> or a <delimited identifier> and
+should conform to the host language you'll be calling it from.
 
-Each procedure has to contain a list of one or more parameter declarations, 
-terminated with a semicolon -- ``SQLSTATE`` is always mandatory. Your list 
-should be enclosed in parentheses, with each parameter declaration separated 
-from the next by a comma (though our syntax diagram shows that both the 
-parentheses and the commas are currently optional, this is a deprecated feature 
-in the Standard, so avoid it). Other than ``SQLSTATE``, each parameter has a 
-name (preceded by a colon), a <data type> and -- if it is a ``BLOB``, ``CLOB``, 
-``NCLOB``, ``UDT`` or ``ARRAY`` -- an optional ``AS LOCATOR`` indicator. A call 
-of an externally-invoked procedure has to supply the same number of arguments 
-as the parameter declarations in the procedure. 
+Each procedure has to contain a list of one or more parameter declarations,
+terminated with a semicolon -- ``SQLSTATE`` is always mandatory. Your list
+should be enclosed in parentheses, with each parameter declaration separated
+from the next by a comma (though our syntax diagram shows that both the
+parentheses and the commas are currently optional, this is a deprecated feature
+in the Standard, so avoid it). Other than ``SQLSTATE``, each parameter has a
+name (preceded by a colon), a <data type> and -- if it is a ``BLOB``, ``CLOB``,
+``NCLOB``, ``UDT`` or ``ARRAY`` -- an optional ``AS LOCATOR`` indicator. A call
+of an externally-invoked procedure has to supply the same number of arguments
+as the parameter declarations in the procedure.
 
-Each procedure has to contain exactly one SQL procedure statement, terminated 
-with a semicolon. This is the SQL statement that gets executed when the 
-procedure is called. An SQL procedure statement is any executable SQL statement 
--- this includes all the SQL-Schema statements, the SQL-data statements, the 
-SQL-control statements, the SQL-transaction statements, the SQL-Connection 
-statements, the SQL-session statements and the SQL diagnostics statement. 
+Each procedure has to contain exactly one SQL procedure statement, terminated
+with a semicolon. This is the SQL statement that gets executed when the
+procedure is called. An SQL procedure statement is any executable SQL statement
+-- this includes all the SQL-Schema statements, the SQL-data statements, the
+SQL-control statements, the SQL-transaction statements, the SQL-Connection
+statements, the SQL-session statements and the SQL diagnostics statement.
 
-If you calling the procedure from: 
+If you calling the procedure from:
 
-**Ada** -- then use only these <data type>s in your <host parameter 
-declaration>s: ``CHARACTER``, ``BIT``, ``SMALLINT``, ``INTEGER``, ``REAL``, 
-``DOUBLE PRECISION``, declare ``SQLSTATE``\'s base type as 
-``SQL_STANDARD.SQLSTATE_TYPE``, and identify the procedure by its <procedure 
-name>, as if it was declared within an Ada library unit specification that has 
-a name equal to the name of the SQL-client Module that contains the procedure. 
+**Ada** -- then use only these <data type>s in your <host parameter
+declaration>s: ``CHARACTER``, ``BIT``, ``SMALLINT``, ``INTEGER``, ``REAL``,
+``DOUBLE PRECISION``, declare ``SQLSTATE``\'s base type as
+``SQL_STANDARD.SQLSTATE_TYPE``, and identify the procedure by its <procedure
+name>, as if it was declared within an Ada library unit specification that has
+a name equal to the name of the SQL-client Module that contains the procedure.
 
-**C** -- then use only these <data type>s in your <host parameter 
-declaration>s: ``CHARACTER``, ``CHARACTER VARYING``, ``BIT``, ``INTEGER``, 
-``SMALLINT``, ``REAL``, ``DOUBLE PRECISION``, and declare ``SQLSTATE`` as a C 
-``char`` with length 6. 
+**C** -- then use only these <data type>s in your <host parameter
+declaration>s: ``CHARACTER``, ``CHARACTER VARYING``, ``BIT``, ``INTEGER``,
+``SMALLINT``, ``REAL``, ``DOUBLE PRECISION``, and declare ``SQLSTATE`` as a C
+``char`` with length 6.
 
-**COBOL** -- then use only these <data type>s in your <host parameter 
-declaration>s: ``CHARACTER``, ``BIT``, ``NUMERIC``, ``INTEGER``, ``SMALLINT``, 
-and declare ``SQLSTATE`` as a COBOL ``PICTURE X(5)``. 
+**COBOL** -- then use only these <data type>s in your <host parameter
+declaration>s: ``CHARACTER``, ``BIT``, ``NUMERIC``, ``INTEGER``, ``SMALLINT``,
+and declare ``SQLSTATE`` as a COBOL ``PICTURE X(5)``.
 
-**Fortran** -- then use only these <data type>s in your <host parameter 
-declaration>s: ``CHARACTER``, ``BIT``, ``INTEGER``, ``REAL``, ``DOUBLE 
-PRECISION``, and declare ``SQLSTATE`` as a Fortran ``CHARACTER`` with length 5. 
+**Fortran** -- then use only these <data type>s in your <host parameter
+declaration>s: ``CHARACTER``, ``BIT``, ``INTEGER``, ``REAL``, ``DOUBLE
+PRECISION``, and declare ``SQLSTATE`` as a Fortran ``CHARACTER`` with length 5.
 
-**MUMPS** -- then use only these <data type>s in your <host parameter 
-declaration>s: ``CHARACTER VARYING``, ``INTEGER``, ``DECIMAL``, ``REAL``, and 
-declare ``SQLSTATE`` as a MUMPS character with maximum length greater than or 
-equal to 5. 
+**MUMPS** -- then use only these <data type>s in your <host parameter
+declaration>s: ``CHARACTER VARYING``, ``INTEGER``, ``DECIMAL``, ``REAL``, and
+declare ``SQLSTATE`` as a MUMPS character with maximum length greater than or
+equal to 5.
 
-**Pascal** -- then use only these <data type>s in your <host parameter 
-declaration>s: ``CHARACTER``, ``BIT``, ``INTEGER``, ``REAL``, and declare 
-``SQLSTATE`` as a Pascal ``PACKED ARRAY [1..5] OF CHAR``. 
+**Pascal** -- then use only these <data type>s in your <host parameter
+declaration>s: ``CHARACTER``, ``BIT``, ``INTEGER``, ``REAL``, and declare
+``SQLSTATE`` as a Pascal ``PACKED ARRAY [1..5] OF CHAR``.
 
-**PL/I** -- then use only these <data type>s in your <host parameter 
-declaration>s: ``CHARACTER``, ``CHARACTER VARYING``, ``BIT``, ``BIT VARYING``, 
-``DECIMAL``, ``INTEGER``, ``SMALLINT``, ``FLOAT``, and declare ``SQLSTATE`` as 
-a PL/I ``CHARACTER(5)``. 
+**PL/I** -- then use only these <data type>s in your <host parameter
+declaration>s: ``CHARACTER``, ``CHARACTER VARYING``, ``BIT``, ``BIT VARYING``,
+``DECIMAL``, ``INTEGER``, ``SMALLINT``, ``FLOAT``, and declare ``SQLSTATE`` as
+a PL/I ``CHARACTER(5)``.
 
-For a list of the correspondences between SQL <data type>s and host data types, 
-see "Host Variables" in our chapter on embedded SQL. 
+For a list of the correspondences between SQL <data type>s and host data types,
+see "Host Variables" in our chapter on embedded SQL.
 
-Here's an example of an SQL-client Module: 
+Here's an example of an SQL-client Module:
 
 ::
 

--- a/docs/chapters/53.rst
+++ b/docs/chapters/53.rst
@@ -4,65 +4,67 @@
 Chapter 53 -- Style
 ===================
 
-Here is one SQL operation, written in two contrasting styles. Notice the 
-different names, spacing, indentation and choice of optional keywords: 
+.. include:: ../_include/note.rst
 
-[CASUAL] 
+Here is one SQL operation, written in two contrasting styles. Notice the
+different names, spacing, indentation and choice of optional keywords:
+
+[CASUAL]
 
 ::
 
     SELECT * FROM T WHERE C1>5 ORDER BY 1 ASC;
 
-[FORMAL] 
+[FORMAL]
 
 ::
 
-    SELECT   package_id, special_handling_code, buy_date 
-    FROM     Packages 
-    WHERE    package_id > 1.0 
-    ORDER BY package_id; 
+    SELECT   package_id, special_handling_code, buy_date
+    FROM     Packages
+    WHERE    package_id > 1.0
+    ORDER BY package_id;
 
-Casual style is better for notes, examples, blackboard discussions and 
-prototypes. We use it in this book whenever we enclose an SQL statement in an 
-illustrative sentence, as when we say that ``SELECT * FROM T WHERE C1>5 ORDER 
-BY 1 ASC`` is an example of casual style. We don't wear suits on beaches and we 
-believe that casual style is appropriate for our purposes. On the other hand, a 
-serious program demands some formality. There is one good reason and one bad 
-reason. 
+Casual style is better for notes, examples, blackboard discussions and
+prototypes. We use it in this book whenever we enclose an SQL statement in an
+illustrative sentence, as when we say that ``SELECT * FROM T WHERE C1>5 ORDER
+BY 1 ASC`` is an example of casual style. We don't wear suits on beaches and we
+believe that casual style is appropriate for our purposes. On the other hand, a
+serious program demands some formality. There is one good reason and one bad
+reason.
 
-* Appearance -- Okay, this is the bad reason. Formal style persuades others, 
-  perhaps even yourself, that you used some sort of organization and design. 
+* Appearance -- Okay, this is the bad reason. Formal style persuades others,
+  perhaps even yourself, that you used some sort of organization and design.
 
-* Coherence -- You can read statements more easily if you know in advance the 
-  shape, order and vocabulary. More time is spent "reading" code than "writing" 
-  it, so you will save time by investing time at the start. 
+* Coherence -- You can read statements more easily if you know in advance the
+  shape, order and vocabulary. More time is spent "reading" code than "writing"
+  it, so you will save time by investing time at the start.
 
-Besides, maybe you do wear suits on beaches. 
+Besides, maybe you do wear suits on beaches.
 
 **A True Story**
 
-There once was a clever DBMS named O_____ (tm). The people who program O_____ 
-were mulling in their tall building in Redwood Shores CA one day. "Sometimes we 
-have to run the same SQL statements twice", they mulled. "So why should we 
-parse the same statement again when we already know what the Access Plan is 
-from the first time we ran it?" And they came up with a clever plan. They put 
-the first SQL statement in a cache! Then, when the second SQL statement came 
-along, they had a clever way of telling that it was really something they'd 
-done before (maybe with a parameter or two different but that doesn't affect 
-the story). And they just re-used the same Access Plan and saved oodles of 
-time. They even used this clever plan for Views. Which was great. Except that 
-their way of comparing the new SQL statement with the cached SQL statement was, 
-well, simple. What they did was: they compared every byte in the cached 
-statement with every byte in the new statement. That's it. No lower-to-upper 
-conversions, no lead-space trimming, nothing but a ``REP CMPSB`` (that's 
-``strcmp`` to you C fans). 
+There once was a clever DBMS named O_____ (tm). The people who program O_____
+were mulling in their tall building in Redwood Shores CA one day. "Sometimes we
+have to run the same SQL statements twice", they mulled. "So why should we
+parse the same statement again when we already know what the Access Plan is
+from the first time we ran it?" And they came up with a clever plan. They put
+the first SQL statement in a cache! Then, when the second SQL statement came
+along, they had a clever way of telling that it was really something they'd
+done before (maybe with a parameter or two different but that doesn't affect
+the story). And they just re-used the same Access Plan and saved oodles of
+time. They even used this clever plan for Views. Which was great. Except that
+their way of comparing the new SQL statement with the cached SQL statement was,
+well, simple. What they did was: they compared every byte in the cached
+statement with every byte in the new statement. That's it. No lower-to-upper
+conversions, no lead-space trimming, nothing but a ``REP CMPSB`` (that's
+``strcmp`` to you C fans).
 
-What happened next? Well, in all the good-doobie programming shops, where 
-everybody wrote every detail according to the same style rules ... why, the 
-programs ran faster. But in all the other programming shops, where freedom and 
-creativity ruled, nothing happened. 
+What happened next? Well, in all the good-doobie programming shops, where
+everybody wrote every detail according to the same style rules ... why, the
+programs ran faster. But in all the other programming shops, where freedom and
+creativity ruled, nothing happened.
 
-The moral of the story is: choose a common style, then *stick to your style*. 
+The moral of the story is: choose a common style, then *stick to your style*.
 
 .. rubric:: Table of Contents
 
@@ -72,23 +74,23 @@ The moral of the story is: choose a common style, then *stick to your style*.
 Authority
 =========
 
-To get the rules of good SQL style for you, we culled them from actual rules of 
-large programmer shops, or by just looking at what rules are implicit in code 
-written by experts (for example, the sample code in vendors' manuals). Where we 
-had to note inconsistencies -- and there are several -- we've made no attempt 
-to clean them up. Where we are aware of minority views, we've reported them. 
-And where we saw opportunities to improve things by adding some new reasonable 
-rule, we didn't -- on the grounds that anything which is really reasonable 
-would already be common practice. 
+To get the rules of good SQL style for you, we culled them from actual rules of
+large programmer shops, or by just looking at what rules are implicit in code
+written by experts (for example, the sample code in vendors' manuals). Where we
+had to note inconsistencies -- and there are several -- we've made no attempt
+to clean them up. Where we are aware of minority views, we've reported them.
+And where we saw opportunities to improve things by adding some new reasonable
+rule, we didn't -- on the grounds that anything which is really reasonable
+would already be common practice.
 
-Having said that we are following common practice, we must also say that no 
-single person or organization actually obeys all these prescriptions. About 
-half of the world's database programmers obey about half of the style rules, 
-sometimes. 
+Having said that we are following common practice, we must also say that no
+single person or organization actually obeys all these prescriptions. About
+half of the world's database programmers obey about half of the style rules,
+sometimes.
 
-We've organized the style rules into two general classes: layout rules and 
-naming rules. Within the classes, the rules are in no particular order. The 
-numbers are arbitrary. 
+We've organized the style rules into two general classes: layout rules and
+naming rules. Within the classes, the rules are in no particular order. The
+numbers are arbitrary.
 
 Layout Rules
 ============
@@ -96,9 +98,9 @@ Layout Rules
 *1-- Capitals*
 --------------
 
-Write SQL <keyword>s in upper case. Write <Table name>s with an initial 
-capital, small letters after that; when a <Table name> has two parts, use an 
-initial capital for each part. Write <Column name>s in lower case. For example: 
+Write SQL <keyword>s in upper case. Write <Table name>s with an initial
+capital, small letters after that; when a <Table name> has two parts, use an
+initial capital for each part. Write <Column name>s in lower case. For example:
 
 ::
 
@@ -107,8 +109,8 @@ initial capital for each part. Write <Column name>s in lower case. For example:
     UPDATE Temporary_Personnel SET
         discharge_date = CURRENT_DATE;
 
-Names of other, non-Column, Objects should also have an initial capital. For 
-example: 
+Names of other, non-Column, Objects should also have an initial capital. For
+example:
 
 ::
 
@@ -116,35 +118,35 @@ example:
         ON Widgets
         TO Sandra, Maria;
 
-**Exception:** If a name is an acronym -- e.g.: NATO or SQL or NIST -- use all 
-capital letters. 
+**Exception:** If a name is an acronym -- e.g.: NATO or SQL or NIST -- use all
+capital letters.
 
-**Alternative:** Some write everything in lower case -- it's easier to 
-remember. And we've seen examples written entirely in upper case -- but 
-not recent examples. You should remember that <regular identifiers> are 
-stored in upper case, but it's been a long time since any DBMS insisted 
-that Object names must be entered in upper case in the first place. 
+**Alternative:** Some write everything in lower case -- it's easier to
+remember. And we've seen examples written entirely in upper case -- but
+not recent examples. You should remember that <regular identifiers> are
+stored in upper case, but it's been a long time since any DBMS insisted
+that Object names must be entered in upper case in the first place.
 
 *2-- Spaces*
 ------------
 
-Put a single space after every SQL -- that is, after every <keyword> and 
-after <identifier>s and after operators such as ``*`` or ``+`` or ``=``. 
-For example: 
+Put a single space after every SQL -- that is, after every <keyword> and
+after <identifier>s and after operators such as ``*`` or ``+`` or ``=``.
+For example:
 
 ::
 
     SELECT width * 5 ...
 
 **Exception:** There need be no spaces after scalar or set function names, or
-within parentheses. For example: 
+within parentheses. For example:
 
 ::
 
     SELECT MAX(width) ...
 
-**Exception:** There should be no space before comma (,) or semicolon 
-(;). There should, however, be a space after the comma. For example: 
+**Exception:** There should be no space before comma (,) or semicolon
+(;). There should, however, be a space after the comma. For example:
 
 ::
 
@@ -153,11 +155,11 @@ within parentheses. For example:
 
 **Exception:** There should be no space at the end of a line.
 
-**Exception:** In a qualified name, there should be no space before or after 
+**Exception:** In a qualified name, there should be no space before or after
 the period (.).
 
-**Alternative:** Some would omit spaces around comparison operators or 
-arithmetic operators. For example: 
+**Alternative:** Some would omit spaces around comparison operators or
+arithmetic operators. For example:
 
 ::
 
@@ -168,13 +170,13 @@ arithmetic operators. For example:
 
 [ Skip this rule if you use SQL/CLI or direct SQL]
 
-There are alternate rules for "when to switch to a new line", usually called 
-"breaking". The common rule is to break on every clause-start <keyword>. In a 
-``SELECT`` statement, the clause-start <keyword>s are: ``SELECT`` itself, 
-``FROM``, ``ON``, ``WHERE``, ``GROUP``, ``HAVING``, ``ORDER``; the Boolean 
-operators ``AND / OR`` are usually considered to be equivalent to clause-start 
-<keyword>s. Additionally, some prescribe a break after every full expression. 
-For example: 
+There are alternate rules for "when to switch to a new line", usually called
+"breaking". The common rule is to break on every clause-start <keyword>. In a
+``SELECT`` statement, the clause-start <keyword>s are: ``SELECT`` itself,
+``FROM``, ``ON``, ``WHERE``, ``GROUP``, ``HAVING``, ``ORDER``; the Boolean
+operators ``AND / OR`` are usually considered to be equivalent to clause-start
+<keyword>s. Additionally, some prescribe a break after every full expression.
+For example:
 
 ::
 
@@ -186,7 +188,7 @@ For example:
               AND   length >= 5
               ORDER BY width;
 
-Others will place multiple items on a line if there aren't too many to fit. For 
+Others will place multiple items on a line if there aren't too many to fit. For
 example:
 
 ::
@@ -197,15 +199,15 @@ example:
     AND      length >= 5
     ORDER BY width;
 
-Notice the indentation at the start of each line -- or lack thereof! It is rare 
-to find, say, a ``SELECT`` statement starting on Column #1 but all subsequent 
-clauses starting on Column #3. In any case, to accomplish the lined-up effect, 
-one uses spaces rather than tab characters. The indentation seen in the above 
-``SELECT`` statements is to Column position 10 to accommodate ``ORDER BY``; 
-with non-``SELECT`` statements indent is random. 
+Notice the indentation at the start of each line -- or lack thereof! It is rare
+to find, say, a ``SELECT`` statement starting on Column #1 but all subsequent
+clauses starting on Column #3. In any case, to accomplish the lined-up effect,
+one uses spaces rather than tab characters. The indentation seen in the above
+``SELECT`` statements is to Column position 10 to accommodate ``ORDER BY``;
+with non-``SELECT`` statements indent is random.
 
-**Exception:** One group prefers to right-justify the main <keyword>s. For 
-example: 
+**Exception:** One group prefers to right-justify the main <keyword>s. For
+example:
 
 ::
 
@@ -215,8 +217,8 @@ example:
               AND length >= 5
               ORDER BY width;
 
-There is a universal rule in all languages: if it's nested, indent. So further 
-indentation will be necessary for subqueries. For example: 
+There is a universal rule in all languages: if it's nested, indent. So further
+indentation will be necessary for subqueries. For example:
 
 ::
 
@@ -229,13 +231,13 @@ indentation will be necessary for subqueries. For example:
 
 Notice the position of the ( preceding the word ``SELECT``.
 
-**Alternative:** Put the ( at the end of the previous line. However, placing a 
-closing ) on the same line as the end of the statement is normal -- even though 
-this differs from the way many C programmers use {} braces and differs from the 
-way many Pascal programmers write begin ... end blocks. 
+**Alternative:** Put the ( at the end of the previous line. However, placing a
+closing ) on the same line as the end of the statement is normal -- even though
+this differs from the way many C programmers use {} braces and differs from the
+way many Pascal programmers write begin ... end blocks.
 
-**Alternative:** Put the initial <keyword> of a major clause on a line of its 
-own, as is done with ``WHERE`` and ``AND`` in this example: 
+**Alternative:** Put the initial <keyword> of a major clause on a line of its
+own, as is done with ``WHERE`` and ``AND`` in this example:
 
 ::
 
@@ -248,8 +250,8 @@ own, as is done with ``WHERE`` and ``AND`` in this example:
 
 Note also the different indentation of the conditional clauses.
 
-**Alternative:** Put ``ORed`` conditions on the same line, but break for 
-``AND``. For example: 
+**Alternative:** Put ``ORed`` conditions on the same line, but break for
+``AND``. For example:
 
 ::
 
@@ -259,7 +261,7 @@ Note also the different indentation of the conditional clauses.
              (rowid = 5 OR rowid = 6 OR rowid = 7)
          AND width > 1;
 
-**Alternative:** Add line breaks for each level of a nested function. For 
+**Alternative:** Add line breaks for each level of a nested function. For
 example:
 
 ::
@@ -274,9 +276,9 @@ Make a new line for ``UNION``. Treat ``AND NOT`` as a single operator.
 3a-- Continuation Lines
 _______________________
 
-When room is unavailable on a line, break if possible at a comma or equal sign 
-or other operator <keyword>. If there are too many <Column name>s to fit in one 
-line, break thus: 
+When room is unavailable on a line, break if possible at a comma or equal sign
+or other operator <keyword>. If there are too many <Column name>s to fit in one
+line, break thus:
 
 ::
 
@@ -287,16 +289,16 @@ line, break thus:
 
 ::
 
-    SELECT Column_1, Column_2, Column_3, Column_4, Column_5 
+    SELECT Column_1, Column_2, Column_3, Column_4, Column_5
            ,Column_6, Column_7, Column_8, Column_9, Column_10 ...
 
 3b-- Indenting CREATEs
 ______________________
 
-In a ``CREATE TABLE`` statement, every new Column goes on a new line. When it 
-helps, you may indent so that each part of the <Column definitiion> is at the 
-same position on the line -- but nobody does that all the time. Here's an 
-example: 
+In a ``CREATE TABLE`` statement, every new Column goes on a new line. When it
+helps, you may indent so that each part of the <Column definitiion> is at the
+same position on the line -- but nobody does that all the time. Here's an
+example:
 
 ::
 
@@ -306,20 +308,20 @@ example:
        partid         INTEGER,
        comments       VARCHAR(3000));
 
-Usually ``CREATE TABLE`` statements will also have Constraint clauses. We have 
-split them out here, adding the Constraints in later ``ALTER TABLE`` 
-statements. Constraints are in fact separate from Tables, but if you find that 
-splitting up the Table definition into separate statements is unacceptable, 
-you're not alone. The other part of this illustration shows our preference for 
-giving names to everything, including Constraints -- see Rule 16. Here's an 
-example: 
+Usually ``CREATE TABLE`` statements will also have Constraint clauses. We have
+split them out here, adding the Constraints in later ``ALTER TABLE``
+statements. Constraints are in fact separate from Tables, but if you find that
+splitting up the Table definition into separate statements is unacceptable,
+you're not alone. The other part of this illustration shows our preference for
+giving names to everything, including Constraints -- see Rule 16. Here's an
+example:
 
 ::
 
     ALTER Table Transactions
     ADD CONSTRAINT transaction_primary_key
     PRIMARY KEY (transactionid);
-    
+
     ALTER Table Transactions
     ADD CONSTRAINT transaction_references_inventory
     FOREIGN KEY partid REFERENCES Inventory(partid)
@@ -329,9 +331,9 @@ example:
 3c-- Indenting INSERTs
 ______________________
 
-Here is an ``INSERT`` statement formed according to the same rules as 
-discussed. Notice that the ``SELECT`` in the example is not indented like a 
-subquery would be. 
+Here is an ``INSERT`` statement formed according to the same rules as
+discussed. Notice that the ``SELECT`` in the example is not indented like a
+subquery would be.
 
 ::
 
@@ -341,7 +343,7 @@ subquery would be.
     FROM   Players
     WHERE  leagueno IS NULL;
 
-For streams of ``INSERT`` statements, one relaxes the rules to squeeze to one 
+For streams of ``INSERT`` statements, one relaxes the rules to squeeze to one
 line. For example:
 
 ::
@@ -350,13 +352,13 @@ line. For example:
     INSERT INTO Personnel VALUES (7, 4, 166, 'Minimum');
     INSERT INTO Personnel VALUES (15, -6, 0, NULL);
 
-It might appear nice to line up the values in this example, but that's not what 
+It might appear nice to line up the values in this example, but that's not what
 people do.
 
 3d-- Indenting UPDATEs
 ______________________
 
-If we apply the rules consistently, then an ``UPDATE`` statement should look 
+If we apply the rules consistently, then an ``UPDATE`` statement should look
 like this:
 
 ::
@@ -364,7 +366,7 @@ like this:
     UPDATE Contacts
     SET    first_grade = 'A', second_grade = 'B', third_grade = 'C';
 
-**Alternative:** The more common style is to break for each assignment. For 
+**Alternative:** The more common style is to break for each assignment. For
 example:
 
 ::
@@ -377,37 +379,37 @@ example:
 *4-- Statement End*
 -------------------
 
-End statements with a semicolon without a preceding space. For example: 
+End statements with a semicolon without a preceding space. For example:
 
 ::
 
     COMMIT;
 
-**Exception:** Where the semicolon is inappropriate, omit it (for example, in 
-COBOL shops or where the vendor won't accept it). 
+**Exception:** Where the semicolon is inappropriate, omit it (for example, in
+COBOL shops or where the vendor won't accept it).
 
 *5-- Comments*
 --------------
 
-A simple comment begins with a double minus sign (\-\-) and ends at the next 
-line. Unfortunately, if an SQL statement comes from keyboard input, then the 
-dialog manager will strip the line breaks. And, OSs disagree whether a line 
-break is one character (LF) or two (CR+LF). Because of the danger that presents 
-to the parser, many eschew all comments in the SQL statement and put them in 
-the host language code. For example: 
+A simple comment begins with a double minus sign (\-\-) and ends at the next
+line. Unfortunately, if an SQL statement comes from keyboard input, then the
+dialog manager will strip the line breaks. And, OSs disagree whether a line
+break is one character (LF) or two (CR+LF). Because of the danger that presents
+to the parser, many eschew all comments in the SQL statement and put them in
+the host language code. For example:
 
 ::
 
-    /* Here is a C comment preceding an embedded SQL statement */ 
+    /* Here is a C comment preceding an embedded SQL statement */
             EXEC SQL
             SELECT width, length
             FROM Widgets;
     /* Here is a C comment following an embedded SQL statement */
 
-The problem disappears if your DBMS supports SQL3, which allows C-like comments 
--- i.e.: comments that begin with \/* and end with \*/. Although C-like comments 
-are far from universal, they are the preferred style among Microsoft SQL Server 
-users. Occasionally they are even used for section headings, thus: 
+The problem disappears if your DBMS supports SQL3, which allows C-like comments
+-- i.e.: comments that begin with \/* and end with \*/. Although C-like comments
+are far from universal, they are the preferred style among Microsoft SQL Server
+users. Occasionally they are even used for section headings, thus:
 
 ::
 
@@ -422,16 +424,16 @@ users. Occasionally they are even used for section headings, thus:
        CREATE PROCEDURE ...
        CREATE PROCEDURE ...
 
-Speaking of comments, Weinberg (The Psychology of Computer Programming) suggested that code and comments should be 
-written in separate columns. This would make it easier to focus on the code 
-when debugging (if a program has bugs then the comments are probably lies). 
+Speaking of comments, Weinberg (The Psychology of Computer Programming) suggested that code and comments should be
+written in separate columns. This would make it easier to focus on the code
+when debugging (if a program has bugs then the comments are probably lies).
 
 *6-- Qualifiers*
 ----------------
 
-When an SQL statement contains references to more than one Table, use <Column 
-reference>s rather than <Column name>s. This is particularly true for joins. 
-For example: 
+When an SQL statement contains references to more than one Table, use <Column
+reference>s rather than <Column name>s. This is particularly true for joins.
+For example:
 
 ::
 
@@ -439,12 +441,12 @@ For example:
     FROM   Widgets, Foobars
     WHERE  Widgets.length = Foobars.width;
 
-Not only does the qualification of a <Column reference> help the reader see 
-which Table a Column belongs to, it guards against later breakage of the code 
-(if, for instance, a new Column named ``WIDTH`` is someday added to 
-``FOOBARS``). Sometimes the qualification may have to include Schema and 
-<Catalog name>s too. If qualification starts to get at all lengthy, use 
-<Correlation name>s. 
+Not only does the qualification of a <Column reference> help the reader see
+which Table a Column belongs to, it guards against later breakage of the code
+(if, for instance, a new Column named ``WIDTH`` is someday added to
+``FOOBARS``). Sometimes the qualification may have to include Schema and
+<Catalog name>s too. If qualification starts to get at all lengthy, use
+<Correlation name>s.
 
 *7-- Shorthands*
 ----------------
@@ -452,19 +454,19 @@ which Table a Column belongs to, it guards against later breakage of the code
 7a-- Shorthands for lists
 _________________________
 
-Do not use ``SELECT * ...`` to mean "``SELECT all Columns ...``". List the 
-Columns you want by name. For example: 
+Do not use ``SELECT * ...`` to mean "``SELECT all Columns ...``". List the
+Columns you want by name. For example:
 
 ::
 
     SELECT length, width
     FROM   Widgets;
 
-**Exception:** In the set function ``COUNT(*)``, the asterisk is necessary and 
-in ``EXISTS (SELECT * ...`` the asterisk is preferred. 
+**Exception:** In the set function ``COUNT(*)``, the asterisk is necessary and
+in ``EXISTS (SELECT * ...`` the asterisk is preferred.
 
-Do not use an ``INSERT`` statement without a Column list. List the Columns you 
-want by name. For example: 
+Do not use an ``INSERT`` statement without a Column list. List the Columns you
+want by name. For example:
 
 ::
 
@@ -472,11 +474,11 @@ want by name. For example:
         (length, width)
     VALUES (1, 2);
 
-**Exception:** Streams of ``INSERT`` statements contain no Column list, see 
+**Exception:** Streams of ``INSERT`` statements contain no Column list, see
 rule 3c.
 
-Do not use ``GRANT ALL PRIVILEGES`` or ``REVOKE ALL PRIVILEGES`` for a 
-Privilege list. List the Privileges you want by name. For example: 
+Do not use ``GRANT ALL PRIVILEGES`` or ``REVOKE ALL PRIVILEGES`` for a
+Privilege list. List the Privileges you want by name. For example:
 
 ::
 
@@ -487,24 +489,24 @@ Privilege list. List the Privileges you want by name. For example:
 7b-- Shorthands for Expressions
 _______________________________
 
-Usually, expression shorthands involve learning new syntax. For example, 
-``COALESCE(a,b)`` is short for ``CASE WHEN a IS NOT NULL THEN a ELSE b END``. 
-But we'd guess that some people would have to look up ``COALESCE`` to find out 
-what it means. On the other hand, they might be able to puzzle out the longer 
-``CASE`` expression, because they've seen similar constructs in most other 
-computer languages. The consensus seems to be to use the longer expression, 
-rather than the shorthand -- unless the shorthand itself is a common and 
-well-understood construct. 
+Usually, expression shorthands involve learning new syntax. For example,
+``COALESCE(a,b)`` is short for ``CASE WHEN a IS NOT NULL THEN a ELSE b END``.
+But we'd guess that some people would have to look up ``COALESCE`` to find out
+what it means. On the other hand, they might be able to puzzle out the longer
+``CASE`` expression, because they've seen similar constructs in most other
+computer languages. The consensus seems to be to use the longer expression,
+rather than the shorthand -- unless the shorthand itself is a common and
+well-understood construct.
 
 *8-- Short forms*
 -----------------
 
-For <data type>s, use short forms: ``CHAR`` rather than ``CHARACTER``, 
-``VARCHAR`` rather than ``CHARACTER VARYING``, ``INT`` rather than ``INTEGER``, 
-``BLOB`` rather than ``BINARY LARGE OBJECT``. 
+For <data type>s, use short forms: ``CHAR`` rather than ``CHARACTER``,
+``VARCHAR`` rather than ``CHARACTER VARYING``, ``INT`` rather than ``INTEGER``,
+``BLOB`` rather than ``BINARY LARGE OBJECT``.
 
-Speaking of shortness -- though this has nothing to do with Rule 8 -- a 
-too-long name is: ``Parts_Which_Have_No_Serial_Numbers``. 
+Speaking of shortness -- though this has nothing to do with Rule 8 -- a
+too-long name is: ``Parts_Which_Have_No_Serial_Numbers``.
 
 *9-- Redundancy*
 ----------------
@@ -512,8 +514,8 @@ too-long name is: ``Parts_Which_Have_No_Serial_Numbers``.
 9a-- Noise <keyword>s
 _____________________
 
-Where a <keyword> is optional and eliminating it would cause no change in 
-meaning, eliminate it. One example: 
+Where a <keyword> is optional and eliminating it would cause no change in
+meaning, eliminate it. One example:
 
 ::
 
@@ -527,7 +529,7 @@ instead of:
     GRANT UPDATE, INSERT
     ON TABLE Widgets ...
 
-Another example: 
+Another example:
 
 ::
 
@@ -569,27 +571,27 @@ instead of:
     SELECT ALL width
     FROM       Widgets;
 
-Remember Shannon and information theory: when a word adds nothing to the 
+Remember Shannon and information theory: when a word adds nothing to the
 meaning, it is not information. It is noise.
 
-**Exception:** It's never bad to add unnecessary parentheses if there is any 
-chance that a reader might not guess what the precedence of operators might be. 
-For example: 
+**Exception:** It's never bad to add unnecessary parentheses if there is any
+chance that a reader might not guess what the precedence of operators might be.
+For example:
 
 ::
 
     SELECT (width * 5) + 4
     FROM   Widgets;
 
-**Exception:** Although ``UNION DISTINCT`` is not in common use, it is clear 
+**Exception:** Although ``UNION DISTINCT`` is not in common use, it is clear
 that SQL3's designers believe that explicitly saying ``DISTINCT`` is good.
 
 9b-- Superfluous Clauses
 ________________________
 
-Most SQL programmers are willing to say the same thing twice "to make the 
-meaning clearer". We give two examples of this bad but normal practice. The 
-first shows a superfluous ``NOT NULL`` clause: 
+Most SQL programmers are willing to say the same thing twice "to make the
+meaning clearer". We give two examples of this bad but normal practice. The
+first shows a superfluous ``NOT NULL`` clause:
 
 ::
 
@@ -597,9 +599,9 @@ first shows a superfluous ``NOT NULL`` clause:
        (width      INT         NOT NULL,
         CONSTRAINT widget_pkey PRIMARY KEY(width));
 
-In SQL-92 and SQL3, a primary key is automatically ``NOT NULL``. 
+In SQL-92 and SQL3, a primary key is automatically ``NOT NULL``.
 
-The second example shows a superfluous predicate: 
+The second example shows a superfluous predicate:
 
 ::
 
@@ -608,8 +610,8 @@ The second example shows a superfluous predicate:
     WHERE  spoffo BETWEEN 'A' AND 'AZZZ'
     AND    spoffo LIKE 'A%';
 
-The ``BETWEEN`` clause is unnecessary. It's probably there for "optimization" 
-reasons which are outside the scope of this chapter. 
+The ``BETWEEN`` clause is unnecessary. It's probably there for "optimization"
+reasons which are outside the scope of this chapter.
 
 9c-- Explicitizing
 __________________
@@ -620,18 +622,18 @@ You don't need to start any program with the SQL statement:
 
     CONNECT TO DEFAULT;
 
-because the DBMS would ``CONNECT TO DEFAULT`` anyway. So should you bother? 
-According to one DBMS expert: yes. In general, if some critical process is 
-*implicit* (performed automatically as default behaviour), you might do good by 
-making it *explicit* (specified in the instruction). You're making your 
-intentions clear not only to the reader, but also to the DBMS, so this act is 
-more than a mere comment. In this view, the first SQL executed statement should 
-be ``CONNECT``. 
+because the DBMS would ``CONNECT TO DEFAULT`` anyway. So should you bother?
+According to one DBMS expert: yes. In general, if some critical process is
+*implicit* (performed automatically as default behaviour), you might do good by
+making it *explicit* (specified in the instruction). You're making your
+intentions clear not only to the reader, but also to the DBMS, so this act is
+more than a mere comment. In this view, the first SQL executed statement should
+be ``CONNECT``.
 
 *10-- Literals*
 ---------------
 
-Enter <exact numeric literal>s using maximum scale but without lead zeros and 
+Enter <exact numeric literal>s using maximum scale but without lead zeros and
 without leading ``+`` signs. For example:
 
 ::
@@ -639,12 +641,12 @@ without leading ``+`` signs. For example:
     UPDATE Widgets
     SET    maximality = 10.00;
 
-**Exception:** When using <literal>s in arithmetic expressions, use the scale 
-that you want to the result to have. (Note: If you want to be emphatic about 
-what specific numeric <data type> you are using, consider using ``CAST``.) 
+**Exception:** When using <literal>s in arithmetic expressions, use the scale
+that you want to the result to have. (Note: If you want to be emphatic about
+what specific numeric <data type> you are using, consider using ``CAST``.)
 
-Even if a search of a character string Column is probably case-insensitive, use 
-both upper and lower case as you would if you were inserting. For example: 
+Even if a search of a character string Column is probably case-insensitive, use
+both upper and lower case as you would if you were inserting. For example:
 
 ::
 
@@ -652,11 +654,11 @@ both upper and lower case as you would if you were inserting. For example:
     FROM     Widgets
     WHERE    surname = 'Smith';
 
-Do not put trailing spaces in <character string literal>s unless they are 
-necessary for comparisons with ``PAD SPACE`` Collations. 
+Do not put trailing spaces in <character string literal>s unless they are
+necessary for comparisons with ``PAD SPACE`` Collations.
 
-For binary items, use ``X'....'`` rather than ``B'....'`` notation. For 
-example: 
+For binary items, use ``X'....'`` rather than ``B'....'`` notation. For
+example:
 
 ::
 
@@ -666,31 +668,31 @@ example:
 *11-- Specify Character Sets*
 -----------------------------
 
-We can't call this "common practice" because we haven't seen much of 
-_introducer use, but it would be consistent with the preceding to say that if a 
-character string has, or will have, non-Latin letters, and the default 
-Character set is not obvious, specify the Character set. 
+We can't call this "common practice" because we haven't seen much of
+_introducer use, but it would be consistent with the preceding to say that if a
+character string has, or will have, non-Latin letters, and the default
+Character set is not obvious, specify the Character set.
 
 *12. Statement Splitting*
 -------------------------
 
-Most SQL programmers are willing to write very long SQL statements. There is 
-some practical justification for this tendency: *(a)* if any form of 
-"auto-commit" is in effect, then splitting up SQL statements could leave the 
-database in an inconsistent state and *(b)* most DBMSs optimize at the 
-statement level, so putting everything in one statement might provide useful 
-information to the optimizer. 
+Most SQL programmers are willing to write very long SQL statements. There is
+some practical justification for this tendency: *(a)* if any form of
+"auto-commit" is in effect, then splitting up SQL statements could leave the
+database in an inconsistent state and *(b)* most DBMSs optimize at the
+statement level, so putting everything in one statement might provide useful
+information to the optimizer.
 
-Alternative: A minority view (which we espouse) holds that separate thoughts 
-belong in separate sentences, as in any ordinary language. For example, we've 
-suggested before that it's a good idea to add Constraints later (with ``ALTER 
-TABLE``), rather than mix all Constraints with <Column definition>s in the 
-original ``CREATE TABLE`` statement. 
+Alternative: A minority view (which we espouse) holds that separate thoughts
+belong in separate sentences, as in any ordinary language. For example, we've
+suggested before that it's a good idea to add Constraints later (with ``ALTER
+TABLE``), rather than mix all Constraints with <Column definition>s in the
+original ``CREATE TABLE`` statement.
 
 *13-- Impossibilities*
 ----------------------
 
-Consider this example of a ``CASE`` expression: 
+Consider this example of a ``CASE`` expression:
 
 ::
 
@@ -699,22 +701,22 @@ Consider this example of a ``CASE`` expression:
     WHEN <= 5 THEN '<=5'
     END
 
-It's hard to be sure, but it looks like the writers didn't ask "what if 
-``COLUMN_OF_DOOM`` is ``NULL``?". There should be an explicit ``ELSE`` clause, 
-here to allow for that. Defensive programmers code for the "default" or 
-"otherwise" case, even if the case can't possibly happen. 
+It's hard to be sure, but it looks like the writers didn't ask "what if
+``COLUMN_OF_DOOM`` is ``NULL``?". There should be an explicit ``ELSE`` clause,
+here to allow for that. Defensive programmers code for the "default" or
+"otherwise" case, even if the case can't possibly happen.
 
 *14-- Precise Comparisons*
 --------------------------
-Comparisons with ``>`` and ``<`` operators are sometimes vaguer than they need 
-be. For example: 
+Comparisons with ``>`` and ``<`` operators are sometimes vaguer than they need
+be. For example:
 
 ::
 
     name > 'X'         /* what if somebody is named 'X'? */
     position < 1       /* you mean position <= 0? */
 
-By rephrasing the comparison with a ``>=`` or ``<=`` operator, you can 
+By rephrasing the comparison with a ``>=`` or ``<=`` operator, you can
 sometimes catch such problems.
 
 *15-- Distributing NOTs*
@@ -722,43 +724,43 @@ sometimes catch such problems.
 
 "Neither a borrower nor a lender be." -- Polonius
 
-Instead of saying "be not a borrower or a lender" Polonius said "neither a 
-borrower nor a lender be" -- using a separate negation word for each negated 
-thing. This was an application of one of DeMorgan's Rules: 
+Instead of saying "be not a borrower or a lender" Polonius said "neither a
+borrower nor a lender be" -- using a separate negation word for each negated
+thing. This was an application of one of DeMorgan's Rules:
 
 ::
 
     NOT (A OR B) can be changed to NOT(A) AND NOT(B)
     NOT (A AND B) can be changed to NOT(A) OR NOT(B)
 
-Since the changed form is closer to the way that people actually talk, it is 
+Since the changed form is closer to the way that people actually talk, it is
 easier to read.
 
 Naming Rules
 ============
 
-Everyone says that onomatopoeia is the oldest profession. Or, at least, they 
-would say that, if they knew that onomatopoeia originally meant "the making of 
-names", and that Adam's first job was to name all the beasts in the Garden of 
-Eden. 
+Everyone says that onomatopoeia is the oldest profession. Or, at least, they
+would say that, if they knew that onomatopoeia originally meant "the making of
+names", and that Adam's first job was to name all the beasts in the Garden of
+Eden.
 
 *16. Give Everything a Name*
 ----------------------------
 
-The DBMS often lets you skip giving an Object a name: it just assigns a default 
-name. But this default name is arbitrary. And besides, no two DBMSs use the 
-same rules for default names. So, give explicit names to expressions in select 
-lists. For example: 
+The DBMS often lets you skip giving an Object a name: it just assigns a default
+name. But this default name is arbitrary. And besides, no two DBMSs use the
+same rules for default names. So, give explicit names to expressions in select
+lists. For example:
 
 ::
 
     SELECT (length + width) AS length_and_width
     FROM    Widgets;
 
-Consider giving explicit names to Constraints in ``CREATE TABLE``, ``ALTER 
-TABLE``, ``CREATE DOMAIN`` and ``ALTER DOMAIN`` statements. If you don't, how 
-will you drop the Constraints later? And how will you interpret the 
-diagnostics, which include <Contstraint name>s? Here's an example: 
+Consider giving explicit names to Constraints in ``CREATE TABLE``, ``ALTER
+TABLE``, ``CREATE DOMAIN`` and ``ALTER DOMAIN`` statements. If you don't, how
+will you drop the Constraints later? And how will you interpret the
+diagnostics, which include <Contstraint name>s? Here's an example:
 
 ::
 
@@ -766,138 +768,138 @@ diagnostics, which include <Contstraint name>s? Here's an example:
          (length     INT,
           CONSTRAINT Widgets_Length_Checker CHECK (length > 0));
 
-**Exception:** Usually one does not give names to simple Column Constraints 
-like ``NOT NULL`` or ``PRIMARY KEY``. 
+**Exception:** Usually one does not give names to simple Column Constraints
+like ``NOT NULL`` or ``PRIMARY KEY``.
 
-Actually, naming is just one prominent example of a case where the DBMS will 
-assign some "implementation-dependent" value if you don't specify one yourself. 
-In all such cases, it's probably safer to specify. 
+Actually, naming is just one prominent example of a case where the DBMS will
+assign some "implementation-dependent" value if you don't specify one yourself.
+In all such cases, it's probably safer to specify.
 
 *17-- When a Name Has Two Parts, Separate the Parts with the Underscore Character (_)*
 --------------------------------------------------------------------------------------
 
 For example: ``ytd_sales initial_extent``
 
-**Alternative:** For <Table name>s especially, you can keep the parts 
-unseparated but capitalize the second word. For example: ``OrderItems 
-DepartmentNumbers``. 
+**Alternative:** For <Table name>s especially, you can keep the parts
+unseparated but capitalize the second word. For example: ``OrderItems
+DepartmentNumbers``.
 
 *18-- Avoid Names That Might Be Reserved Words in Some SQL Dialect*
 -------------------------------------------------------------------
 
-The way to do this is to use names that refer to objects in the real world that 
-you're modelling with your database. You can be fairly sure that names like 
-``CandyStores``, ``book_title`` or ``swather`` are not names that the DBMS 
-needs for its own purposes. If you must be absolutely sure, you can take 
-further measures -- but there are problems with all of them. 
+The way to do this is to use names that refer to objects in the real world that
+you're modelling with your database. You can be fairly sure that names like
+``CandyStores``, ``book_title`` or ``swather`` are not names that the DBMS
+needs for its own purposes. If you must be absolutely sure, you can take
+further measures -- but there are problems with all of them.
 
-* You can use the list of <keyword>s, in our chapter on general SQL concept. 
-  This list includes reserved words used in major SQL dialects, as well as 
-  reserved words used in all standard SQL variations at the time of printing. 
-  It's better to look it up here rather than depend on a vendor's manual. But 
-  it's impossible to keep such a list up to date. 
+* You can use the list of <keyword>s, in our chapter on general SQL concept.
+  This list includes reserved words used in major SQL dialects, as well as
+  reserved words used in all standard SQL variations at the time of printing.
+  It's better to look it up here rather than depend on a vendor's manual. But
+  it's impossible to keep such a list up to date.
 
-* You can check by passing to your DBMS an SQL statement containing the 
-  <identifier> and looking for an error message. For example, try to execute 
-  something like "``CREATE TABLE`` <word> (<word> ``INT``);" If the SQL 
-  statement works, <word> is not a reserved word. However, this won't tell you 
-  if some other DBMS reserves that word, or if the next version of your DBMS 
-  will reserve it. 
+* You can check by passing to your DBMS an SQL statement containing the
+  <identifier> and looking for an error message. For example, try to execute
+  something like "``CREATE TABLE`` <word> (<word> ``INT``);" If the SQL
+  statement works, <word> is not a reserved word. However, this won't tell you
+  if some other DBMS reserves that word, or if the next version of your DBMS
+  will reserve it.
 
-* You can put underscores (``_``) in names. This is unpopular. The SQL Standards 
-  committee doesn't intend to add <keyword>s containing underscores in any 
-  future SQL version. However, there are some exceptions: words that begin with 
-  ``CURRENT_`` or ``SESSION_`` or ``SYSTEM_``, or words that end with 
-  ``_LENGTH``. Underscores have special meanings when used with introducers, 
-  with ``LIKE`` predicates and with ``SIMILAR`` predicates. The SQL Standards 
-  committee will also avoid <keyword>s containing digits in all future 
-  versions. So try ``Mussels4``. But first read Rule 25. 
+* You can put underscores (``_``) in names. This is unpopular. The SQL Standards
+  committee doesn't intend to add <keyword>s containing underscores in any
+  future SQL version. However, there are some exceptions: words that begin with
+  ``CURRENT_`` or ``SESSION_`` or ``SYSTEM_``, or words that end with
+  ``_LENGTH``. Underscores have special meanings when used with introducers,
+  with ``LIKE`` predicates and with ``SIMILAR`` predicates. The SQL Standards
+  committee will also avoid <keyword>s containing digits in all future
+  versions. So try ``Mussels4``. But first read Rule 25.
 
-* You can enclose all names with quotes (``""``). But <delimited identifier>s cause 
-  their own problems: see Rule 19. 
+* You can enclose all names with quotes (``""``). But <delimited identifier>s cause
+  their own problems: see Rule 19.
 
 *19-- Avoid <delimited identifier>s*
 ------------------------------------
 
-The troubles with them are, first, that double quote marks are false signals to 
-many people who are used to thinking that quote marks appear around strings 
-instead of names. Second, there's case sensitivity -- "X" is not the same as 
-"x". Third, quote marks are ugly. 
+The troubles with them are, first, that double quote marks are false signals to
+many people who are used to thinking that quote marks appear around strings
+instead of names. Second, there's case sensitivity -- "X" is not the same as
+"x". Third, quote marks are ugly.
 
-**Exception:** <Table name>s might require <delimited identifier>s, because 
-some DBMSs use files for Tables. File names include special characters -- ``.`` 
-or ``/`` or ``\`` or ``:`` -- that are illegal in regular <identifier>s. 
+**Exception:** <Table name>s might require <delimited identifier>s, because
+some DBMSs use files for Tables. File names include special characters -- ``.``
+or ``/`` or ``\`` or ``:`` -- that are illegal in regular <identifier>s.
 
-**Exception:** Microsoft Access programmers often use <delimited identifier>s 
-for <Table name>s (Access is a non-standard SQL which uses ``[]``\s instead of 
-``""``\s to mark the delimitation). 
+**Exception:** Microsoft Access programmers often use <delimited identifier>s
+for <Table name>s (Access is a non-standard SQL which uses ``[]``\s instead of
+``""``\s to mark the delimitation).
 
-**Exception:** Applications which generate SQL statements, such as user 
-interfaces, might automatically enclose all <delimited identifier>s inside 
-``""``\s. 
+**Exception:** Applications which generate SQL statements, such as user
+interfaces, might automatically enclose all <delimited identifier>s inside
+``""``\s.
 
-With all these exceptions, you might decide to take the minority line and use 
-<delimited identifier>s regularly. If you do, at least avoid names that have 
-lead or trailing spaces. Some DBMSs' processes include an automatic ``TRIM``. 
+With all these exceptions, you might decide to take the minority line and use
+<delimited identifier>s regularly. If you do, at least avoid names that have
+lead or trailing spaces. Some DBMSs' processes include an automatic ``TRIM``.
 
 *20-- Names of Tables are Plural; Names of All Other Objects Are Singular*
 --------------------------------------------------------------------------
 
-Thus, in the ``INFORMATION_SCHEMA``, we have a View named ``SCHEMATA`` and the 
-Columns of this View are: ``CATALOG_NAME``, ``SCHEMA_NAME`` and so on. Often a 
-plural is a collective noun, for example: ``INVENTORY``. Admittedly, this means 
-that <Table name>s will be longer (at least in English), but it's a subtle 
-signal that distinguishes <Table name>s from other <identifier>s. 
+Thus, in the ``INFORMATION_SCHEMA``, we have a View named ``SCHEMATA`` and the
+Columns of this View are: ``CATALOG_NAME``, ``SCHEMA_NAME`` and so on. Often a
+plural is a collective noun, for example: ``INVENTORY``. Admittedly, this means
+that <Table name>s will be longer (at least in English), but it's a subtle
+signal that distinguishes <Table name>s from other <identifier>s.
 
-**Alternative:** The dissenting minority points out that the English phrases 
-for many tabular items are singular: ``"ADDRESS BOOK"`` (not ``"ADDRESSES 
-BOOK"``), ``"PHONE BOOK"``, ``"INVESTMENT PORTFOLIO"``, ``"RESTAURANT LIST"``, 
-etc. 
+**Alternative:** The dissenting minority points out that the English phrases
+for many tabular items are singular: ``"ADDRESS BOOK"`` (not ``"ADDRESSES
+BOOK"``), ``"PHONE BOOK"``, ``"INVESTMENT PORTFOLIO"``, ``"RESTAURANT LIST"``,
+etc.
 
 *21- Use Words in Your National Language*
 -----------------------------------------
 
-The fact that SQL <keyword>s look like English is irrelevant. For example, this 
-sample SQL statement appeared in an article in a Polish magazine: 
+The fact that SQL <keyword>s look like English is irrelevant. For example, this
+sample SQL statement appeared in an article in a Polish magazine:
 
 ::
 
     UPDATE studenci SET nazwisko='Kowalski';
 
-This does mean that names will sometimes include characters outside the regular 
-English alphabet. Obviously the effect on portability is unfortunate, but if 
-your DBMS doesn't support accented characters in names then it doubtless won't 
-properly support them in data values either, so why would you use such a DBMS 
-anyway? Precisely because you don't know what a ``nazwisko`` is, you can see 
-that a Pole would have trouble understanding the word that you use instead of 
-``nazwisko``. 
+This does mean that names will sometimes include characters outside the regular
+English alphabet. Obviously the effect on portability is unfortunate, but if
+your DBMS doesn't support accented characters in names then it doubtless won't
+properly support them in data values either, so why would you use such a DBMS
+anyway? Precisely because you don't know what a ``nazwisko`` is, you can see
+that a Pole would have trouble understanding the word that you use instead of
+``nazwisko``.
 
 *22-- Don't Worry about How <Column name>s Appear When a Table Is Displayed on the Screen*
 ------------------------------------------------------------------------------------------
 
-That's something that changes anyway (use ``AS`` clauses). Instead, worry about 
-how names appear if you print out a program. Remember: The goal is long-term 
-comprehension, so ephemeral considerations such as screen-display deserve low 
-priority. 
+That's something that changes anyway (use ``AS`` clauses). Instead, worry about
+how names appear if you print out a program. Remember: The goal is long-term
+comprehension, so ephemeral considerations such as screen-display deserve low
+priority.
 
 *23-- Names Should Be Descriptive, but Not Too Descriptive*
 -----------------------------------------------------------
 
-Minimally, you should avoid algebra like ``UPDATE k SET k1=4`` -- where no one 
-could possibly guess what ``k`` and ``k1`` are supposed to represent. Medianly, 
-you should avoid non-specific descriptors like ``PHONE_NUMBER`` -- where no one 
-can be sure whether the referent is a home- or office- or general-contact- 
-telephone number. But stop there! Avoid names like ``SOLDIERS_IN_THE_ARMY`` 
-because (presumably) all the soldiers in the database are in the army; the "in 
-the army" bit is only helpful if you also have soldiers in the navy and you 
-have to distinguish between them. This part of the rule -- avoid making 
-accidents part of the identification -- is analogous to one of the 
-normalization rules. 
+Minimally, you should avoid algebra like ``UPDATE k SET k1=4`` -- where no one
+could possibly guess what ``k`` and ``k1`` are supposed to represent. Medianly,
+you should avoid non-specific descriptors like ``PHONE_NUMBER`` -- where no one
+can be sure whether the referent is a home- or office- or general-contact-
+telephone number. But stop there! Avoid names like ``SOLDIERS_IN_THE_ARMY``
+because (presumably) all the soldiers in the database are in the army; the "in
+the army" bit is only helpful if you also have soldiers in the navy and you
+have to distinguish between them. This part of the rule -- avoid making
+accidents part of the identification -- is analogous to one of the
+normalization rules.
 
 *24-- If Two Columns from Different Tables Are Based on the Same Domain, They Should Have the Same Name*
 --------------------------------------------------------------------------------------------------------
 
-In fact, they should have the Domain's name. For example: 
+In fact, they should have the Domain's name. For example:
 
 ::
 
@@ -905,101 +907,101 @@ In fact, they should have the Domain's name. For example:
     CREATE TABLE Students (surname surname, ...);
     CREATE TABLE Professors (surname surname, ...);
 
-This rule would apply even if your DBMS doesn't support explicit creation of 
-Domains, or if you use SQL3's user-defined type feature -- you're still using 
-the concept of Domains. 
+This rule would apply even if your DBMS doesn't support explicit creation of
+Domains, or if you use SQL3's user-defined type feature -- you're still using
+the concept of Domains.
 
-**Exception:** This rule does not apply for two Columns in the same Table. 
+**Exception:** This rule does not apply for two Columns in the same Table.
 
-Incidentally, when <Column name>s are the same, ``NATURAL JOIN`` is easier. 
-That's usually a blessing, but some caution is required -- you certainly don't 
-want to cause a join over two Columns which have the same name by accident. 
+Incidentally, when <Column name>s are the same, ``NATURAL JOIN`` is easier.
+That's usually a blessing, but some caution is required -- you certainly don't
+want to cause a join over two Columns which have the same name by accident.
 
 *25-- Digits Are a Bad Sign*
 ----------------------------
 
-Too often we use digits as arbitrary distinguishers -- e.g.: ``Lines_1 / 
-Lines_2`` -- when there is some intrinsic difference between ``Lines_1`` and 
-``Lines_2`` that could be expressed in the names, for example, 
-``Lines_Freshwater`` and ``Lines_Longitude``. Particularly bad are the digits 
-``'0'`` and ``'1'``, which look too much like the letters ``'O'`` and ``'l'``. 
+Too often we use digits as arbitrary distinguishers -- e.g.: ``Lines_1 /
+Lines_2`` -- when there is some intrinsic difference between ``Lines_1`` and
+``Lines_2`` that could be expressed in the names, for example,
+``Lines_Freshwater`` and ``Lines_Longitude``. Particularly bad are the digits
+``'0'`` and ``'1'``, which look too much like the letters ``'O'`` and ``'l'``.
 
 *26-- Try to Stop a Name at 18 Characters; The Maximum Length Allowed in SQL-89*
 --------------------------------------------------------------------------------
 
-Mainly, it's hard to remember a long name. For example, do you remember if the 
-name mentioned in rule 8 was ``Parts_Which_Have_No_Serial_Numbers``? Or was it 
-``Parts_Which_Have_No_Serialnumber``? 
+Mainly, it's hard to remember a long name. For example, do you remember if the
+name mentioned in rule 8 was ``Parts_Which_Have_No_Serial_Numbers``? Or was it
+``Parts_Which_Have_No_Serialnumber``?
 
 *27-- Repeat the <Table name> in the <Column name> . . . Not*
 -------------------------------------------------------------
 
-Firstly, you'd end up violating rule 24. Secondly, if you make a View of the 
-Table you'll have to either violate this rule, or make View <Column name>s not 
-equal to Table <Column name>s. For example, the ``INFORMATION_SCHEMA`` View 
-called ``GRANTS`` has a Column called ``IS_GRANTABLE`` instead of 
-``GRANT_IS_GRANTABLE``. Remember, if you really need to make it clear what 
-Table the Column is in, you can use a <Column reference>: 
-``GRANTS.IS_GRANTABLE``. 
+Firstly, you'd end up violating rule 24. Secondly, if you make a View of the
+Table you'll have to either violate this rule, or make View <Column name>s not
+equal to Table <Column name>s. For example, the ``INFORMATION_SCHEMA`` View
+called ``GRANTS`` has a Column called ``IS_GRANTABLE`` instead of
+``GRANT_IS_GRANTABLE``. Remember, if you really need to make it clear what
+Table the Column is in, you can use a <Column reference>:
+``GRANTS.IS_GRANTABLE``.
 
-**Exception:** A Column which is part of the primary key of the Table could 
-include the <Table name> in the singular. For example, the 
-``INFORMATION_SCHEMA`` View called ``SCHEMATA`` has a Column called 
-``SCHEMA_NAME`` -- and any foreign keys that reference ``SCHEMATA`` would be 
-Columns called ``SCHEMA_NAME`` too (assuming that Views could have such 
-Constraints). There are several conflicting conventions for foreign keys. In 
-any case, though, it is not part of your mandate to ensure that all <Column 
-name>s in the database must be unique. 
+**Exception:** A Column which is part of the primary key of the Table could
+include the <Table name> in the singular. For example, the
+``INFORMATION_SCHEMA`` View called ``SCHEMATA`` has a Column called
+``SCHEMA_NAME`` -- and any foreign keys that reference ``SCHEMATA`` would be
+Columns called ``SCHEMA_NAME`` too (assuming that Views could have such
+Constraints). There are several conflicting conventions for foreign keys. In
+any case, though, it is not part of your mandate to ensure that all <Column
+name>s in the database must be unique.
 
 *28-- Depend on a Dialect . . . Not*
 ------------------------------------
 
-This can be subtle, e.g.: ``UCASE`` is a function name that some people 
-seem to think is standard SQL (in fact it's ODBC). Write with 
-lowest-common-denominator syntax when you can, but test it first with an 
-SQL3 parser to make sure you're not going to violate a rule when you 
-upgrade. 
+This can be subtle, e.g.: ``UCASE`` is a function name that some people
+seem to think is standard SQL (in fact it's ODBC). Write with
+lowest-common-denominator syntax when you can, but test it first with an
+SQL3 parser to make sure you're not going to violate a rule when you
+upgrade.
 
 *29-- Sometimes <Correlation name>s (Or Aliases) Are Simply Necessary Because the Actual <Table name> Is Unwieldy, Containing Qualifiers or Lengthy Path Names*
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 In
-Oracle, use of <Correlation name>s actually helps the optimizer. But should you 
-always use <Correlation name>s? No -- they're most appropriate in ``SELECT`` 
-statements where <Column name>s must be qualified. 
+Oracle, use of <Correlation name>s actually helps the optimizer. But should you
+always use <Correlation name>s? No -- they're most appropriate in ``SELECT``
+statements where <Column name>s must be qualified.
 
 *30-- Abbreviations*
 --------------------
 
-Legacy SQL code has frequent abbreviations: ``PROV`` for ``PROVINCE``, ``DEPT`` 
-for ``DEPARTMENT``, ``LEN`` for ``LENGTH``, ``FNAME`` for ``FIRST NAME`` and so 
-on. Judging from trends in other computer languages, this taste will become 
-obsolete. At this moment it's still a matter of taste. A few abbreviated 
-prefixes/suffixes are used for some common Domains: ``_id`` for single-Column 
-candidate key (e.g.: ``author_id``, ``program_id``), ``_no`` for ordinal number 
-(e.g.: ``player_no``, ``receipt_no``), ``qty_`` for quantity (e.g.: 
-``qty_of_goods_sold``), ``avg_`` for average (e.g.: ``avg_qty_of_goods_sold``), 
-``min_`` for minimum (e.g.: ``min_weight``), ``max_`` for maximum (e.g.: 
-``max_length``) and ``sum_`` for total (e.g.: ``sum_balance``). Notice that 
-some of the prefixes are derived from SQL <keyword>s. 
+Legacy SQL code has frequent abbreviations: ``PROV`` for ``PROVINCE``, ``DEPT``
+for ``DEPARTMENT``, ``LEN`` for ``LENGTH``, ``FNAME`` for ``FIRST NAME`` and so
+on. Judging from trends in other computer languages, this taste will become
+obsolete. At this moment it's still a matter of taste. A few abbreviated
+prefixes/suffixes are used for some common Domains: ``_id`` for single-Column
+candidate key (e.g.: ``author_id``, ``program_id``), ``_no`` for ordinal number
+(e.g.: ``player_no``, ``receipt_no``), ``qty_`` for quantity (e.g.:
+``qty_of_goods_sold``), ``avg_`` for average (e.g.: ``avg_qty_of_goods_sold``),
+``min_`` for minimum (e.g.: ``min_weight``), ``max_`` for maximum (e.g.:
+``max_length``) and ``sum_`` for total (e.g.: ``sum_balance``). Notice that
+some of the prefixes are derived from SQL <keyword>s.
 
-* Examples of <Domain name>s/<Column name>s. Some names that we have seen in 
-  use in databases for banking/libraries /retail shops/government include: 
-  ``firstname``, ``lastname`` or ``surname``, ``street``, ``houseno``, 
-  ``aptno`` or ``unitno`` or ``suiteno``, ``city``, ``state`` or ``province``, 
-  ``country``, ``phoneno`` or ``email``, ``sex``, ``birth_date``, 
-  ``account_id``, ``balance``, ``account_open_date``, ``account_close_date``, 
-  ``transaction_code``, ``author_firstname``, ``author_lastname``, ``title``, 
-  ``callno``, ``isbn``, ``year_published``, ``checkout_date``, ``loan_type``, 
-  ``amount``, ``itemno``, ``transaction_time``, ``transaction_code``. 
+* Examples of <Domain name>s/<Column name>s. Some names that we have seen in
+  use in databases for banking/libraries /retail shops/government include:
+  ``firstname``, ``lastname`` or ``surname``, ``street``, ``houseno``,
+  ``aptno`` or ``unitno`` or ``suiteno``, ``city``, ``state`` or ``province``,
+  ``country``, ``phoneno`` or ``email``, ``sex``, ``birth_date``,
+  ``account_id``, ``balance``, ``account_open_date``, ``account_close_date``,
+  ``transaction_code``, ``author_firstname``, ``author_lastname``, ``title``,
+  ``callno``, ``isbn``, ``year_published``, ``checkout_date``, ``loan_type``,
+  ``amount``, ``itemno``, ``transaction_time``, ``transaction_code``.
 
 Certainly we've seen many other names too, in many styles. We picked ones that
-generally fit the criteria that we've described heretofore. 
+generally fit the criteria that we've described heretofore.
 
 *31-- Host Language Conventions*
 --------------------------------
 
-There is certainly an argument that this C code snippet looks fine: 
+There is certainly an argument that this C code snippet looks fine:
 
 ::
 
@@ -1007,116 +1009,116 @@ There is certainly an argument that this C code snippet looks fine:
     INSERT INTO Recordings (szRecording)
     VALUES (:szRecording);
 
-The point here is that the C host variable ``szRecording`` associates with the 
-SQL Column ``szRecording``. Hence the same name. In general we could say that 
-SQL Object names are often influenced by conventions used in the most common 
-host language, such as C in this case. We don't condemn this practice, we just 
-ignore it, since our concern is SQL conventions rather than host language 
-conventions. 
+The point here is that the C host variable ``szRecording`` associates with the
+SQL Column ``szRecording``. Hence the same name. In general we could say that
+SQL Object names are often influenced by conventions used in the most common
+host language, such as C in this case. We don't condemn this practice, we just
+ignore it, since our concern is SQL conventions rather than host language
+conventions.
 
-One detail about the ``szRecording`` in the preceding example: it's in a Polish 
-notation, that is, the sz in the name indicates the data type (string zero). We 
-will concern ourselves solely with the question: is it good SQL to embed <data 
-type> information in names, for example ``szrecording`` or ``name_char`` or 
-(more subtly) ``namestring``? The answer, judging as usual from what seems to 
-be common practice, is yes that's okay, but nobody is doing so systematically. 
-Sometimes we do see <Column name>s that end in ``_date`` or ``num[eric]``, but 
-we don't see consistency. 
+One detail about the ``szRecording`` in the preceding example: it's in a Polish
+notation, that is, the sz in the name indicates the data type (string zero). We
+will concern ourselves solely with the question: is it good SQL to embed <data
+type> information in names, for example ``szrecording`` or ``name_char`` or
+(more subtly) ``namestring``? The answer, judging as usual from what seems to
+be common practice, is yes that's okay, but nobody is doing so systematically.
+Sometimes we do see <Column name>s that end in ``_date`` or ``num[eric]``, but
+we don't see consistency.
 
-For the narrower concept -- Domains -- we have Rule 24. 
+For the narrower concept -- Domains -- we have Rule 24.
 
 *32-- User Names*
 -----------------
 
-If you have control over user names, prefer first names: Ralph, Mike, Lucien. 
-Where necessary add the first letter of the last name: JeanC, RalphK, LucienB. 
-This convention appears to derive from names on the Internet. 
+If you have control over user names, prefer first names: Ralph, Mike, Lucien.
+Where necessary add the first letter of the last name: JeanC, RalphK, LucienB.
+This convention appears to derive from names on the Internet.
 
-Often there is no choice in this regard, because the operating system feeds 
-user names to the DBMS. 
+Often there is no choice in this regard, because the operating system feeds
+user names to the DBMS.
 
 *33-- Comma Lists*
 ------------------
 
-Whenever a list is disordered, people wonder why. For example, these SQL 
-statements look a trifle curious: 
+Whenever a list is disordered, people wonder why. For example, these SQL
+statements look a trifle curious:
 
 ::
 
     SELECT firstname, travel_allowance, surname
     FROM   SalesPersons;
-    
+
     SELECT *
     FROM   States
     WHERE  state_abbreviation IN('WY','MI','AK','CO');
 
-If there is some hidden order, add a note explaining what it is. Otherwise, 
+If there is some hidden order, add a note explaining what it is. Otherwise,
 change to a natural or alphabetical order.
 
 Examples of Statements in Formal Style
 ======================================
 
-Here are some actual SQL statement examples. We have not edited them to fit all 
-the rules in this chapter. 
+Here are some actual SQL statement examples. We have not edited them to fit all
+the rules in this chapter.
 
 ::
 
     ALTER Table Countries
     ADD   gnp   DECIMAL(8, 2);
-    
+
     COMMIT;
-    
+
     CONNECT TO 'c:\db';
-    
+
     CREATE TABLE players
         (playerno  SMALLINT  NOT NULL  PRIMARY KEY,
         name       CHAR(15)  NOT NULL             ,
         leagueno   SMALLINT                       DEFAULT 99);
-    
+
     ALTER Table players
     ADD Constraint check_playerno
     CHECK (playerno BETWEEN 00 AND 99);
-    
+
     CREATE  VIEW ages (playerno, age) AS
-    SELECT  playerno, 1986 - YEAR_OF_BIRTH 
+    SELECT  playerno, 1986 - YEAR_OF_BIRTH
     FROM    Players;
-    
+
     DELETE FROM Order_Items
     WHERE partid IN (
           SELECT partid
           FROM   Inventory
           WHERE  description LIKE 'd%');
-    
+
     GRANT   SELECT, UPDATE
     ON      Jackets
     TO      Carol, Kathleen;
-    
+
     INSERT INTO Gradings (gradeno, inspectorid, description)
     VALUES (3, ?, 'Prime');
-    
+
     INSERT INTO Temporary_Workers (workerid, name, town, phoneno)
     SELECT   workerid, name, town, phoneno
     FROM     Workers
     WHERE    benefit IS NULL;
-    
+
     SELECT   title
     FROM     Videos
     WHERE    out_date > DATE '1994-07-06'
     GROUP BY title;
     HAVING   COUNT(*) > 1
     ORDER BY title;
-    
+
     SELECT   accountid, balance
     FROM     Accounts
     WHERE    (town = 'Amesville'
     OR       balance < 0);
     AND NOT  (town = 'Amityville'
     AND      balance < 0);
-    
+
     SELECT   NAME, TOWN
     FROM     PLAYERS
     WHERE    TOWN IN ('Inglewood', 'Stratford')
-    
+
     SELECT  first_name, last_name
     FROM    Students
     WHERE   studentno IN
@@ -1126,11 +1128,11 @@ the rules in this chapter.
     SELECT  first_name, last_name
     FROM    Teachers
     WHERE   teacher_status = 'sick';
-    
+
     SELECT Realtors.name AS realtor_name, Vendors.name AS vendor_name
     FROM   Members_Of_Real_Estate_Board Realtors, Sellers_Of_Farm_Land Vendors
     WHERE  Realtors.name = Vendors.contact_name;
-    
+
     UPDATE   Addresses
     SET      street              = ?,
              houseno             = ?,
@@ -1139,7 +1141,7 @@ the rules in this chapter.
              zip_or_postal_code  = ?,
              country             = ?
     WHERE    CURRENT OF Selection;
-    
+
     SELECT   title, release, censorrtg, runtime
       FROM   title
     WHERE    runtime BETWEEN 120 AND 231
@@ -1148,9 +1150,9 @@ the rules in this chapter.
 Host Language Programs
 ======================
 
-Some programmers keep SQL statements apart from host language statements, in 
-separate procedures (or even separate modules). Others allow mixing, as in this 
-(embedded Pascal SQL) example: 
+Some programmers keep SQL statements apart from host language statements, in
+separate procedures (or even separate modules). Others allow mixing, as in this
+(embedded Pascal SQL) example:
 
 ::
 
@@ -1171,22 +1173,22 @@ The following style notes apply to either SQL/CLI or to embedded SQL.
 *36-- Employ Assertions*
 ------------------------
 
-Here we use the word "assertion" in the non-SQL sense: a conditional statement 
-that you'd like to have in the debug version but not in the production version. 
+Here we use the word "assertion" in the non-SQL sense: a conditional statement
+that you'd like to have in the debug version but not in the production version.
 
-SQL is interpretive, so all "asserting" has to take place at runtime. In 
-programs, the best method is to add executable SQL statements with 
-``#if/#endif`` host language directives. 
+SQL is interpretive, so all "asserting" has to take place at runtime. In
+programs, the best method is to add executable SQL statements with
+``#if/#endif`` host language directives.
 
 .. CAUTION::
 
-   Some SQL precompilers ignore ``#if`` and ``#endif``. For example, this 
-   assertion example checks that Column ``PROGRAMS``. ``SUMMARY`` has matching 
-   definitions in both C and SQL. The format of the ``SQLExecDirect`` call is 
-   not a common style; you should take it merely as a suggestion. 
-   
+   Some SQL precompilers ignore ``#if`` and ``#endif``. For example, this
+   assertion example checks that Column ``PROGRAMS``. ``SUMMARY`` has matching
+   definitions in both C and SQL. The format of the ``SQLExecDirect`` call is
+   not a common style; you should take it merely as a suggestion.
+
    ::
-   
+
        ...
        #define SUMMARY_LENGTH [500]
        SQLCHAR summary[SUMMARY_LENGTH+1];
@@ -1215,14 +1217,14 @@ The following style notes apply only to SQL/CLI.
 *37-- Use Conventional Names*
 -----------------------------
 
-For example, resource handles are ``henv``, ``hdbc``, ``hstmt`` and ``hdesc``. 
-When there is more than one ``stmt``, use ordinals: ``hstmt1``, ``hstmt2`` and 
-so on. 
+For example, resource handles are ``henv``, ``hdbc``, ``hstmt`` and ``hdesc``.
+When there is more than one ``stmt``, use ordinals: ``hstmt1``, ``hstmt2`` and
+so on.
 
 *38-- Declare Variables with Constants or Macros Supplied in sqlcli.h*
 ----------------------------------------------------------------------
 
-For example: 
+For example:
 
 ::
 
@@ -1248,7 +1250,7 @@ For example, add this to the last example:
 *40-- When Testing a Function's Return Values, Programmers Use Various Styles*
 ------------------------------------------------------------------------------
 
-For example: 
+For example:
 
 ::
 

--- a/docs/chapters/index.rst
+++ b/docs/chapters/index.rst
@@ -4,6 +4,8 @@
 Chapters
 ========
 
+.. include:: ../_include/note.rst
+
 .. rubric:: Table of Contents
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,6 +4,8 @@
 SQL-99 Complete, Really
 ========================
 
+.. include:: _include/note.rst
+
 .. rubric:: Table of Contents
 
 .. toctree::

--- a/docs/preface.rst
+++ b/docs/preface.rst
@@ -4,6 +4,8 @@
 Preface
 =======
 
+.. include:: _include/note.rst
+
 If you've ever used a relational database product, chances are that you're
 already familiar with SQL -- the internationally-accepted, standard programming
 language for databases which is supported by the vast majority of relational


### PR DESCRIPTION
fixes https://github.com/crate/tech-writing-domain/issues/297

note: this PR also eliminates trailing whitespace