### PR TITLE
Update sitemap URL & Disallow

### DIFF
--- a/docs/_extra/robots.txt
+++ b/docs/_extra/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
-Disallow: /
+Disallow:
 
-Sitemap: https://crate.io/docs/sql-99/en/latest/site.xml
+Sitemap: https://sql-99.readthedocs.io/en/latest/site.xml


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Updated sitemap URL to non-cratedb.com and also removed the `Disallow` slash so bots will index the pages (we have/had that in there so the readthedocs URLs won't make it to the search results and compete with cratedb.com URLs.
