### PR TITLE
Update link to cratedb reference (always use latest)

### DIFF
--- a/docs/_include/note.rst
+++ b/docs/_include/note.rst
@@ -6,5 +6,5 @@
     For more information specific to CrateDB, check out the `CrateDB
     Reference`_.
 
-.. _CrateDB Reference: https://crate.io/docs/crate/reference/en/4.3/general/index.html
+.. _CrateDB Reference: https://cratedb.com/docs/crate/reference/en/latest/general/index.html
 .. _SQL-99 standard: https://en.wikipedia.org/wiki/SQL:1999


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

The current link doesn't show the latest version and also the old domain name, this links to the latest version of the cratedb reference