### PR TITLE
UX: Disable version chooser, this project is not versioned

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+# Skip running redundant builds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   documentation:
     name: Build docs on ${{ matrix.os }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,11 +15,14 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Acquire sources
+        uses: actions/checkout@v4
+
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.11'
+
       - name: Build docs
         run: |
           cd docs && make check

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -18,4 +18,3 @@ pull_request_rules:
       queue:
         method: rebase
         name: default
-        rebase_fallback: none

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,11 +1,15 @@
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
 sphinx:
   builder: html
   configuration: docs/conf.py
   fail_on_warning: true
 
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements.txt

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -8,7 +8,7 @@ The project is written using `Sphinx`_ and `ReStructuredText`_.
 Working on the project
 ======================
 
-Python 3.7 is required.
+You will need a recent installation of Python 3.
 
 Change into the ``docs`` directory:
 

--- a/docs/build.json
+++ b/docs/build.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "label": "docs build",
-  "message": "2.0.1"
+  "message": "2.1.1"
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,1 +1,8 @@
 from crate.theme.rtd.conf.sql_99 import *
+
+# Disable version chooser.
+html_context.update({
+    "display_version": False,
+    "current_version": None,
+    "versions": [],
+})


### PR DESCRIPTION
What the title says, and a few more maintenance commits, also fixing the Mergify configuration, which currently displays a "fail" outcome on the PR status, because it used an invalid attribute.